### PR TITLE
Fixed LogMessageFormatterTest to work with the current issue of Protobuf native extension

### DIFF
--- a/tests/Google/Ads/GoogleAds/Lib/V1/LogMessageFormatterTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/LogMessageFormatterTest.php
@@ -152,11 +152,8 @@ class LogMessageFormatterTest extends TestCase
             $actualOutput
         );
         $this->assertContains('Host: googleads.api.com', $actualOutput);
-        $this->assertContains(
-            'Response: {"results":[{"campaign":{"id":"1"}},{"campaign":{"id":"2"}},'
-            . '{"campaign":{"id":"3"}}]}',
-            $actualOutput
-        );
+        $this->assertRegExp('/Response: {"results":\[{"campaign":{"id":"?1"?}},'
+            . '{"campaign":{"id":"?2"?}},{"campaign":{"id":"?3"?}}\]}/', $actualOutput);
     }
 
     /**


### PR DESCRIPTION
The current version of Protobuf library converts Int64 as Number, not String.
This modification will allow both users of Protobuf native and PHP extensions able to run this PHPUnit test.