### PR TITLE
Use enum getters in BO examples

### DIFF
--- a/examples/BasicOperations/GetArtifactMetadata.php
+++ b/examples/BasicOperations/GetArtifactMetadata.php
@@ -112,7 +112,7 @@ class GetArtifactMetadata
             printf(
                 "An artifact named '%s' with category '%s' and data type '%s' %s selectable, %s "
                 . "filterable, %s sortable and %s repeated.%s",
-                $googleAdsField->getName()->getValue(),
+                $googleAdsField->getNameValue(),
                 GoogleAdsFieldCategory::name($googleAdsField->getCategory()),
                 GoogleAdsFieldDataType::name($googleAdsField->getDataType()),
                 self::getIsOrIsNot($googleAdsField->getSelectable()),

--- a/examples/BasicOperations/GetArtifactMetadata.php
+++ b/examples/BasicOperations/GetArtifactMetadata.php
@@ -26,6 +26,8 @@ use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClient;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClientBuilder;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsException;
 use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\V1\Enums\GoogleAdsFieldCategoryEnum\GoogleAdsFieldCategory;
+use Google\Ads\GoogleAds\V1\Enums\GoogleAdsFieldDataTypeEnum\GoogleAdsFieldDataType;
 use Google\Ads\GoogleAds\V1\Errors\GoogleAdsError;
 use Google\Ads\GoogleAds\V1\Resources\GoogleAdsField;
 use Google\ApiCore\ApiException;
@@ -107,16 +109,12 @@ class GetArtifactMetadata
         // Iterates over all rows and prints our the metadata of the returned artifacts
         foreach ($response->iterateAllElements() as $googleAdsField) {
             /** @var GoogleAdsField $googleAdsField */
-            // Note that the category and data type printed below are enum values.
-            // For example, a value of 2 will be returned when the category is 'RESOURCE'.
-            // A mapping of enum names to values can be found at GoogleAdsFieldCategory.php for the
-            // category and GoogleAdsFieldDataType.php for the data type.
             printf(
-                "An artifact named '%s' with category %d and data type %d %s selectable, %s "
+                "An artifact named '%s' with category '%s' and data type '%s' %s selectable, %s "
                 . "filterable, %s sortable and %s repeated.%s",
                 $googleAdsField->getName()->getValue(),
-                $googleAdsField->getCategory(),
-                $googleAdsField->getDataType(),
+                GoogleAdsFieldCategory::name($googleAdsField->getCategory()),
+                GoogleAdsFieldDataType::name($googleAdsField->getDataType()),
                 self::getIsOrIsNot($googleAdsField->getSelectable()),
                 self::getIsOrIsNot($googleAdsField->getFilterable()),
                 self::getIsOrIsNot($googleAdsField->getSortable()),

--- a/examples/BasicOperations/GetExpandedTextAds.php
+++ b/examples/BasicOperations/GetExpandedTextAds.php
@@ -26,6 +26,7 @@ use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClient;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClientBuilder;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsException;
 use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\V1\Enums\AdGroupAdStatusEnum\AdGroupAdStatus;
 use Google\Ads\GoogleAds\V1\Errors\GoogleAdsError;
 use Google\Ads\GoogleAds\V1\Services\GoogleAdsRow;
 use Google\ApiCore\ApiException;
@@ -121,14 +122,11 @@ class GetExpandedTextAds
         foreach ($response->iterateAllElements() as $googleAdsRow) {
             /** @var GoogleAdsRow $googleAdsRow */
             $ad = $googleAdsRow->getAdGroupAd()->getAd();
-            // Note that the status printed below are enum values.
-            // For example, a value of 2 will be returned when the status is 'ENABLED'.
-            // A mapping of enum names to values can be found at AdGroupAdStatus.php
             printf(
-                "Expanded text ad with ID %d, status %d, and headline '%s - %s' was found in ad "
+                "Expanded text ad with ID %d, status '%s', and headline '%s - %s' was found in ad "
                 . "group with ID %d.%s",
                 $ad->getId()->getValue(),
-                $googleAdsRow->getAdGroupAd()->getStatus(),
+                AdGroupAdStatus::name($googleAdsRow->getAdGroupAd()->getStatus()),
                 $ad->getExpandedTextAd()->getHeadlinePart1()->getValue(),
                 $ad->getExpandedTextAd()->getHeadlinePart2()->getValue(),
                 $googleAdsRow->getAdGroup()->getId()->getValue(),

--- a/examples/BasicOperations/GetExpandedTextAds.php
+++ b/examples/BasicOperations/GetExpandedTextAds.php
@@ -125,11 +125,11 @@ class GetExpandedTextAds
             printf(
                 "Expanded text ad with ID %d, status '%s', and headline '%s - %s' was found in ad "
                 . "group with ID %d.%s",
-                $ad->getId()->getValue(),
+                $ad->getIdValue(),
                 AdGroupAdStatus::name($googleAdsRow->getAdGroupAd()->getStatus()),
-                $ad->getExpandedTextAd()->getHeadlinePart1()->getValue(),
-                $ad->getExpandedTextAd()->getHeadlinePart2()->getValue(),
-                $googleAdsRow->getAdGroup()->getId()->getValue(),
+                $ad->getExpandedTextAd()->getHeadlinePart1Value(),
+                $ad->getExpandedTextAd()->getHeadlinePart2Value(),
+                $googleAdsRow->getAdGroup()->getIdValue(),
                 PHP_EOL
             );
         }

--- a/examples/BasicOperations/GetKeywords.php
+++ b/examples/BasicOperations/GetKeywords.php
@@ -26,6 +26,8 @@ use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClient;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsClientBuilder;
 use Google\Ads\GoogleAds\Lib\V1\GoogleAdsException;
 use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\V1\Enums\CriterionTypeEnum\CriterionType;
+use Google\Ads\GoogleAds\V1\Enums\KeywordMatchTypeEnum\KeywordMatchType;
 use Google\Ads\GoogleAds\V1\Errors\GoogleAdsError;
 use Google\Ads\GoogleAds\V1\Services\GoogleAdsRow;
 use Google\ApiCore\ApiException;
@@ -120,16 +122,14 @@ class GetKeywords
         // the keyword in each row.
         foreach ($response->iterateAllElements() as $googleAdsRow) {
             /** @var GoogleAdsRow $googleAdsRow */
-            // Note that the match type and criteria type printed below are enum values.
-            // For example, a value of 2 will be returned when the keyword match type is 'EXACT'.
-            // A mapping of enum names to values can be found at KeywordMatchType.php for keyword
-            // match type and CriterionType.php for criterion type.
             printf(
-                "Keyword with text '%s', match type %d, criterion type %d, and ID %d "
+                "Keyword with text '%s', match type '%s', criterion type '%s', and ID %d "
                 . "was found in ad group with ID %d.%s",
                 $googleAdsRow->getAdGroupCriterion()->getKeyword()->getText()->getValue(),
-                $googleAdsRow->getAdGroupCriterion()->getKeyword()->getMatchType(),
-                $googleAdsRow->getAdGroupCriterion()->getType(),
+                KeywordMatchType::name(
+                    $googleAdsRow->getAdGroupCriterion()->getKeyword()->getMatchType()
+                ),
+                CriterionType::name($googleAdsRow->getAdGroupCriterion()->getType()),
                 $googleAdsRow->getAdGroupCriterion()->getCriterionId()->getValue(),
                 $googleAdsRow->getAdGroup()->getId()->getValue(),
                 PHP_EOL

--- a/examples/BasicOperations/GetKeywords.php
+++ b/examples/BasicOperations/GetKeywords.php
@@ -125,13 +125,13 @@ class GetKeywords
             printf(
                 "Keyword with text '%s', match type '%s', criterion type '%s', and ID %d "
                 . "was found in ad group with ID %d.%s",
-                $googleAdsRow->getAdGroupCriterion()->getKeyword()->getText()->getValue(),
+                $googleAdsRow->getAdGroupCriterion()->getKeyword()->getTextValue(),
                 KeywordMatchType::name(
                     $googleAdsRow->getAdGroupCriterion()->getKeyword()->getMatchType()
                 ),
                 CriterionType::name($googleAdsRow->getAdGroupCriterion()->getType()),
-                $googleAdsRow->getAdGroupCriterion()->getCriterionId()->getValue(),
-                $googleAdsRow->getAdGroup()->getId()->getValue(),
+                $googleAdsRow->getAdGroupCriterion()->getCriterionIdValue(),
+                $googleAdsRow->getAdGroup()->getIdValue(),
                 PHP_EOL
             );
         }


### PR DESCRIPTION
Use enum getters to display value names instead of IDs in the BasicOperations code examples.