### PR TITLE
Use enum getters in AM and CM examples

### DIFF
--- a/examples/AccountManagement/GetAccountChanges.php
+++ b/examples/AccountManagement/GetAccountChanges.php
@@ -121,7 +121,7 @@ class GetAccountChanges
             /** @var GoogleAdsRow $googleAdsRow */
             printf(
                 "On %s, change status '%s' shows resource '%s' with type '%s' and status '%s'.%s",
-                $googleAdsRow->getChangeStatus()->getLastChangeDateTime()->getValue(),
+                $googleAdsRow->getChangeStatus()->getLastChangeDateTimeValue(),
                 $googleAdsRow->getChangeStatus()->getResourceName(),
                 self::getResourceNameForResourceType($googleAdsRow->getChangeStatus()),
                 ChangeStatusResourceType::name(
@@ -150,19 +150,19 @@ class GetAccountChanges
         $resourceName = ''; // Default value for UNSPECIFIED or UNKNOWN resource type.
         switch ($resourceType) {
             case ChangeStatusResourceType::AD_GROUP:
-                $resourceName = $changeStatus->getAdGroup()->getValue();
+                $resourceName = $changeStatus->getAdGroupValue();
                 break;
             case ChangeStatusResourceType::AD_GROUP_AD:
-                $resourceName = $changeStatus->getAdGroupAd()->getValue();
+                $resourceName = $changeStatus->getAdGroupAdValue();
                 break;
             case ChangeStatusResourceType::AD_GROUP_CRITERION:
-                $resourceName = $changeStatus->getAdGroupCriterion()->getValue();
+                $resourceName = $changeStatus->getAdGroupCriterionValue();
                 break;
             case ChangeStatusResourceType::CAMPAIGN:
-                $resourceName = $changeStatus->getCampaign()->getValue();
+                $resourceName = $changeStatus->getCampaignValue();
                 break;
             case ChangeStatusResourceType::CAMPAIGN_CRITERION:
-                $resourceName = $changeStatus->getCampaignCriterion()->getValue();
+                $resourceName = $changeStatus->getCampaignCriterionValue();
                 break;
         }
 

--- a/examples/AccountManagement/GetAccountChanges.php
+++ b/examples/AccountManagement/GetAccountChanges.php
@@ -26,6 +26,7 @@ use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClient;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClientBuilder;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsException;
 use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\V1\Enums\ChangeStatusOperationEnum\ChangeStatusOperation;
 use Google\Ads\GoogleAds\V1\Enums\ChangeStatusResourceTypeEnum\ChangeStatusResourceType;
 use Google\Ads\GoogleAds\V1\Errors\GoogleAdsError;
 use Google\Ads\GoogleAds\V1\Resources\ChangeStatus;
@@ -118,18 +119,13 @@ class GetAccountChanges
         // the change status in each row.
         foreach ($response->iterateAllElements() as $googleAdsRow) {
             /** @var GoogleAdsRow $googleAdsRow */
-            // Note that the resource type and resource status printed below are enum values.
-            // For example, a value of 3 will be returned when the resource type is 'AD_GROUP'.
-            // A mapping of enum names to values can be found in the following files:
-            // * ChangeStatusResourceType.php (for resource type)
-            // * ChangeStatusOperation.php (for resource status)
             printf(
-                "On %s, change status '%s' shows resource '%s' with type %d and status %d.%s",
+                "On %s, change status '%s' shows resource '%s' with type '%s' and status '%s'.%s",
                 $googleAdsRow->getChangeStatus()->getLastChangeDateTime()->getValue(),
                 $googleAdsRow->getChangeStatus()->getResourceName(),
                 self::getResourceNameForResourceType($googleAdsRow->getChangeStatus()),
-                $googleAdsRow->getChangeStatus()->getResourceType(),
-                $googleAdsRow->getChangeStatus()->getResourceStatus(),
+                ChangeStatusResourceType::name($googleAdsRow->getChangeStatus()->getResourceType()),
+                ChangeStatusOperation::name($googleAdsRow->getChangeStatus()->getResourceStatus()),
                 PHP_EOL
             );
         }

--- a/examples/AccountManagement/GetAccountChanges.php
+++ b/examples/AccountManagement/GetAccountChanges.php
@@ -124,7 +124,9 @@ class GetAccountChanges
                 $googleAdsRow->getChangeStatus()->getLastChangeDateTime()->getValue(),
                 $googleAdsRow->getChangeStatus()->getResourceName(),
                 self::getResourceNameForResourceType($googleAdsRow->getChangeStatus()),
-                ChangeStatusResourceType::name($googleAdsRow->getChangeStatus()->getResourceType()),
+                ChangeStatusResourceType::name(
+                    $googleAdsRow->getChangeStatus()->getResourceType()
+                ),
                 ChangeStatusOperation::name($googleAdsRow->getChangeStatus()->getResourceStatus()),
                 PHP_EOL
             );

--- a/examples/CampaignManagement/GetAllDisapprovedAds.php
+++ b/examples/CampaignManagement/GetAllDisapprovedAds.php
@@ -28,7 +28,9 @@ use Google\Ads\GoogleAds\Lib\V1\GoogleAdsException;
 use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
 use Google\Ads\GoogleAds\V1\Common\PolicyTopicEntry;
 use Google\Ads\GoogleAds\V1\Common\PolicyTopicEvidence;
+use Google\Ads\GoogleAds\V1\Enums\AdTypeEnum\AdType;
 use Google\Ads\GoogleAds\V1\Enums\PolicyApprovalStatusEnum\PolicyApprovalStatus;
+use Google\Ads\GoogleAds\V1\Enums\PolicyTopicEntryTypeEnum\PolicyTopicEntryType;
 use Google\Ads\GoogleAds\V1\Errors\GoogleAdsError;
 use Google\Ads\GoogleAds\V1\Services\GoogleAdsRow;
 use Google\ApiCore\ApiException;
@@ -127,27 +129,19 @@ class GetAllDisapprovedAds
 
             $disapprovedAdsCount++;
 
-            // Note that the ad type printed below is an enum value.
-            // For example, a value of 3 will be returned when the keyword match type is
-            // 'EXPANDED_TEXT_AD'.
-            // A mapping of enum names to values can be found in AdType.php.
             printf(
-                "Ad with ID %d and type '%d' was disapproved with the following policy "
+                "Ad with ID %d and type '%s' was disapproved with the following policy "
                 . "topic entries:%s",
                 $ad->getId()->getValue(),
-                $ad->getType(),
+                AdType::name($ad->getType()),
                 PHP_EOL
             );
             foreach ($policySummary->getPolicyTopicEntries() as $policyTopicEntry) {
                 /** @var PolicyTopicEntry $policyTopicEntry */
-                // Note that the policy topic entry type printed below is an enum value.
-                // For example, a value of 2 will be returned when the policy topic entry type is
-                // 'PROHIBITED'.
-                // A mapping of enum names to values can be found in PolicyTopicEntryType.php.
                 printf(
-                    "  topic: '%s', type: '%d'%s",
+                    "  topic: '%s', type: '%s'%s",
                     $policyTopicEntry->getTopic()->getValue(),
-                    $policyTopicEntry->getType(),
+                    PolicyTopicEntryType::name($policyTopicEntry->getType()),
                     PHP_EOL
                 );
                 foreach ($policyTopicEntry->getEvidences() as $evidence) {

--- a/examples/CampaignManagement/GetAllDisapprovedAds.php
+++ b/examples/CampaignManagement/GetAllDisapprovedAds.php
@@ -132,7 +132,7 @@ class GetAllDisapprovedAds
             printf(
                 "Ad with ID %d and type '%s' was disapproved with the following policy "
                 . "topic entries:%s",
-                $ad->getId()->getValue(),
+                $ad->getIdValue(),
                 AdType::name($ad->getType()),
                 PHP_EOL
             );
@@ -140,7 +140,7 @@ class GetAllDisapprovedAds
                 /** @var PolicyTopicEntry $policyTopicEntry */
                 printf(
                     "  topic: '%s', type: '%s'%s",
-                    $policyTopicEntry->getTopic()->getValue(),
+                    $policyTopicEntry->getTopicValue(),
                     PolicyTopicEntryType::name($policyTopicEntry->getType()),
                     PHP_EOL
                 );


### PR DESCRIPTION
Use enum getters to display value names instead of IDs in the Account Management and CampaignManagement code examples.