### PR TITLE
Revert the fix for LogMessageFormatterTest.

### DIFF
--- a/tests/Google/Ads/GoogleAds/Lib/V1/LogMessageFormatterTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V1/LogMessageFormatterTest.php
@@ -152,8 +152,11 @@ class LogMessageFormatterTest extends TestCase
             $actualOutput
         );
         $this->assertContains('Host: googleads.api.com', $actualOutput);
-        $this->assertRegExp('/Response: {"results":\[{"campaign":{"id":"?1"?}},'
-            . '{"campaign":{"id":"?2"?}},{"campaign":{"id":"?3"?}}\]}/', $actualOutput);
+        $this->assertContains(
+            'Response: {"results":[{"campaign":{"id":"1"}},{"campaign":{"id":"2"}},'
+            . '{"campaign":{"id":"3"}}]}',
+            $actualOutput
+        );
     }
 
     /**


### PR DESCRIPTION
This is a revert of the temporary fix for the protobuf library's [issue](https://github.com/protocolbuffers/protobuf/issues/5663).
Now, the original issue is fixed, so we can revert the test to be more specific again.

This is a fix for #138.