### PR TITLE
Added more things to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 /.gitattributes export-ignore
+/examples export-ignore
 /tests export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
examples/ are not needed when it's included as a library.