### PR TITLE
Better type hinting

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/V0/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V0/GoogleAdsClientBuilder.php
@@ -55,12 +55,12 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * is optional, and if omitted, it will look for the default configuration
      * filename in the home directory of the user running PHP.
      *
-     * @param string $path the file path
+     * @param string|null $path the file path
      * @return self this builder populated from the configuration
      * @throws InvalidArgumentException if the configuration file could not be
      *     found
      */
-    public function fromFile($path = null)
+    public function fromFile(?$path)
     {
         if ($path === null) {
             $path = self::DEFAULT_CONFIGURATION_FILENAME;
@@ -97,7 +97,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * @param string $developerToken
      * @return self this builder
      */
-    public function withDeveloperToken($developerToken)
+    public function withDeveloperToken(string $developerToken)
     {
         $this->developerToken = $developerToken;
         return $this;
@@ -112,10 +112,10 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * create a separate GoogleAdsClient instance for each manager account. Use this method to
      * set each login customer ID and call build() to create a separate instance.
      *
-     * @param int $loginCustomerId the login customer ID
+     * @param string|null $loginCustomerId the login customer ID
      * @return self this builder
      */
-    public function withLoginCustomerId($loginCustomerId)
+    public function withLoginCustomerId(?string $loginCustomerId)
     {
         $this->loginCustomerId = $loginCustomerId;
         return $this;

--- a/src/Google/Ads/GoogleAds/Lib/V0/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V0/GoogleAdsClientBuilder.php
@@ -60,7 +60,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * @throws InvalidArgumentException if the configuration file could not be
      *     found
      */
-    public function fromFile(?$path)
+    public function fromFile(string $path = null)
     {
         if ($path === null) {
             $path = self::DEFAULT_CONFIGURATION_FILENAME;

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * @throws InvalidArgumentException if the configuration file could not be
      *     found
      */
-    public function fromFile($path = null)
+    public function fromFile(?string $path)
     {
         if ($path === null) {
             $path = self::DEFAULT_CONFIGURATION_FILENAME;
@@ -97,7 +97,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * @param string $developerToken
      * @return self this builder
      */
-    public function withDeveloperToken($developerToken)
+    public function withDeveloperToken(string $developerToken)
     {
         $this->developerToken = $developerToken;
         return $this;
@@ -112,10 +112,10 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * create a separate GoogleAdsClient instance for each manager account. Use this method to
      * set each login customer ID and call build() to create a separate instance.
      *
-     * @param int $loginCustomerId the login customer ID
+     * @param string|null $loginCustomerId the login customer ID
      * @return self this builder
      */
-    public function withLoginCustomerId($loginCustomerId)
+    public function withLoginCustomerId(?string $loginCustomerId)
     {
         $this->loginCustomerId = $loginCustomerId;
         return $this;
@@ -164,7 +164,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * @param string $logLevel the PSR-3 log level name, e.g., INFO
      * @return self this builder
      */
-    public function withLogLevel($logLevel)
+    public function withLogLevel(string $logLevel)
     {
         $this->logLevel = $logLevel;
         return $this;

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -60,7 +60,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * @throws InvalidArgumentException if the configuration file could not be
      *     found
      */
-    public function fromFile(?string $path)
+    public function fromFile(string $path = null)
     {
         if ($path === null) {
             $path = self::DEFAULT_CONFIGURATION_FILENAME;


### PR DESCRIPTION
This resolves #45 by setting the proper type hinting in the PHPdoc for `withLoginCustomerId`, and also leverages the scalar type hinting feature introduced in PHP7 and the nullable notation introduced in PHP7.1 to enforce proper types being passed to all functions in the `GoogleAdsClientBuilder` class.