### PR TITLE
Prevent phpunit from marking this test as risky

### DIFF
--- a/tests/Google/Ads/GoogleAds/InstantiateClassesTest.php
+++ b/tests/Google/Ads/GoogleAds/InstantiateClassesTest.php
@@ -36,6 +36,9 @@ class InstantiateClassesTest extends TestCase
      */
     public function testInstantiateClass($class)
     {
+        // Prevent phpunit from marking as risky tests that don't perform any assertion.
+        $this->assertTrue(true);
+
         if (strpos($class, 'metadata') !== false || strpos($class, 'Testing') !== false) {
             return;
         }


### PR DESCRIPTION
Recent (>7) versions of PHPUnit mark as risky tests that don't perform any assertions.

For this test, it's acceptable not to perform any in some cases, so in order to prevent its runs from being marked as risky I added a dummy assertion on top.