### PR TITLE
Remove extra spaces in the docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
     build: .
     volumes:
     - ./:/google-ads-php
-      - ~/:/root
+    - ~/:/root
       


### PR DESCRIPTION
These spaces make the Docker Compose fail.