### PR TITLE
Upgraded phpunit to v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "monolog/monolog": "^1.23.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.35 || ^5.7",
+    "phpunit/phpunit": "^7",
     "squizlabs/php_codesniffer": "^2.9 || ^3.2",
     "ext-bcmath": "*",
     "react/http": "^0.8.3"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "monolog/monolog": "^1.23.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7",
+    "phpunit/phpunit": "^7.5",
     "squizlabs/php_codesniffer": "^2.9 || ^3.2",
     "ext-bcmath": "*",
     "react/http": "^0.8.3"


### PR DESCRIPTION
This upgrades phpunit to version 7, which is the latest that still supports PHP 7.1.

The latest version of phpunit, v8, requires PHP 7.2 or 7.3.

Besides upgrading to a newer version, this also gets rid of the transitive dependency on phpunit-mock-objects that was causing the warning referred to in issue #39.

The test suite remains all green, of course.