### PR TITLE
Removed options from filter_var() as it's deprecated in PHP 7.3

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClientBuilder.php
@@ -227,12 +227,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
 
         // For the proxy URI using filter_var is ok because the GRPC library expects the URI
         // in a very specific format.
-        if (!empty($this->proxy) &&
-            filter_var(
-                $this->proxy,
-                FILTER_VALIDATE_URL,
-                FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED
-            ) === false) {
+        if (!empty($this->proxy) && filter_var($this->proxy, FILTER_VALIDATE_URL) === false) {
             throw new InvalidArgumentException(
                 'Proxy must be a valid URI in the form protocol://user:pass@host:port'
             );

--- a/src/Google/Ads/GoogleAds/Lib/V2/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V2/GoogleAdsClientBuilder.php
@@ -227,12 +227,7 @@ final class GoogleAdsClientBuilder implements GoogleAdsBuilder
 
         // For the proxy URI using filter_var is ok because the GRPC library expects the URI
         // in a very specific format.
-        if (!empty($this->proxy) &&
-            filter_var(
-                $this->proxy,
-                FILTER_VALIDATE_URL,
-                FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED
-            ) === false) {
+        if (!empty($this->proxy) && filter_var($this->proxy, FILTER_VALIDATE_URL) === false) {
             throw new InvalidArgumentException(
                 'Proxy must be a valid URI in the form protocol://user:pass@host:port'
             );


### PR DESCRIPTION
Removal of the options doesn't affect any earlier PHP versions too. It's just redundant and PHP 7.3 decides to throw an error instead.