### PR TITLE
Set max response message and metadata size.

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
@@ -149,6 +149,19 @@ trait ServiceClientFactoryTrait
         if (!empty($this->getEndpoint())) {
             $clientOptions += [self::$SERVICE_ADDRESS_KEY => $this->getEndpoint()];
         }
+
+        $clientOptions['transportConfig'] = [
+            'grpc' => [
+                'stubOpts' => [
+                    // Inbound headers may exceed default (8kb) max header size.
+                    // Sets max header size to 16MB, which should be more than necessary.
+                    'grpc.max_metadata_size' => 16 * 1024 * 1024,
+                    // Sets max response size to 64MB, since large responses will often exceed the
+                    // default (4MB).
+                    'grpc.max_receive_message_length' => 64 * 1024 * 1024
+                ]
+            ]
+        ];
         if (!empty($this->getLogger())) {
             $googleAdsLoggingInterceptor = new GoogleAdsLoggingInterceptor(
                 new GoogleAdsUnaryCallLogger(
@@ -157,28 +170,15 @@ trait ServiceClientFactoryTrait
                     $this->getEndpoint() ?: self::$DEFAULT_SERVICE_ADDRESS
                 )
             );
-            $clientOptions['transportConfig'] = [
-                'grpc' => [
-                    'interceptors' => [$googleAdsLoggingInterceptor]
-                ]
+            $clientOptions['transportConfig']['grpc'] += [
+                'interceptors' => [$googleAdsLoggingInterceptor]
             ];
         }
-
-        $clientOptions['transportConfig']['grpc'] += [
-            'stubOpts' => [
-                // Inbound headers may exceed default (8kb) max header size.
-                // Sets max header size to 16MB, which should be more than necessary.
-                'grpc.max_metadata_size' => 16 * 1024 * 1024,
-                // Sets max response size to 64MB, since large responses will often exceed the default
-                // (4MB).
-                'grpc.max_receive_message_length' => 64 * 1024 * 1024
-            ]
-        ];
 
         if (!empty($this->getProxy())) {
             putenv('http_proxy=' . $this->getProxy());
         }
-        
+
         return $clientOptions;
     }
 

--- a/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/ServiceClientFactoryTrait.php
@@ -164,6 +164,17 @@ trait ServiceClientFactoryTrait
             ];
         }
 
+        $clientOptions['transportConfig']['grpc'] += [
+            'stubOpts' => [
+                // Inbound headers may exceed default (8kb) max header size.
+                // Sets max header size to 16MB, which should be more than necessary.
+                'grpc.max_metadata_size' => 16 * 1024 * 1024,
+                // Sets max response size to 64MB, since large responses will often exceed the default
+                // (4MB).
+                'grpc.max_receive_message_length' => 64 * 1024 * 1024
+            ]
+        ];
+
         if (!empty($this->getProxy())) {
             putenv('http_proxy=' . $this->getProxy());
         }


### PR DESCRIPTION
Set max response message and metadata size accordingly to prevent edge-case problems.