### PR TITLE
Remove mocking of protobuf classes

### DIFF
--- a/tests/Google/Ads/GoogleAds/Util/V1/GoogleAdsErrorsTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V1/GoogleAdsErrorsTest.php
@@ -54,17 +54,11 @@ class GoogleAdsErrorsTest extends TestCase
                 ])
             ]
         ]);
-                
-        $anyMock = $this
-            ->getMockBuilder(Any::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $anyMock
-            ->method("unpack")
-            ->willReturn($this->failure);
 
+        $any = new Any();
+        $any->pack($this->failure);
         $this->status = new Status([
-            'details' => [$anyMock]
+            'details' => [$any]
         ]);
     }
 

--- a/tests/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailuresTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailuresTest.php
@@ -27,29 +27,19 @@ class GoogleAdsFailureTest extends TestCase
 {
     public function testFromAny()
     {
-        $anyMock = $this
-            ->getMockBuilder(Any::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $anyMock
-            ->method("unpack")
-            ->willReturn(new GoogleAdsFailure());
+        $any = new Any();
+        $any->pack(new GoogleAdsFailure());
         
-        $this->assertInstanceOf(GoogleAdsFailure::class, GoogleAdsFailures::fromAny($anyMock));
+        $this->assertInstanceOf(GoogleAdsFailure::class, GoogleAdsFailures::fromAny($any));
     }
 
     public function testFromAnyContainingInvalidTypeWillThrowException()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $anyMock = $this
-            ->getMockBuilder(Any::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $anyMock
-            ->method("unpack")
-            ->willReturn(new GoogleAdsError());
+        $any = new Any();
+        $any->pack(new GoogleAdsError());
         
-        GoogleAdsFailures::fromAny($anyMock);
+        GoogleAdsFailures::fromAny($any);
     }
 
     public function testFromEmptyStatus()
@@ -59,15 +49,10 @@ class GoogleAdsFailureTest extends TestCase
 
     public function testFromStatusWithSingleFailure()
     {
-        $anyMock = $this
-            ->getMockBuilder(Any::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $anyMock
-            ->method("unpack")
-            ->willReturn(new GoogleAdsFailure());
+        $any = new Any();
+        $any->pack(new GoogleAdsFailure());
 
-        $status = new Status(['details' => [$anyMock]]);
+        $status = new Status(['details' => [$any]]);
         $failures = GoogleAdsFailures::fromStatus($status);
         $this->assertCount(1, $failures);
         $this->assertInstanceOf(GoogleAdsFailure::class, $failures[0]);

--- a/tests/Google/Ads/GoogleAds/Util/V1/PartialFailuresTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V1/PartialFailuresTest.php
@@ -17,7 +17,8 @@
 
 namespace Google\Ads\GoogleAds\Util\V1;
 
-use Google\Protobuf\Internal\Message;
+use Google\Rpc\Status;
+use Google\Protobuf\GPBEmpty;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,27 +31,15 @@ class PartialFailuresTest extends TestCase
 {
     public function testIsPartialFailure()
     {
-        $messageMock = $this
-            ->getMockBuilder(Message::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $messageMock
-            ->method("serializeToString")
-            ->willReturn("");
+        $emptyMessage = new GPBEmpty();
 
-        $this->assertTrue(PartialFailures::isPartialFailure($messageMock));
+        $this->assertTrue(PartialFailures::isPartialFailure($emptyMessage));
     }
 
     public function testNotPartialFailure()
     {
-        $messageMock = $this
-            ->getMockBuilder(Message::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $messageMock
-            ->method("serializeToString")
-            ->willReturn("a");
+        $someMessage = new Status(['message' => 'a']);
 
-        $this->assertFalse(PartialFailures::isPartialFailure($messageMock));
+        $this->assertFalse(PartialFailures::isPartialFailure($someMessage));
     }
 }


### PR DESCRIPTION
The protobuf c extension does not work with mocks - it causes a segmentation fault. See https://github.com/protocolbuffers/protobuf/issues/4107.

This PR replaces mocks with actual instances of protobuf classes.

cc @AnashOommen 