### PR TITLE
Do not require ReactPHP HTTP library 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     "google/protobuf": "^3.4.0",
     "google/common-protos": "^0.1.0",
     "ulrichsg/getopt-php": "^3.2.2",
-    "react/http": "^0.8.3",
     "monolog/monolog": "^1.23.0"
   },
   "require-dev": {
@@ -19,7 +18,8 @@
     "ext-bcmath": "*"
   },
   "suggest": {
-    "php-64bit": ">=5.5.9"
+    "php-64bit": ">=5.5.9",
+    "react/http": "To run AuthenticateInWebApplication.php example"
   },
   "license": "Apache-2.0",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   "require-dev": {
     "phpunit/phpunit": "^4.8.35 || ^5.7",
     "squizlabs/php_codesniffer": "^2.9 || ^3.2",
-    "ext-bcmath": "*"
+    "ext-bcmath": "*",
+    "react/http": "^0.8.3"
   },
   "suggest": {
     "php-64bit": ">=5.5.9",

--- a/examples/Authentication/AuthenticateInWebApplication.php
+++ b/examples/Authentication/AuthenticateInWebApplication.php
@@ -59,6 +59,11 @@ class AuthenticateInWebApplication
 
     public static function main()
     {
+        if (!class_exists(Server::class)) {
+            echo 'Please install "react/http" package to be able to run this example';
+            exit(1);
+        }
+
         $loop = Factory::create();
         // Creates a socket for localhost with random port.
         $socket = new \React\Socket\Server(0, $loop);


### PR DESCRIPTION
`"react/http"` is required only `AuthenticateInWebApplication.php` example and is not used by any real library code.

Requiring it doesn't make sense for production usage, so looks like it should be optional.