### PR TITLE
Log level defaults and validation

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -246,7 +246,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
 
         if (is_null($this->logLevel)) {
             $this->logLevel = LogLevel::INFO;
-        } elseif (!defined('Psr\Log\LogLevel::' . $this->logLevel)) {
+        } elseif (!defined('Psr\Log\LogLevel::' . strtoupper($this->logLevel))) {
             throw new InvalidArgumentException("The log level must be a valid PSR log level");
         }
     }

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -244,8 +244,10 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
             );
         }
 
-        if ($this->logLevel === null) {
+        if (is_null($this->logLevel)) {
             $this->logLevel = LogLevel::INFO;
+        } elseif (!defined('Psr\Log\LogLevel::' . $this->logLevel)) {
+            throw new InvalidArgumentException("The log level must be a valid PSR log level");
         }
     }
 

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -23,6 +23,7 @@ use Google\Ads\GoogleAds\Lib\GoogleAdsBuilder;
 use Google\Auth\FetchAuthTokenInterface;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Builds Google Ads API clients.
@@ -241,6 +242,10 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
             throw new InvalidArgumentException(
                 'OAuth2 authentication credentials must not be null.'
             );
+        }
+
+        if ($this->logLevel === null) {
+            $this->logLevel = LogLevel::INFO;
         }
     }
 

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsUnaryCallLogger.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsUnaryCallLogger.php
@@ -125,8 +125,8 @@ final class GoogleAdsUnaryCallLogger
      */
     private function isEnabled(string $level): bool
     {
-        return self::$logLevelNamesToNormalizedValues[$this->filterLevel] <=
-                self::$logLevelNamesToNormalizedValues[$level];
+        return self::$logLevelNamesToNormalizedValues[strtoupper($this->filterLevel)] <=
+                self::$logLevelNamesToNormalizedValues[strtoupper($level)];
     }
 
     /**

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
@@ -295,4 +295,15 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->withLogLevel("banana")
             ->build();
     }
+
+    public function testBuildWithLowercaseLogLevel()
+    {
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->withLogLevel("debug")
+            ->build();
+
+        $this->assertSame(LogLevel::DEBUG, $googleAdsClient->getLogLevel());
+    }
 }

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
@@ -282,4 +282,17 @@ class GoogleAdsClientBuilderTest extends TestCase
 
         $this->assertSame(LogLevel::INFO, $googleAdsClient->getLogLevel());
     }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Lib\GoogleAdsClientBuilder::build
+     * @expectedException \InvalidArgumentException
+     */
+    public function testBuildWithInvalidLogLevelThrowsException()
+    {
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->withLogLevel("banana")
+            ->build();
+    }
 }

--- a/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilderTest.php
@@ -20,6 +20,7 @@ namespace Google\Ads\GoogleAds\Lib\V1;
 use Google\Ads\GoogleAds\Lib\Configuration;
 use Google\Auth\FetchAuthTokenInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 
 /**
  * Unit tests for `GoogleAdsClientBuilder`.
@@ -267,5 +268,18 @@ class GoogleAdsClientBuilderTest extends TestCase
             ['https://localhost:8080'],
             ['https://user:pass@localhost:8080']
         ];
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Lib\GoogleAdsClientBuilder::build
+     */
+    public function testBuildWithoutLogLevelSetsDefault()
+    {
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->build();
+
+        $this->assertSame(LogLevel::INFO, $googleAdsClient->getLogLevel());
     }
 }


### PR DESCRIPTION
This sets a default in case the log level is not set in the configuration file and adds some format validation to make sure invalid values are not being set.

Additionally, it also adds some defensive code to make sure the proper log level is being used when logging messages.