### PR TITLE
Updated getopt dependency to the latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "google/protobuf": "^3.4.0",
     "php" : ">=5.5.9 || ^7.0",
     "ext-grpc": "*",
-    "ulrichsg/getopt-php": "^3.0",
+    "ulrichsg/getopt-php": "^3.2.2",
     "react/http": "^0.8.3",
     "monolog/monolog": "^1.23.0"
   },

--- a/tests/Google/Ads/GoogleAds/Examples/Utils/ArgumentParserTest.php
+++ b/tests/Google/Ads/GoogleAds/Examples/Utils/ArgumentParserTest.php
@@ -97,7 +97,7 @@ class ArgumentParserTest extends TestCase
     public function testPassingRequiredArgumentButMissingValue()
     {
         $this->expectOutputRegex('/Usage/');
-        $_SERVER['argv'] = [null, '--customerId', '--campaignId', 11111];
+        $_SERVER['argv'] = [null, '--campaignId', 11111, '--customerId'];
         $this->argumentParser->parseCommandArguments(
             ['customerId' => GetOpt::REQUIRED_ARGUMENT, 'campaignId' => GetOpt::OPTIONAL_ARGUMENT]
         );


### PR DESCRIPTION
This also fixes a test that fails with getopt  v3.2.2 but passes with v3.0.

