### PR TITLE
Proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,29 @@ $googleAdsClient = (new GoogleAdsClientBuilder())
     ->build();
 ```
 
+## Proxy configuration
+
+If you need to connect to the Google Ads API through a proxy, you can do so by setting the `proxy`
+property in the `CONNECTION` section of your `google_ads_php.ini` file:
+
+```
+[CONNECTION]
+; Optional proxy settings to be used by requests.
+; If you don't have username and password, just specify host and port.
+proxy = "protocol://user:pass@host:port"
+```
+
+Alternatively, you can configure the proxy setting programmatically like every other configuration
+setting:
+
+```php
+$googleAdsClient = (new GoogleAdsClientBuilder())
+    ...
+    ->withProxy('protocol://user:pass@host:port')
+    ->build();
+```
+
+
 ## Miscellaneous
 
 ### Wiki

--- a/src/Google/Ads/GoogleAds/Lib/ConfigurationTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/ConfigurationTrait.php
@@ -94,7 +94,7 @@ trait ConfigurationTrait
     }
 
     /**
-     * Gets the proxy URI in the form protocol://user:pass@host:port.
+     * Gets the proxy URI.
      *
      * @return string the proxy URI
      */

--- a/src/Google/Ads/GoogleAds/Lib/ConfigurationTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/ConfigurationTrait.php
@@ -31,6 +31,7 @@ trait ConfigurationTrait
     private $oAuth2Credential;
     private $logger;
     private $logLevel;
+    private $proxy;
 
     /**
      * Gets the developer token.
@@ -90,5 +91,15 @@ trait ConfigurationTrait
     public function getLogLevel()
     {
         return $this->logLevel;
+    }
+
+    /**
+     * Gets the proxy URI in the form protocol://user:pass@host:port.
+     *
+     * @return string the proxy URI
+     */
+    public function getProxy()
+    {
+        return $this->proxy;
     }
 }

--- a/src/Google/Ads/GoogleAds/Lib/OAuth2TokenBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/OAuth2TokenBuilder.php
@@ -121,8 +121,7 @@ final class OAuth2TokenBuilder implements GoogleAdsBuilder
     {
         $this->defaultOptionals();
         $this->validate();
-        putenv('http_proxy=cane');
-
+        
         return new UserRefreshCredentials(
             null,
             [

--- a/src/Google/Ads/GoogleAds/Lib/OAuth2TokenBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/OAuth2TokenBuilder.php
@@ -121,6 +121,7 @@ final class OAuth2TokenBuilder implements GoogleAdsBuilder
     {
         $this->defaultOptionals();
         $this->validate();
+        putenv('http_proxy=cane');
 
         return new UserRefreshCredentials(
             null,

--- a/src/Google/Ads/GoogleAds/Lib/OAuth2TokenBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/OAuth2TokenBuilder.php
@@ -121,7 +121,7 @@ final class OAuth2TokenBuilder implements GoogleAdsBuilder
     {
         $this->defaultOptionals();
         $this->validate();
-        
+
         return new UserRefreshCredentials(
             null,
             [

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClient.php
@@ -41,5 +41,6 @@ final class GoogleAdsClient
         $this->oAuth2Credential = $builder->getOAuth2Credential();
         $this->logger = $builder->getLogger();
         $this->logLevel = $builder->getLogLevel();
+        $this->proxy = $builder->getProxy();
     }
 }

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -227,7 +227,11 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
         // For the proxy URI using filter_var is ok because the GRPC library expects the URI
         // in a very specific format.
         if (!empty($this->proxy) &&
-            filter_var($this->proxy, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED) === false) {
+            filter_var(
+                $this->proxy,
+                FILTER_VALIDATE_URL,
+                FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED
+            ) === false) {
             throw new InvalidArgumentException(
                 'Proxy must be a valid URI in the form protocol://user:pass@host:port'
             );
@@ -301,7 +305,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     }
 
     /**
-     * Gets the proxy URI in the form protocol://user:pass@host:port.
+     * Gets the proxy URI.
      *
      * @return string the proxy URI
      */

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -56,7 +56,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * is optional, and if omitted, it will look for the default configuration
      * filename in the home directory of the user running PHP.
      *
-     * @param string $path the file path
+     * @param  string $path the file path
      * @return self this builder populated from the configuration
      * @throws InvalidArgumentException if the configuration file could not be
      *     found
@@ -72,7 +72,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Populates this builder from the specified configuration object.
      *
-     * @param Configuration $configuration the configuration
+     * @param  Configuration $configuration the configuration
      * @return self this builder populated from the configuration
      */
     public function from(Configuration $configuration)
@@ -96,7 +96,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Includes a developer token. This is required.
      *
-     * @param string $developerToken
+     * @param  string $developerToken
      * @return self this builder
      */
     public function withDeveloperToken(string $developerToken)
@@ -114,7 +114,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * create a separate GoogleAdsClient instance for each manager account. Use this method to
      * set each login customer ID and call build() to create a separate instance.
      *
-     * @param string|null $loginCustomerId the login customer ID
+     * @param  string|null $loginCustomerId the login customer ID
      * @return self this builder
      */
     public function withLoginCustomerId(?string $loginCustomerId)
@@ -126,7 +126,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Includes the Google Ads API server's base endpoint. This is optional.
      *
-     * @param string|null $endpoint
+     * @param  string|null $endpoint
      * @return self this builder
      */
     public function withEndpoint($endpoint)
@@ -139,7 +139,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * Includes the OAuth2 credential to be used for authentication. This is
      * required.
      *
-     * @param FetchAuthTokenInterface $oAuth2Credential
+     * @param  FetchAuthTokenInterface $oAuth2Credential
      * @return self this builder
      */
     public function withOAuth2Credential(FetchAuthTokenInterface $oAuth2Credential)
@@ -151,7 +151,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Includes a logger to log requests and responses.
      *
-     * @param LoggerInterface $logger
+     * @param  LoggerInterface $logger
      * @return self this builder
      */
     public function withLogger(LoggerInterface $logger)
@@ -163,7 +163,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Sets the log level for Google Ads API requests and responses.
      *
-     * @param string $logLevel the PSR-3 log level name, e.g., INFO
+     * @param  string $logLevel the PSR-3 log level name, e.g., INFO
      * @return self this builder
      */
     public function withLogLevel(string $logLevel)
@@ -175,7 +175,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Sets the proxy URI for Google Ads API requests in the format protocol://user:pass@host:port.
      *
-     * @param string $proxy the proxy URI, e.g., http://user:password@localhost:8080
+     * @param  string $proxy the proxy URI, e.g., http://user:password@localhost:8080
      * @return self this builder
      */
     public function withProxy(string $proxy)
@@ -226,12 +226,13 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
 
         // For the proxy URI using filter_var is ok because the GRPC library expects the URI
         // in a very specific format.
-        if (!empty($this->proxy) &&
-            filter_var(
+        if (!empty($this->proxy)
+            && filter_var(
                 $this->proxy,
                 FILTER_VALIDATE_URL,
                 FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED
-            ) === false) {
+            ) === false
+        ) {
             throw new InvalidArgumentException(
                 'Proxy must be a valid URI in the form protocol://user:pass@host:port'
             );

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -224,6 +224,8 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
             throw new InvalidArgumentException('Endpoint must be a valid URL.');
         }
 
+        // For the proxy URI using filter_var is ok because the GRPC library expects the URI
+        // in a very specific format.
         if (!empty($this->proxy) &&
             filter_var($this->proxy, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED) === false) {
             throw new InvalidArgumentException(

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -56,7 +56,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * is optional, and if omitted, it will look for the default configuration
      * filename in the home directory of the user running PHP.
      *
-     * @param  string $path the file path
+     * @param string $path the file path
      * @return self this builder populated from the configuration
      * @throws InvalidArgumentException if the configuration file could not be
      *     found
@@ -72,7 +72,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Populates this builder from the specified configuration object.
      *
-     * @param  Configuration $configuration the configuration
+     * @param Configuration $configuration the configuration
      * @return self this builder populated from the configuration
      */
     public function from(Configuration $configuration)
@@ -96,7 +96,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Includes a developer token. This is required.
      *
-     * @param  string $developerToken
+     * @param string $developerToken
      * @return self this builder
      */
     public function withDeveloperToken(string $developerToken)
@@ -114,7 +114,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * create a separate GoogleAdsClient instance for each manager account. Use this method to
      * set each login customer ID and call build() to create a separate instance.
      *
-     * @param  string|null $loginCustomerId the login customer ID
+     * @param string|null $loginCustomerId the login customer ID
      * @return self this builder
      */
     public function withLoginCustomerId(?string $loginCustomerId)
@@ -126,7 +126,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Includes the Google Ads API server's base endpoint. This is optional.
      *
-     * @param  string|null $endpoint
+     * @param string|null $endpoint
      * @return self this builder
      */
     public function withEndpoint($endpoint)
@@ -139,7 +139,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
      * Includes the OAuth2 credential to be used for authentication. This is
      * required.
      *
-     * @param  FetchAuthTokenInterface $oAuth2Credential
+     * @param FetchAuthTokenInterface $oAuth2Credential
      * @return self this builder
      */
     public function withOAuth2Credential(FetchAuthTokenInterface $oAuth2Credential)
@@ -151,7 +151,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Includes a logger to log requests and responses.
      *
-     * @param  LoggerInterface $logger
+     * @param LoggerInterface $logger
      * @return self this builder
      */
     public function withLogger(LoggerInterface $logger)
@@ -163,7 +163,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Sets the log level for Google Ads API requests and responses.
      *
-     * @param  string $logLevel the PSR-3 log level name, e.g., INFO
+     * @param string $logLevel the PSR-3 log level name, e.g., INFO
      * @return self this builder
      */
     public function withLogLevel(string $logLevel)
@@ -175,7 +175,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     /**
      * Sets the proxy URI for Google Ads API requests in the format protocol://user:pass@host:port.
      *
-     * @param  string $proxy the proxy URI, e.g., http://user:password@localhost:8080
+     * @param string $proxy the proxy URI, e.g., http://user:password@localhost:8080
      * @return self this builder
      */
     public function withProxy(string $proxy)
@@ -226,13 +226,12 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
 
         // For the proxy URI using filter_var is ok because the GRPC library expects the URI
         // in a very specific format.
-        if (!empty($this->proxy)
-            && filter_var(
+        if (!empty($this->proxy) &&
+            filter_var(
                 $this->proxy,
                 FILTER_VALIDATE_URL,
                 FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED
-            ) === false
-        ) {
+            ) === false) {
             throw new InvalidArgumentException(
                 'Proxy must be a valid URI in the form protocol://user:pass@host:port'
             );

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -41,6 +41,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     private $oAuth2Credential;
     private $logger;
     private $logLevel;
+    private $proxy;
 
     private $configurationLoader;
 
@@ -87,6 +88,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
             $configuration->getConfiguration('logFilePath', 'LOGGING'),
             $this->logLevel
         );
+        $this->proxy = $configuration->getConfiguration('proxy', 'CONNECTION');
 
         return $this;
     }
@@ -171,6 +173,18 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     }
 
     /**
+     * Sets the proxy URI for Google Ads API requests in the format protocol://user:pass@host:port.
+     *
+     * @param string $proxy the proxy URI, e.g., http://user:password@localhost:8080
+     * @return self this builder
+     */
+    public function withProxy(string $proxy)
+    {
+        $this->proxy = $proxy;
+        return $this;
+    }
+
+    /**
      * @see GoogleAdsBuilder::build()
      *
      * @return GoogleAdsClient the created Google Ads client
@@ -208,6 +222,13 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
         // but filter_var doesn't allow that.
         if (!empty($this->endpoint) && parse_url($this->endpoint) === false) {
             throw new InvalidArgumentException('Endpoint must be a valid URL.');
+        }
+
+        if (!empty($this->proxy) &&
+            filter_var($this->proxy, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED) === false) {
+            throw new InvalidArgumentException(
+                'Proxy must be a valid URI in the form protocol://user:pass@host:port'
+            );
         }
 
         if ($this->oAuth2Credential === null) {
@@ -275,5 +296,15 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
     public function getLogLevel()
     {
         return $this->logLevel;
+    }
+
+    /**
+     * Gets the proxy URI in the form protocol://user:pass@host:port.
+     *
+     * @return string the proxy URI
+     */
+    public function getProxy()
+    {
+        return $this->proxy;
     }
 }

--- a/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
@@ -164,6 +164,10 @@ trait ServiceClientFactoryTrait
             ];
         }
 
+        if (!empty($this->getProxy())) {
+            putenv('http_proxy=' . $this->getProxy());
+        }
+        
         return $clientOptions;
     }
 

--- a/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
@@ -166,7 +166,6 @@ trait ServiceClientFactoryTrait
 
         if (!empty($this->getProxy())) {
             putenv('http_proxy=' . $this->getProxy());
-            putenv('https_proxy=' . $this->getProxy());
         }
         
         return $clientOptions;

--- a/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
@@ -166,6 +166,7 @@ trait ServiceClientFactoryTrait
 
         if (!empty($this->getProxy())) {
             putenv('http_proxy=' . $this->getProxy());
+            putenv('https_proxy=' . $this->getProxy());
         }
         
         return $clientOptions;

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
@@ -59,7 +59,8 @@ class GoogleAdsClientBuilderTest extends TestCase
             /* Config name, section, value */
             ['developerToken', 'GOOGLE_ADS', self::$DEVELOPER_TOKEN],
             ['loginCustomerId', 'GOOGLE_ADS', self::$LOGIN_CUSTOMER_ID],
-            ['endpoint', 'GOOGLE_ADS', 'https://abc.xyz:443']
+            ['endpoint', 'GOOGLE_ADS', 'https://abc.xyz:443'],
+            ['proxy', 'CONNECTION', 'https://localhost:8080']
         ];
         $configurationMock = $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
@@ -76,6 +77,7 @@ class GoogleAdsClientBuilderTest extends TestCase
         $this->assertSame(self::$DEVELOPER_TOKEN, $googleAdsClient->getDeveloperToken());
         $this->assertSame(self::$LOGIN_CUSTOMER_ID, $googleAdsClient->getLoginCustomerId());
         $this->assertSame('https://abc.xyz:443', $googleAdsClient->getEndpoint());
+        $this->assertSame('https://localhost:8080', $googleAdsClient->getProxy());
     }
 
     /**
@@ -136,6 +138,19 @@ class GoogleAdsClientBuilderTest extends TestCase
     {
         $this->googleAdsClientBuilder
             ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->build();
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Lib\GoogleAdsClientBuilder::build
+     * @expectedException \InvalidArgumentException
+     */
+    public function testBuildFailsWithInvalidProxyUri()
+    {
+        $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withProxy('foo')
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
             ->build();
     }
 
@@ -215,5 +230,30 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->withLoginCustomerId(-1)
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
             ->build();
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Lib\GoogleAdsClientBuilder::build
+     * @dataProvider provideValidProxyURIs
+     */
+    public function testBuildWithValidProxyURIs(string $proxy)
+    {
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withProxy($proxy)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->build();
+
+        $this->assertSame($proxy, $googleAdsClient->getProxy());
+    }
+
+    public function provideValidProxyURIs()
+    {
+        return [
+            ['http://localhost:8080'],
+            ['http://user:pass@localhost:8080'],
+            ['https://localhost:8080'],
+            ['https://user:pass@localhost:8080'],
+        ];
     }
 }

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
@@ -141,15 +141,26 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->build();
     }
 
+    public function provideInvalidProxyURIs()
+    {
+        return [
+            ['foo'],
+            ['http://'],
+            ['foo.com'],
+            ['http://.com']
+        ];
+    }
+
     /**
      * @covers \Google\Ads\GoogleAds\Lib\GoogleAdsClientBuilder::build
+     * @dataProvider provideInvalidProxyURIs
      * @expectedException \InvalidArgumentException
      */
-    public function testBuildFailsWithInvalidProxyUri()
+    public function testBuildFailsWithInvalidProxyUri($invalidProxyUri)
     {
         $this->googleAdsClientBuilder
             ->withDeveloperToken(self::$DEVELOPER_TOKEN)
-            ->withProxy('foo')
+            ->withProxy($invalidProxyUri)
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
             ->build();
     }

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
@@ -265,7 +265,7 @@ class GoogleAdsClientBuilderTest extends TestCase
             ['http://localhost:8080'],
             ['http://user:pass@localhost:8080'],
             ['https://localhost:8080'],
-            ['https://user:pass@localhost:8080'],
+            ['https://user:pass@localhost:8080']
         ];
     }
 }

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
@@ -141,16 +141,6 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->build();
     }
 
-    public function provideInvalidProxyURIs()
-    {
-        return [
-            ['foo'],
-            ['http://'],
-            ['foo.com'],
-            ['http://.com']
-        ];
-    }
-
     /**
      * @covers \Google\Ads\GoogleAds\Lib\GoogleAdsClientBuilder::build
      * @dataProvider provideInvalidProxyURIs
@@ -163,6 +153,17 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->withProxy($invalidProxyUri)
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
             ->build();
+    }
+
+
+    public function provideInvalidProxyURIs()
+    {
+        return [
+            ['foo'],
+            ['http://'],
+            ['foo.com'],
+            ['http://.com']
+        ];
     }
 
     /**

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientTest.php
@@ -37,6 +37,8 @@ class GoogleAdsClientTest extends TestCase
 
     private static $DEVELOPER_TOKEN = 'ABcdeFGH93KL-NOPQ_STUv';
     private static $LOGIN_CUSTOMER_ID = '1234567890';
+    
+    private static $PROXY = 'http://localhost:8080';
 
     /** @var GoogleAdsClientBuilder $googleAdsClientBuilder*/
     private $googleAdsClientBuilder;
@@ -66,6 +68,7 @@ class GoogleAdsClientTest extends TestCase
             ->withLoginCustomerId(self::$LOGIN_CUSTOMER_ID)
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
             ->withLogger(new Logger('', [new NullHandler()]))
+            ->withProxy(self::$PROXY)
             ->build();
         $clientOptions = $googleAdsClient->getGoogleAdsClientOptions();
 
@@ -84,6 +87,10 @@ class GoogleAdsClientTest extends TestCase
         $this->assertInstanceOf(
             GoogleAdsLoggingInterceptor::class,
             $clientOptions['transportConfig']['grpc']['interceptors'][0]
+        );
+        $this->assertSame(
+            getenv('http_proxy'),
+            self::$PROXY
         );
     }
 


### PR DESCRIPTION
This adds support for an HTTP proxy: both setting the proxy property in the .ini file and programmatically setting its value are allowed.

Validation is performed using filter_var with `FILTER_VALIDATE_URL`; the actual configuration is done by setting the `http_proxy` env variable as described [here](https://github.com/grpc/grpc/blob/master/doc/environment_variables.md).