### PR TITLE
Update service-level timeout and method-level idempotency configuration

### DIFF
--- a/src/Google/Ads/GoogleAds/V1/Services/resources/account_budget_proposal_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/account_budget_proposal_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/account_budget_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/account_budget_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_ad_label_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_ad_label_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_ad_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_ad_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_audience_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_audience_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_bid_modifier_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_bid_modifier_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_criterion_label_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_criterion_label_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_criterion_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_criterion_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_criterion_simulation_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_criterion_simulation_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_extension_setting_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_extension_setting_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_feed_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_feed_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_label_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_label_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_simulation_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_group_simulation_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_parameter_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_parameter_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/ad_schedule_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/ad_schedule_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/age_range_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/age_range_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/asset_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/asset_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/bidding_strategy_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/bidding_strategy_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/billing_setup_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/billing_setup_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_audience_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_audience_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_bid_modifier_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_bid_modifier_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_budget_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_budget_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_criterion_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_criterion_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_criterion_simulation_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_criterion_simulation_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_draft_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_draft_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_experiment_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_experiment_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_extension_setting_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_extension_setting_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_feed_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_feed_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_label_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_label_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_shared_set_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/campaign_shared_set_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/carrier_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/carrier_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/change_status_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/change_status_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/click_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/click_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/conversion_action_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/conversion_action_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/conversion_adjustment_upload_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/conversion_adjustment_upload_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/conversion_upload_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/conversion_upload_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/custom_interest_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/custom_interest_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_client_link_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_client_link_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_client_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_client_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_extension_setting_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_extension_setting_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_feed_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_feed_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_label_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_label_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_manager_link_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_manager_link_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_negative_criterion_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_negative_criterion_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/customer_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/customer_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/detail_placement_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/detail_placement_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/display_keyword_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/display_keyword_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/domain_category_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/domain_category_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/dynamic_search_ads_search_term_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/dynamic_search_ads_search_term_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/expanded_landing_page_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/expanded_landing_page_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/extension_feed_item_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/extension_feed_item_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/feed_item_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/feed_item_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/feed_item_target_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/feed_item_target_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/feed_mapping_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/feed_mapping_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/feed_placeholder_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/feed_placeholder_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/feed_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/feed_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/gender_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/gender_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/geo_target_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/geo_target_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/geographic_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/geographic_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/google_ads_field_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/google_ads_field_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {
@@ -27,7 +27,7 @@
         },
         "SearchGoogleAdsFields": {
           "timeout_millis": 600000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }
       }

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/google_ads_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/google_ads_service_client_config.json
@@ -10,19 +10,19 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {
         "Search": {
           "timeout_millis": 3600000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "Mutate": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/group_placement_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/group_placement_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/hotel_group_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/hotel_group_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/hotel_performance_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/hotel_performance_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_ad_group_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_ad_group_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_campaign_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_campaign_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_idea_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_idea_service_client_config.json
@@ -10,19 +10,19 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {
         "GenerateKeywordIdeas": {
           "timeout_millis": 600000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }
       }

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_keyword_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_keyword_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_negative_keyword_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_negative_keyword_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_plan_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {
@@ -32,12 +32,12 @@
         },
         "GenerateForecastMetrics": {
           "timeout_millis": 600000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "GenerateHistoricalMetrics": {
           "timeout_millis": 600000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }
       }

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/keyword_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/label_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/label_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/landing_page_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/landing_page_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/language_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/language_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/location_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/location_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/managed_placement_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/managed_placement_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/media_file_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/media_file_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/merchant_center_link_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/merchant_center_link_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/mobile_app_category_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/mobile_app_category_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/mobile_device_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/mobile_device_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/mutate_job_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/mutate_job_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/operating_system_version_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/operating_system_version_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/paid_organic_search_term_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/paid_organic_search_term_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/parental_status_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/parental_status_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/payments_account_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/payments_account_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/product_bidding_category_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/product_bidding_category_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/product_group_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/product_group_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/recommendation_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/recommendation_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/remarketing_action_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/remarketing_action_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/search_term_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/search_term_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/shared_criterion_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/shared_criterion_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/shared_set_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/shared_set_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/shopping_performance_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/shopping_performance_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/topic_constant_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/topic_constant_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/topic_view_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/topic_view_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/user_interest_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/user_interest_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/user_list_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/user_list_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {

--- a/src/Google/Ads/GoogleAds/V1/Services/resources/video_service_client_config.json
+++ b/src/Google/Ads/GoogleAds/V1/Services/resources/video_service_client_config.json
@@ -10,13 +10,13 @@
       },
       "retry_params": {
         "default": {
-          "initial_retry_delay_millis": 100,
+          "initial_retry_delay_millis": 5000,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 20000,
+          "initial_rpc_timeout_millis": 3600000,
           "rpc_timeout_multiplier": 1.0,
-          "max_rpc_timeout_millis": 20000,
-          "total_timeout_millis": 600000
+          "max_rpc_timeout_millis": 3600000,
+          "total_timeout_millis": 3600000
         }
       },
       "methods": {


### PR DESCRIPTION
This change updates our client-side timeout settings to more closely match those that are defined by the server in order to prevent the client library from ending requests too soon and ultimately reducing the amount of DEADLINE_EXCEEDED errors that are generated.

Before this change all services were configured with a 20 second timeout in the client library. The majority of services have a server-side timeout of 60 seconds, and in the case of GoogleAdsService.Search there's a 1 hour server-side timeout. This change sets the client-side timeouts to the upper bound (1 hour) in order to prevent the client library from ending requests prematurely.

Additionally a few service methods (including GoogleAdsService.Search) were previously incorrectly configured to be non-idempotent. This means that such methods would not retry requests at all, causing a behavior where a search request would wait 20 seconds for a response and fail instead of retrying. With the change search requests (and a few others) will properly retry if they encounter a DEADLINE_EXCEEDED or UNAVAILABLE error from the server