### PR TITLE
Updated type hint of examples' function variables

### DIFF
--- a/examples/AccountManagement/CreateCustomer.php
+++ b/examples/AccountManagement/CreateCustomer.php
@@ -94,9 +94,9 @@ class CreateCustomer
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $managerCustomerId the manager customer ID without hyphens
+     * @param int $managerCustomerId the manager customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $managerCustomerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $managerCustomerId)
     {
         $customer = new Customer([
             'descriptive_name' => new StringValue(

--- a/examples/AccountManagement/GetAccountChanges.php
+++ b/examples/AccountManagement/GetAccountChanges.php
@@ -92,9 +92,9 @@ class GetAccountChanges
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves all change statuses.

--- a/examples/AccountManagement/GetAccountInformation.php
+++ b/examples/AccountManagement/GetAccountInformation.php
@@ -90,9 +90,9 @@ class GetAccountInformation
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Issues a getCustomer() request and gets the result.
         $customerServiceClient = $googleAdsClient->getCustomerServiceClient();

--- a/examples/AccountManagement/LinkManagerToClient.php
+++ b/examples/AccountManagement/LinkManagerToClient.php
@@ -96,7 +96,7 @@ class LinkManagerToClient
      * sure to update the configuration before fetching any services you need to use.
      *
      * @param int $managerCustomerId the manager customer ID
-     * @param int $clientCustomerId the client customer ID
+     * @param int $clientCustomerId the customer ID
      */
     public static function runExample(int $managerCustomerId, int $clientCustomerId)
     {
@@ -121,7 +121,7 @@ class LinkManagerToClient
      * Extends an invitation from a manager customer to a client customer.
      *
      * @param int $managerCustomerId the manager customer ID
-     * @param int $clientCustomerId the client customer ID
+     * @param int $clientCustomerId the customer ID
      * @return string the resource name of the customer client link created for the invitation
      */
     private static function createInvitation(
@@ -169,7 +169,7 @@ class LinkManagerToClient
      * Retrieves the manager link resource name of a customer client link given its resource name.
      *
      * @param int $managerCustomerId the manager customer ID
-     * @param int $clientCustomerId the client customer ID
+     * @param int $clientCustomerId the customer ID
      * @param string $customerClientLinkResourceName the customer client link resource name
      * @return string the manager link resource name
      */
@@ -219,7 +219,7 @@ class LinkManagerToClient
     /**
      * Accepts an invitation.
      *
-     * @param int $clientCustomerId the client customer ID
+     * @param int $clientCustomerId the customer ID
      * @param string $managerLinkResourceName the resource name of the manager link to accept
      */
     private static function acceptInvitation(

--- a/examples/AdvancedOperations/AddAdGroupBidModifier.php
+++ b/examples/AdvancedOperations/AddAdGroupBidModifier.php
@@ -102,15 +102,15 @@ class AddAdGroupBidModifier
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID to add an ad group bid modifier to
      * @param float $bidModifierValue the bid modifier value to set
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $bidModifierValue
+        int $customerId,
+        int $adGroupId,
+        float $bidModifierValue
     ) {
         // Creates an ad group bid modifier for mobile devices with the specified ad group ID and
         // bid modifier value.

--- a/examples/AdvancedOperations/AddDynamicPageFeed.php
+++ b/examples/AdvancedOperations/AddDynamicPageFeed.php
@@ -119,7 +119,7 @@ class AddDynamicPageFeed
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the campaign ID
      * @param int $adGroupId the ad group ID
      */
@@ -150,7 +150,7 @@ class AddDynamicPageFeed
     * Creates a feed.
     *
     * @param GoogleAdsClient googleAdsClient the Google Ads API client
-    * @param int customerId the client customer ID in which to create the feed
+    * @param int $customerId the customer ID in which to create the feed
     * @return array the names and IDs of feed attributes
     */
     private static function createFeed(
@@ -194,7 +194,7 @@ class AddDynamicPageFeed
      * Retrieves details about a feed.
      *
      * @param GoogleAdsClient googleAdsClient the Google Ads API client
-     * @param int customerId the client customer ID
+     * @param int customerId the customer ID
      * @param string feedResourceName the resource name of the feed
      * @return array the feed details containing the feed's resource name and the feed attributes'
      * names and values
@@ -223,7 +223,7 @@ class AddDynamicPageFeed
      * Creates a feed mapping for a given feed.
      *
      * @param GoogleAdsClient googleAdsClient the Google Ads API client
-     * @param int customerId the client customer ID
+     * @param int customerId the customer ID
      * @param array feedDetails the names and IDs of feed attributes
      */
     private static function createFeedMapping(
@@ -274,9 +274,9 @@ class AddDynamicPageFeed
      * Creates feed items for a given feed.
      *
      * @param GoogleAdsClient googleAdsClient the Google Ads API client
-     * @param int customerId the client customer ID
-     * @param array feedDetails the names and IDs of feed attributes
-     * @param string dsaPageUrlLabel the label for the DSA page URLs
+     * @param int $customerId the customer ID
+     * @param array $feedDetails the names and IDs of feed attributes
+     * @param string $dsaPageUrlLabel the label for the DSA page URLs
      */
     private function createFeedItems(
         GoogleAdsClient $googleAdsClient,
@@ -335,9 +335,9 @@ class AddDynamicPageFeed
      * Updates a campaign to set the DSA feed.
      *
      * @param GoogleAdsClient googleAdsClient the Google Ads API client
-     * @param int customerId the client customer ID
-     * @param array feedDetails the names and IDs of feed attributes
-     * @param int campaignId the campaign ID of the campaign to update
+     * @param int $customerId the customer ID
+     * @param array $feedDetails the names and IDs of feed attributes
+     * @param int $campaignId the campaign ID of the campaign to update
      */
     private static function updateCampaignDsaSetting(
         GoogleAdsClient $googleAdsClient,
@@ -387,8 +387,8 @@ class AddDynamicPageFeed
      * is not a DSA campaign.
      *
      * @param GoogleAdsClient googleAdsClient the Google Ads API client
-     * @param int customerId the client customer ID
-     * @param int campaignId the campaign ID of the campaign to update
+     * @param int $customerId the customer ID
+     * @param int $campaignId the campaign ID of the campaign to update
      * @return DynamicSearchAdsSetting the DSA settings for the campaign
      */
     private static function getDsaSetting(
@@ -435,9 +435,9 @@ class AddDynamicPageFeed
      * Creates an ad group criterion targeting the DSA label.
      *
      * @param GoogleAdsClient googleAdsClient the Google Ads API client
-     * @param int customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
-     * @param string dsaPageUrlLabel the label for the DSA page URLs
+     * @param string $dsaPageUrlLabel the label for the DSA page URLs
      */
     public static function addDsaTarget(
         GoogleAdsClient $googleAdsClient,

--- a/examples/AdvancedOperations/AddDynamicSearchAds.php
+++ b/examples/AdvancedOperations/AddDynamicSearchAds.php
@@ -116,7 +116,7 @@ class AddDynamicSearchAds
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
@@ -141,7 +141,7 @@ class AddDynamicSearchAds
      * Creates a campaign budget.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return string the campaign budget resource name
      */
     private static function createCampaignBudget(
@@ -176,7 +176,7 @@ class AddDynamicSearchAds
      * Creates a campaign.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $campaignBudgetResourceName the resource name of the campaign budget
      * @return string the resource name of the newly created campaign
      */
@@ -224,7 +224,7 @@ class AddDynamicSearchAds
      * Creates an ad group.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $campaignResourceName the resource name of the campaign
      * @return string the resource name of the newly created ad group
      */
@@ -264,7 +264,7 @@ class AddDynamicSearchAds
      * Creates an expanded dynamic search ad.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the ad group resource name
      */
     private static function createExpandedDSA(
@@ -303,7 +303,7 @@ class AddDynamicSearchAds
      * Creates a webpage targeting criterion for the DSA.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the resource name of the ad group
      */
     private static function createWebPageCriterion(

--- a/examples/AdvancedOperations/AddExpandedTextAdWithUpgradedUrls.php
+++ b/examples/AdvancedOperations/AddExpandedTextAdWithUpgradedUrls.php
@@ -99,13 +99,13 @@ class AddExpandedTextAdWithUpgradedUrls
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID to add a keyword to
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId
+        int $customerId,
+        int $adGroupId
     ) {
         // Creates the expanded text ad info.
         $expandedTextAdInfo = new ExpandedTextAdInfo([

--- a/examples/AdvancedOperations/AddGmailAd.php
+++ b/examples/AdvancedOperations/AddGmailAd.php
@@ -108,7 +108,7 @@ class AddGmailAd
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID to add an ad to
      */
     public static function runExample(
@@ -124,7 +124,7 @@ class AddGmailAd
      * Adds the media files by using the class constants.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return array the media file resource names
      */
     private static function addMediaFiles(
@@ -186,7 +186,7 @@ class AddGmailAd
      * Adds the Gmail ad.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
      * @param array $mediaFiles the media file resource names
      */

--- a/examples/AdvancedOperations/AddSmartDisplayAd.php
+++ b/examples/AdvancedOperations/AddSmartDisplayAd.php
@@ -135,7 +135,7 @@ class AddSmartDisplayAd
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string|null $marketingImageAssetResourceName optional, the resource name of marketing
      *     image asset
      * @param string|null $squareMarketingImageAssetResourceName optional, the resource name of
@@ -171,7 +171,7 @@ class AddSmartDisplayAd
      * Creates a campaign budget.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return string the resource name of newly created campaign budget
      */
     private static function createCampaignBudget(
@@ -208,7 +208,7 @@ class AddSmartDisplayAd
      * Creates a Smart Display campaign.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $campaignBudgetResourceName the resource name of the campaign budget
      * @return string the resource name of the newly created campaign
      */
@@ -257,7 +257,7 @@ class AddSmartDisplayAd
      * Creates an ad group.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $campaignResourceName the resource name of the campaign
      * @return string the resource name of the newly created ad group
      */
@@ -293,7 +293,7 @@ class AddSmartDisplayAd
      * Creates a responsive display ad, which is a recommended ad type for Smart Display campaigns.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the ad group resource name
      * @param string|null $marketingImageAssetResourceName optional, the resource name of marketing
      *     image asset
@@ -384,7 +384,7 @@ class AddSmartDisplayAd
      * Creates an image asset to be used for creating ads.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $imageUrl the image URL to be downloaded
      * @param string $imageName the image name
      * @return string the created image asset's resource name

--- a/examples/AdvancedOperations/CreateAndAttachSharedKeywordSet.php
+++ b/examples/AdvancedOperations/CreateAndAttachSharedKeywordSet.php
@@ -102,13 +102,13 @@ class CreateAndAttachSharedKeywordSet
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the ID of the campaign
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignId
+        int $customerId,
+        int $campaignId
     ) {
         // Create shared negative keyword set.
         $sharedSet = new SharedSet([

--- a/examples/AdvancedOperations/FindAndRemoveCriteriaFromSharedSet.php
+++ b/examples/AdvancedOperations/FindAndRemoveCriteriaFromSharedSet.php
@@ -98,13 +98,13 @@ class FindAndRemoveCriteriaFromSharedSet
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the ID of the campaign
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignId
+        int $customerId,
+        int $campaignId
     ) {
         $sharedSetIds = [];
         $criterionResourceNames = [];

--- a/examples/AdvancedOperations/GetAdGroupBidModifiers.php
+++ b/examples/AdvancedOperations/GetAdGroupBidModifiers.php
@@ -93,12 +93,15 @@ class GetAdGroupBidModifiers
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID for which ad group bid modifiers will be retrieved. If
      *     `null`, returns from all ad groups
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $adGroupId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $adGroupId
+    ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves ad group bid modifiers.
         $query =

--- a/examples/AdvancedOperations/UsePortfolioBiddingStrategy.php
+++ b/examples/AdvancedOperations/UsePortfolioBiddingStrategy.php
@@ -109,13 +109,13 @@ class UsePortfolioBiddingStrategy
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignBudgetId the campaign budget ID
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignBudgetId
+        int $customerId,
+        int $campaignBudgetId
     ) {
         $biddingStrategyResourceName = self::createBiddingStrategy($googleAdsClient, $customerId);
         if (is_null($campaignBudgetId)) {
@@ -137,10 +137,10 @@ class UsePortfolioBiddingStrategy
      * Creates the portfolio bidding strategy.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @return string the resource name of created bidding strategy
      */
-    private static function createBiddingStrategy(GoogleAdsClient $googleAdsClient, $customerId)
+    private static function createBiddingStrategy(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Creates a portfolio bidding strategy.
         $portfolioBiddingStrategy = new BiddingStrategy([
@@ -178,12 +178,12 @@ class UsePortfolioBiddingStrategy
      * Creates an explicitly shared budget to be used to create the campaign.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @return string the resource name of created shared budget
      */
     private static function createSharedCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        $customerId
+        int $customerId
     ) {
         // Creates a shared budget.
         $budget = new CampaignBudget([
@@ -221,15 +221,15 @@ class UsePortfolioBiddingStrategy
      * Creates a campaign with the created portfolio bidding strategy.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $biddingStrategyResourceName the bidding strategy resource name to use
      * @param string $campaignBudgetResourceName the shared budget resource name to use
      */
     private static function createCampaignWithBiddingStrategy(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $biddingStrategyResourceName,
-        $campaignBudgetResourceName
+        int $customerId,
+        string $biddingStrategyResourceName,
+        string $campaignBudgetResourceName
     ) {
         // Creates a Search campaign.
         $campaign = new Campaign([

--- a/examples/BasicOperations/AddAdGroups.php
+++ b/examples/BasicOperations/AddAdGroups.php
@@ -95,13 +95,13 @@ class AddAdGroups
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the campaign ID to add ad groups to
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignId
+        int $customerId,
+        int $campaignId
     ) {
         $campaignResourceName =
             new StringValue(['value' => ResourceNames::forCampaign($customerId, $campaignId)]);

--- a/examples/BasicOperations/AddCampaigns.php
+++ b/examples/BasicOperations/AddCampaigns.php
@@ -99,9 +99,9 @@ class AddCampaigns
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Creates a single shared budget to be used by the campaigns added below.
         $budgetResourceName =
@@ -163,10 +163,10 @@ class AddCampaigns
      * Creates a new campaign budget in the specified client account.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return string the resource name of the newly created budget
      */
-    private static function addCampaignBudget(GoogleAdsClient $googleAdsClient, $customerId)
+    private static function addCampaignBudget(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Creates a campaign budget.
         $budget = new CampaignBudget([

--- a/examples/BasicOperations/AddExpandedTextAds.php
+++ b/examples/BasicOperations/AddExpandedTextAds.php
@@ -97,13 +97,13 @@ class AddExpandedTextAds
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID to add a keyword to
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId
+        int $customerId,
+        int $adGroupId
     ) {
         $adGroupResourceName =
             new StringValue(['value' => ResourceNames::forAdGroup($customerId, $adGroupId)]);

--- a/examples/BasicOperations/AddKeywords.php
+++ b/examples/BasicOperations/AddKeywords.php
@@ -99,15 +99,15 @@ class AddKeywords
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID to add a keyword to
      * @param string $keywordText the keyword text to add
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $keywordText
+        int $customerId,
+        int $adGroupId,
+        string $keywordText
     ) {
         // Configures the keyword text and match type settings.
         $keywordInfo = new KeywordInfo([

--- a/examples/BasicOperations/GetAdGroups.php
+++ b/examples/BasicOperations/GetAdGroups.php
@@ -92,12 +92,15 @@ class GetAdGroups
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the campaign ID for which ad groups will be retrieved. If `null`,
      *     returns from all campaigns
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $campaignId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $campaignId
+    ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves all ad groups.
         $query = 'SELECT campaign.id, ad_group.id, ad_group.name FROM ad_group';

--- a/examples/BasicOperations/GetArtifactMetadata.php
+++ b/examples/BasicOperations/GetArtifactMetadata.php
@@ -98,7 +98,7 @@ class GetArtifactMetadata
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
      * @param int $artifactName the name of artifact to get its metadata
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $artifactName)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $artifactName)
     {
         $googleAdsFieldServiceClient = $googleAdsClient->getGoogleAdsFieldServiceClient();
         // Searches for an artifact whose name is the same as the specified artifactName.

--- a/examples/BasicOperations/GetCampaigns.php
+++ b/examples/BasicOperations/GetCampaigns.php
@@ -88,9 +88,9 @@ class GetCampaigns
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves all campaigns.

--- a/examples/BasicOperations/GetExpandedTextAds.php
+++ b/examples/BasicOperations/GetExpandedTextAds.php
@@ -93,12 +93,15 @@ class GetExpandedTextAds
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID for which expanded text ads will be retrieved. If
      *     `null`, returns from all ad groups
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $adGroupId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $adGroupId
+    ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves expanded text ads.
         $query =

--- a/examples/BasicOperations/GetKeywords.php
+++ b/examples/BasicOperations/GetKeywords.php
@@ -94,12 +94,15 @@ class GetKeywords
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID for which keywords will be retrieved. If `null`,
      *     returns from all ad groups
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $adGroupId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $adGroupId
+    ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves keywords.
         $query =

--- a/examples/BasicOperations/PauseAd.php
+++ b/examples/BasicOperations/PauseAd.php
@@ -98,15 +98,15 @@ class PauseAd
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID that the ad group ad belongs to
      * @param int $adId the ID of the ad to pause
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $adId
+        int $customerId,
+        int $adGroupId,
+        int $adId
     ) {
         // Creates ad group ad resource name.
         $adGroupAdResourceName = ResourceNames::forAdGroupAd($customerId, $adGroupId, $adId);

--- a/examples/BasicOperations/RemoveAd.php
+++ b/examples/BasicOperations/RemoveAd.php
@@ -96,15 +96,15 @@ class RemoveAd
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID that the ad group ad belongs to
      * @param int $adId the ID of the ad to remove
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $adId
+        int $customerId,
+        int $adGroupId,
+        int $adId
     ) {
         // Creates ad group ad resource name.
         $adGroupAdResourceName = ResourceNames::forAdGroupAd($customerId, $adGroupId, $adId);

--- a/examples/BasicOperations/RemoveAdGroup.php
+++ b/examples/BasicOperations/RemoveAdGroup.php
@@ -94,13 +94,13 @@ class RemoveAdGroup
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ID of ad group to remove
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId
+        int $customerId,
+        int $adGroupId
     ) {
         // Creates ad group resource name.
         $adGroupResourceName = ResourceNames::forAdGroup($customerId, $adGroupId);

--- a/examples/BasicOperations/RemoveCampaign.php
+++ b/examples/BasicOperations/RemoveCampaign.php
@@ -93,11 +93,14 @@ class RemoveCampaign
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the ID of the campaign to remove
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $campaignId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $campaignId
+    ) {
         // Creates the resource name of a campaign to remove.
         $campaignResourceName = ResourceNames::forCampaign($customerId, $campaignId);
 

--- a/examples/BasicOperations/RemoveKeyword.php
+++ b/examples/BasicOperations/RemoveKeyword.php
@@ -98,15 +98,15 @@ class RemoveKeyword
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID that the ad group criterion belongs to
      * @param int $criterionId the ID of the ad group criterion to remove
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $criterionId
+        int $customerId,
+        int $adGroupId,
+        int $criterionId
     ) {
         // Creates ad group criterion resource name.
         $adGroupCriterionResourceName =

--- a/examples/BasicOperations/UpdateAdGroup.php
+++ b/examples/BasicOperations/UpdateAdGroup.php
@@ -100,14 +100,14 @@ class UpdateAdGroup
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ID of ad group to update
      * @param int $cpcBidMicroAmount the bid amount in micros to use for the ad group bid
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
+        int $customerId,
+        int $adGroupId,
         $cpcBidMicroAmount
     ) {
         // Creates an ad group object with the specified resource name and other changes.

--- a/examples/BasicOperations/UpdateCampaign.php
+++ b/examples/BasicOperations/UpdateCampaign.php
@@ -96,13 +96,13 @@ class UpdateCampaign
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the ID of campaign to update
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignId
+        int $customerId,
+        int $campaignId
     ) {
         // Creates a campaign object with the specified resource name and other changes.
         $campaign = new Campaign([

--- a/examples/BasicOperations/UpdateKeyword.php
+++ b/examples/BasicOperations/UpdateKeyword.php
@@ -101,15 +101,15 @@ class UpdateKeyword
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID that the criterion ID belongs to
      * @param int $criterionId the ID of the ad group criterion to update
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $criterionId
+        int $customerId,
+        int $adGroupId,
+        int $criterionId
     ) {
         // Creates an ad group criterion with the proper resource name and any other changes.
         $adGroupCriterion = new AdGroupCriterion([

--- a/examples/Billing/AddAccountBudgetProposal.php
+++ b/examples/Billing/AddAccountBudgetProposal.php
@@ -98,13 +98,13 @@ class AddAccountBudgetProposal
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $billingSetupId the billing setup ID used to add the account budget proposal
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $billingSetupId
+        int $customerId,
+        int $billingSetupId
     ) {
         // Constructs an account budget proposal.
         $accountBudgetProposal = new AccountBudgetProposal([

--- a/examples/Billing/GetAccountBudgetProposals.php
+++ b/examples/Billing/GetAccountBudgetProposals.php
@@ -93,9 +93,9 @@ class GetAccountBudgetProposals
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves the account budget proposals.

--- a/examples/Billing/GetAccountBudgets.php
+++ b/examples/Billing/GetAccountBudgets.php
@@ -89,9 +89,9 @@ class GetAccountBudgets
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves the account budgets.

--- a/examples/Billing/GetBillingSetup.php
+++ b/examples/Billing/GetBillingSetup.php
@@ -89,9 +89,9 @@ class GetBillingSetup
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves the billing setups.

--- a/examples/Billing/RemoveBillingSetup.php
+++ b/examples/Billing/RemoveBillingSetup.php
@@ -94,13 +94,13 @@ class RemoveBillingSetup
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $billingSetupId the ID of the billing setup to remove
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $billingSetupId
+        int $customerId,
+        int $billingSetupId
     ) {
         // Creates the resource name of a billing setup to remove.
         $billingSetupResourceName = ResourceNames::forBillingSetup($customerId, $billingSetupId);

--- a/examples/CampaignManagement/AddCampaignBidModifier.php
+++ b/examples/CampaignManagement/AddCampaignBidModifier.php
@@ -100,15 +100,15 @@ class AddCampaignBidModifier
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the ID of the campaign where the bid modifier will be added
      * @param float $bidModifierValue the value of the bid modifier to add
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignId,
-        $bidModifierValue
+        int $customerId,
+        int $campaignId,
+        float $bidModifierValue
     ) {
         // Creates a campaign bid modifier.
         $campaignBidModifier = new CampaignBidModifier([

--- a/examples/CampaignManagement/AddCampaignDraft.php
+++ b/examples/CampaignManagement/AddCampaignDraft.php
@@ -96,7 +96,7 @@ class AddCampaignDraft
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $baseCampaignId the campaign ID to base the draft on
      */
     public static function runExample(

--- a/examples/CampaignManagement/AddCampaignLabels.php
+++ b/examples/CampaignManagement/AddCampaignLabels.php
@@ -97,7 +97,7 @@ class AddCampaignLabels
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param array $campaignIds the IDs of the campaigns to which the label will be added
      * @param int $labelId the ID of the label to attach to campaigns
      */

--- a/examples/CampaignManagement/AddCompleteCampaignsUsingMutateJob.php
+++ b/examples/CampaignManagement/AddCompleteCampaignsUsingMutateJob.php
@@ -131,9 +131,9 @@ class AddCompleteCampaignsUsingMutateJob
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $mutateJobServiceClient = $googleAdsClient->getMutateJobServiceClient();
 
@@ -152,7 +152,7 @@ class AddCompleteCampaignsUsingMutateJob
      * Creates a new mutate job for the specified customer ID.
      *
      * @param MutateJobServiceClient $mutateJobServiceClient the mutate job service client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return string the resource name of the created mutate job
      */
     private static function createMutateJob(
@@ -175,7 +175,7 @@ class AddCompleteCampaignsUsingMutateJob
      * that you can use to upload more operations in the future.
      *
      * @param MutateJobServiceClient $mutateJobServiceClient the mutate job service client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $mutateJobResourceName the resource name of mutate job to which the mutate job
      *     operations will be added
      */
@@ -275,7 +275,7 @@ class AddCompleteCampaignsUsingMutateJob
      * Builds all operations for creating a complete campaign and return an array of their
      * corresponding mutate operations.
      *
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return MutateOperation[] the mutate operations to be added to a mutate job
      */
     private static function buildAllOperations(int $customerId)
@@ -344,7 +344,7 @@ class AddCompleteCampaignsUsingMutateJob
     /**
      * Builds a new campaign budget operation for the specified customer ID.
      *
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return CampaignBudgetOperation the campaign budget operation
      */
     private static function buildCampaignBudgetOperation(int $customerId)
@@ -367,7 +367,7 @@ class AddCompleteCampaignsUsingMutateJob
     /**
      * Builds new campaign operations for the specified customer ID.
      *
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $campaignBudgetResourceName the resource name of campaign budget to be used
      *     to create campaigns
      * @return CampaignOperation[] the campaign operations
@@ -437,7 +437,7 @@ class AddCompleteCampaignsUsingMutateJob
     /**
      * Builds new ad group operations for the specified customer ID.
      *
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param CampaignOperation[] $campaignOperations the campaign operations to be used to create
      *     ad groups
      * @return AdGroupOperation[] the ad group operations

--- a/examples/CampaignManagement/GetAllDisapprovedAds.php
+++ b/examples/CampaignManagement/GetAllDisapprovedAds.php
@@ -97,11 +97,14 @@ class GetAllDisapprovedAds
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the campaign ID for which campaign ads will be retrieved
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $campaignId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $campaignId
+    ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves all ads of the specified campaign ID.
         $query = 'SELECT ad_group_ad.ad.id, '

--- a/examples/CampaignManagement/GetCampaignsByLabel.php
+++ b/examples/CampaignManagement/GetCampaignsByLabel.php
@@ -91,11 +91,14 @@ class GetCampaignsByLabel
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $labelId the label ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $labelId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $labelId
+    ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that will retrieve all campaign labels with the specified
         // label ID.

--- a/examples/CampaignManagement/SetAdParameters.php
+++ b/examples/CampaignManagement/SetAdParameters.php
@@ -97,7 +97,7 @@ class SetAdParameters
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
      * @param int $criterionId the criterion ID
      */

--- a/examples/ErrorHandling/HandleExpandedTextAdPolicyViolations.php
+++ b/examples/ErrorHandling/HandleExpandedTextAdPolicyViolations.php
@@ -104,7 +104,7 @@ class HandleExpandedTextAdPolicyViolations
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID to add an expanded text ad to
      */
     public static function runExample(

--- a/examples/ErrorHandling/HandleKeywordPolicyViolations.php
+++ b/examples/ErrorHandling/HandleKeywordPolicyViolations.php
@@ -111,7 +111,7 @@ class HandleKeywordPolicyViolations
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID to add a keyword to
      * @param string $keywordText the keyword text to add
      */

--- a/examples/ErrorHandling/HandlePartialFailure.php
+++ b/examples/ErrorHandling/HandlePartialFailure.php
@@ -106,11 +106,14 @@ class HandlePartialFailure
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId a campaign ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $campaignId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $campaignId
+    ) {
         $response = self::createAdGroups($googleAdsClient, $customerId, $campaignId);
         self::checkIfPartialFailureErrorExists($response);
         self::printResults($response);
@@ -120,14 +123,14 @@ class HandlePartialFailure
      * Create ad groups by enabling partial failure mode.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId a campaign ID
      * @return MutateAdGroupsResponse
      */
     private static function createAdGroups(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignId
+        int $customerId,
+        int $campaignId
     ) {
         $campaignResourceName =
             new StringValue(['value' => ResourceNames::forCampaign($customerId, $campaignId)]);

--- a/examples/HotelAds/AddHotelAd.php
+++ b/examples/HotelAds/AddHotelAd.php
@@ -126,15 +126,15 @@ class AddHotelAds
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $hotelCenterAccountId the Hotel Center account ID
      * @param int $cpcBidCeilingMicroAmount the CPC bid ceiling micro amount
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $hotelCenterAccountId,
-        $cpcBidCeilingMicroAmount
+        int $customerId,
+        int $hotelCenterAccountId,
+        int $cpcBidCeilingMicroAmount
     ) {
         // Creates a budget to be used by the campaign that will be created below.
         $budgetResourceName = self::addCampaignBudget($googleAdsClient, $customerId);
@@ -157,10 +157,10 @@ class AddHotelAds
      * Creates a new campaign budget in the specified client account.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return string the resource name of the newly created budget
      */
-    private static function addCampaignBudget(GoogleAdsClient $googleAdsClient, $customerId)
+    private static function addCampaignBudget(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Creates a campaign budget.
         $budget = new CampaignBudget([
@@ -198,7 +198,7 @@ class AddHotelAds
      * Creates a new hotel campaign in the specified client account.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $budgetResourceName the resource name of budget for a new campaign
      * @param int $hotelCenterAccountId the Hotel Center account ID
      * @param int $cpcBidCeilingMicroAmount the CPC bid ceiling micro amount
@@ -207,10 +207,10 @@ class AddHotelAds
     // [START addHotelCampaign]
     private static function addHotelCampaign(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $budgetResourceName,
-        $hotelCenterAccountId,
-        $cpcBidCeilingMicroAmount
+        int $customerId,
+        string $budgetResourceName,
+        int $hotelCenterAccountId,
+        int $cpcBidCeilingMicroAmount
     ) {
         // Creates a campaign.
         $campaign = new Campaign([
@@ -263,7 +263,7 @@ class AddHotelAds
      * Creates a new hotel ad group in the specified campaign.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $campaignResourceName the resource name of campaign that a new ad group will
      *     belong to
      * @return string the resource name of the newly created ad group
@@ -271,8 +271,8 @@ class AddHotelAds
     // [START addHotelAdGroup]
     private static function addHotelAdGroup(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignResourceName
+        int $customerId,
+        string $campaignResourceName
     ) {
         // Creates an ad group.
         $adGroup = new AdGroup([
@@ -310,15 +310,15 @@ class AddHotelAds
      * Creates a new hotel ad group ad in the specified ad group.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the resource name of ad group that a new ad group ad will
      *     belong to
      */
     // [START addHotelAdGroupAd]
     private static function addHotelAdGroupAd(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupResourceName
+        int $customerId,
+        string $adGroupResourceName
     ) {
         // Creates a new hotel ad.
         $ad = new Ad([

--- a/examples/HotelAds/AddHotelAdGroupBidModifiers.php
+++ b/examples/HotelAds/AddHotelAdGroupBidModifiers.php
@@ -101,14 +101,14 @@ class AddHotelAdGroupBidModifiers
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
      */
     // [START addHotelAdGroupBidModifiers]
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId
+        int $customerId,
+        int $adGroupId
     ) {
         $operations = [];
 

--- a/examples/HotelAds/AddHotelListingGroupTree.php
+++ b/examples/HotelAds/AddHotelListingGroupTree.php
@@ -134,16 +134,16 @@ class AddHotelListingGroupTree
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
      * @param int $percentCpcBidMicroAmount the percent CPC bid micro amount to set on created ad
      *     group criteria
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $percentCpcBidMicroAmount
+        int $customerId,
+        int $adGroupId,
+        int $percentCpcBidMicroAmount
     ) {
         $operations = [];
 
@@ -190,10 +190,10 @@ class AddHotelListingGroupTree
      * @return string the root node's resource name
      */
     private static function addRootNode(
-        $customerId,
-        $adGroupId,
+        int $customerId,
+        int $adGroupId,
         array &$operations,
-        $percentCpcBidMicroAmount
+        int $percentCpcBidMicroAmount
     ) {
         // Creates the root of the tree as a SUBDIVISION node.
         $root = self::createListingGroupInfo(ListingGroupType::SUBDIVISION);
@@ -220,11 +220,11 @@ class AddHotelListingGroupTree
      */
     // [START addLevel1Nodes]
     private static function addLevel1Nodes(
-        $customerId,
-        $adGroupId,
-        $rootResourceName,
+        int $customerId,
+        int $adGroupId,
+        string $rootResourceName,
         array &$operations,
-        $percentCpcBidMicroAmount
+        int $percentCpcBidMicroAmount
     ) {
         // Creates hotel class info and dimension info for 5-star hotels.
         $fiveStarredDimensionInfo = new ListingDimensionInfo([
@@ -292,11 +292,11 @@ class AddHotelListingGroupTree
      *     criteria
      */
     private static function addLevel2Nodes(
-        $customerId,
-        $adGroupId,
-        $parentResourceName,
+        int $customerId,
+        int $adGroupId,
+        string $parentResourceName,
         array &$operations,
-        $percentCpcBidMicroAmount
+        int $percentCpcBidMicroAmount
     ) {
         // The criterion ID for Japan is 2392.
         // See https://developers.google.com/adwords/api/docs/appendix/geotargeting for criteria ID
@@ -361,8 +361,8 @@ class AddHotelListingGroupTree
      * @return ListingGroupInfo the created listing group info
      */
     private static function createListingGroupInfo(
-        $listingGroupType,
-        $parentCriterionResourceName = null,
+        int $listingGroupType,
+        string $parentCriterionResourceName = null,
         ListingDimensionInfo $caseValue = null
     ) {
         $listingGroupInfo = new ListingGroupInfo([
@@ -391,10 +391,10 @@ class AddHotelListingGroupTree
      * @return AdGroupCriterion the created ad group criterion
      */
     private static function createAdGroupCriterion(
-        $customerId,
-        $adGroupId,
+        int $customerId,
+        int $adGroupId,
         ListingGroupInfo $listingGroupInfo,
-        $percentCpcBidMicroAmount
+        int $percentCpcBidMicroAmount
     ) {
         $adGroupCriterion = new AdGroupCriterion([
             'status' => AdGroupStatus::ENABLED,

--- a/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase1.php
+++ b/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase1.php
@@ -89,7 +89,7 @@ class CreateCompleteCampaignBothApisPhase1
      * @param AdWordsServices $adWordsServices the AdWords services
      * @param AdWordsSession $adWordsSession the AdWords session
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param string $customerId the customer ID
      */
     public static function runExample(
         AdWordsServices $adWordsServices,
@@ -120,7 +120,7 @@ class CreateCompleteCampaignBothApisPhase1
     /**
      * Creates a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param string $customerId the customer ID
      * @return CampaignBudget the newly created campaign budget
      */
     private static function createCampaignBudget(
@@ -161,13 +161,13 @@ class CreateCompleteCampaignBothApisPhase1
     /**
      * Gets a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param string $customerId the customer ID
      * @param string $resourceName the resource name of the campaign budget to retrieve
      * @return CampaignBudget the campaign budget
      */
     private static function getCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $resourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();

--- a/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase2.php
+++ b/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase2.php
@@ -83,18 +83,18 @@ class CreateCompleteCampaignBothApisPhase2
     // The default page size for search queries.
     const PAGE_SIZE = 1000;
 
-/**
+    /**
      * Runs the CreateCompleteCampaignBothApisPhase2 example.
      * @param AdWordsServices $adWordsServices the AdWords services
      * @param AdWordsSession $adWordsSession the AdWords session
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      */
     public static function runExample(
         AdWordsServices $adWordsServices,
         AdWordsSession $adWordsSession,
         GoogleAdsClient $googleAdsClient,
-        string $customerId
+        int $customerId
     ) {
         $campaignBudget = self::createCampaignBudget($googleAdsClient, $customerId);
         $campaign = self::createCampaign($googleAdsClient, $customerId, $campaignBudget);
@@ -115,12 +115,12 @@ class CreateCompleteCampaignBothApisPhase2
     /**
      * Creates a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @return CampaignBudget the newly created campaign budget
      */
     private static function createCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId
+        int $customerId
     ) {
         // Creates a campaign budget.
         $campaignBudget = new CampaignBudget([
@@ -156,13 +156,13 @@ class CreateCompleteCampaignBothApisPhase2
     /**
      * Gets a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $resourceName the resource name of the campaign budget to retrieve
      * @return CampaignBudget the campaign budget
      */
     private static function getCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $resourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -179,13 +179,13 @@ class CreateCompleteCampaignBothApisPhase2
     /**
      * Creates a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param CampaignBudget $campaignBudget the campaign budget
      * @return Campaign the newly created campaign
      */
     private static function createCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         CampaignBudget $campaignBudget
     ) {
         $trueValue = new BoolValue(['value' => true]);
@@ -239,13 +239,13 @@ class CreateCompleteCampaignBothApisPhase2
     /**
      * Gets a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $campaignResourceName the resource name of the campaign to retrieve
      * @return Campaign the campaign
      */
     private static function getCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $campaignResourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();

--- a/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase3.php
+++ b/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase3.php
@@ -79,18 +79,18 @@ class CreateCompleteCampaignBothApisPhase3
     // The default page size for search queries.
     const PAGE_SIZE = 1000;
 
-/**
+    /**
      * Runs the CreateCompleteCampaignBothApisPhase3 example.
      * @param AdWordsServices $adWordsServices the AdWords services
      * @param AdWordsSession $adWordsSession the AdWords session
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      */
     public static function runExample(
         AdWordsServices $adWordsServices,
         AdWordsSession $adWordsSession,
         GoogleAdsClient $googleAdsClient,
-        string $customerId
+        int $customerId
     ) {
         $campaignBudget = self::createCampaignBudget($googleAdsClient, $customerId);
         $campaign = self::createCampaign($googleAdsClient, $customerId, $campaignBudget);
@@ -107,12 +107,12 @@ class CreateCompleteCampaignBothApisPhase3
     /**
      * Creates a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @return CampaignBudget the newly created campaign budget
      */
     private static function createCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId
+        int $customerId
     ) {
         // Creates a campaign budget.
         $campaignBudget = new CampaignBudget([
@@ -148,13 +148,13 @@ class CreateCompleteCampaignBothApisPhase3
     /**
      * Gets a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $resourceName the resource name of the campaign budget to retrieve
      * @return CampaignBudget the campaign budget
      */
     private static function getCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $resourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -171,13 +171,13 @@ class CreateCompleteCampaignBothApisPhase3
     /**
      * Creates a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param CampaignBudget $campaignBudget the campaign budget
      * @return Campaign the newly created campaign
      */
     private static function createCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         CampaignBudget $campaignBudget
     ) {
         $trueValue = new BoolValue(['value' => true]);
@@ -231,13 +231,13 @@ class CreateCompleteCampaignBothApisPhase3
     /**
      * Gets a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $campaignResourceName the resource name of the campaign to retrieve
      * @return Campaign the campaign
      */
     private static function getCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $campaignResourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -254,13 +254,13 @@ class CreateCompleteCampaignBothApisPhase3
     /**
      * Creates an ad group.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param Campaign $campaign the campaign
      * @return AdGroup the newly created ad group
      */
     private static function createAdGroup(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         Campaign $campaign
     ) {
         // Constructs an ad group and sets an optional CPC value.
@@ -292,13 +292,13 @@ class CreateCompleteCampaignBothApisPhase3
     /**
      * Gets an ad group.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $adGroupResourceName the resource name of the ad group to retrieve
      * @return AdGroup the ad group
      */
     private static function getAdGroup(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $adGroupResourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();

--- a/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase4.php
+++ b/examples/Migration/CampaignManagement/CreateCompleteCampaignBothApisPhase4.php
@@ -80,18 +80,18 @@ class CreateCompleteCampaignBothApisPhase4
     // The default page size for search queries.
     const PAGE_SIZE = 1000;
 
-/**
+    /**
      * Runs the CreateCompleteCampaignBothApisPhase4 example.
      * @param AdWordsServices $adWordsServices the AdWords services
      * @param AdWordsSession $adWordsSession the AdWords session
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      */
     public static function runExample(
         AdWordsServices $adWordsServices,
         AdWordsSession $adWordsSession,
         GoogleAdsClient $googleAdsClient,
-        string $customerId
+        int $customerId
     ) {
         $campaignBudget = self::createCampaignBudget($googleAdsClient, $customerId);
         $campaign = self::createCampaign($googleAdsClient, $customerId, $campaignBudget);
@@ -108,12 +108,12 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Creates a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @return CampaignBudget the newly created campaign budget
      */
     private static function createCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId
+        int $customerId
     ) {
         // Creates a campaign budget.
         $campaignBudget = new CampaignBudget([
@@ -149,13 +149,13 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Gets a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $resourceName the resource name of the campaign budget to retrieve
      * @return CampaignBudget the campaign budget
      */
     private static function getCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $resourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -172,13 +172,13 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Creates a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param CampaignBudget $campaignBudget the campaign budget
      * @return Campaign the newly created campaign
      */
     private static function createCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         CampaignBudget $campaignBudget
     ) {
         $trueValue = new BoolValue(['value' => true]);
@@ -232,13 +232,13 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Gets a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $campaignResourceName the resource name of the campaign to retrieve
      * @return Campaign the campaign
      */
     private static function getCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $campaignResourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -255,13 +255,13 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Creates an ad group.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param Campaign $campaign the campaign
      * @return AdGroup the newly created ad group
      */
     private static function createAdGroup(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         Campaign $campaign
     ) {
         // Constructs an ad group and sets an optional CPC value.
@@ -293,13 +293,13 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Gets an ad group.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $adGroupResourceName the resource name of the ad group to retrieve
      * @return AdGroup the ad group
      */
     private static function getAdGroup(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $adGroupResourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -316,12 +316,12 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Creates text ads.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param AdGroup $adGroup the ad group
      */
     private static function createTextAds(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         AdGroup $adGroup
     ) {
         $operations = [];
@@ -378,13 +378,13 @@ class CreateCompleteCampaignBothApisPhase4
     /**
      * Gets an array of ads by their resource names.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param array $adResourceNames the resource names of the ads to retrieve
      * @return array an array of ads
      */
     private static function getAds(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         array $adResourceNames
     ) {
         $resourceNames = join(",", array_map(function ($resourceName) {

--- a/examples/Migration/CampaignManagement/CreateCompleteCampaignGoogleAdsApiOnly.php
+++ b/examples/Migration/CampaignManagement/CreateCompleteCampaignGoogleAdsApiOnly.php
@@ -79,9 +79,9 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Runs the CreateCompleteCampaignGoogleAdsApiOnly example.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, string $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $campaignBudget = self::createCampaignBudget($googleAdsClient, $customerId);
         $campaign = self::createCampaign($googleAdsClient, $customerId, $campaignBudget);
@@ -93,12 +93,12 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Creates a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @return CampaignBudget the newly created campaign budget
      */
     private static function createCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId
+        int $customerId
     ) {
         // Creates a campaign budget.
         $campaignBudget = new CampaignBudget([
@@ -134,13 +134,13 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Gets a campaign budget.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $resourceName the resource name of the campaign budget to retrieve
      * @return CampaignBudget the campaign budget
      */
     private static function getCampaignBudget(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $resourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -157,13 +157,13 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Creates a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param CampaignBudget $campaignBudget the campaign budget
      * @return Campaign the newly created campaign
      */
     private static function createCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         CampaignBudget $campaignBudget
     ) {
         $trueValue = new BoolValue(['value' => true]);
@@ -217,13 +217,13 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Gets a campaign.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $campaignResourceName the resource name of the campaign to retrieve
      * @return Campaign the campaign
      */
     private static function getCampaign(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $campaignResourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -240,13 +240,13 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Creates an ad group.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param Campaign $campaign the campaign
      * @return AdGroup the newly created ad group
      */
     private static function createAdGroup(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         Campaign $campaign
     ) {
         // Constructs an ad group and sets an optional CPC value.
@@ -278,13 +278,13 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Gets an ad group.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param string $adGroupResourceName the resource name of the ad group to retrieve
      * @return AdGroup the ad group
      */
     private static function getAdGroup(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         string $adGroupResourceName
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
@@ -301,12 +301,12 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Creates text ads.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param AdGroup $adGroup the ad group
      */
     private static function createTextAds(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         AdGroup $adGroup
     ) {
         $operations = [];
@@ -363,13 +363,13 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Gets an array of ads by their resource names.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param array $adResourceNames the resource names of the ads to retrieve
      * @return array an array of ads
      */
     private static function getAds(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         array $adResourceNames
     ) {
         $resourceNames = join(",", array_map(function ($resourceName) {
@@ -397,14 +397,14 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Creates keywords.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param AdGroup $adGroup the ad group
      * @param array $keywordsToAdd the keywords to create
      * @return AdGroupCriterion[] an array of keywords
      */
     private static function createKeywords(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         AdGroup $adGroup,
         array $keywordsToAdd
     ) {
@@ -461,13 +461,13 @@ class CreateCompleteCampaignGoogleAdsApiOnly
     /**
      * Gets an array of keywords by their resource names.
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param string $customerId the client customer ID without hyphens
+     * @param int $customerId the client customer ID
      * @param array $keywordResourceNames the resource names of the keywords to retrieve
      * @return array an array of keywords
      */
     private static function getKeywords(
         GoogleAdsClient $googleAdsClient,
-        string $customerId,
+        int $customerId,
         array $keywordResourceNames
     ) {
         $resourceNames = join(",", array_map(function ($resourceName) {

--- a/examples/Migration/RunExamples.php
+++ b/examples/Migration/RunExamples.php
@@ -40,6 +40,10 @@ class RunExamples
     const CLIENT_ID = 'INSERT_YOUR_OAUTH2_CLIENT_ID_HERE';
     const CLIENT_SECRET = 'INSERT_YOUR_OAUTH2_CLIENT_SECRET_HERE';
     const REFRESH_TOKEN = 'INSERT_YOUR_OAUTH2_REFRESH_TOKEN_HERE';
+    // Replace the below string with your (client) customer ID as "an integer". Although the AdWords
+    // API library can handle a client customer ID as a string with hyphens included, this variable
+    // is also shared with the Google Ads API client library, which accepts only customer ID as an
+    // integer.
     const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
     const PAGE_SIZE = 1000;
 

--- a/examples/Misc/GetAllVideosAndImages.php
+++ b/examples/Misc/GetAllVideosAndImages.php
@@ -89,7 +89,7 @@ class GetAllVideosAndImages
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
     public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {

--- a/examples/Misc/UploadImage.php
+++ b/examples/Misc/UploadImage.php
@@ -92,9 +92,9 @@ class UploadImage
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Creates an image content.
         $imageContent = file_get_contents(self::IMAGE_URL);

--- a/examples/Planning/AddKeywordPlan.php
+++ b/examples/Planning/AddKeywordPlan.php
@@ -107,9 +107,9 @@ class AddKeywordPlan
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $keywordPlanResource = self::createKeywordPlan(
             $googleAdsClient,
@@ -145,12 +145,12 @@ class AddKeywordPlan
      * Creates a keyword plan.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @return string the newly created keyword plan resource
      */
     private static function createKeywordPlan(
         GoogleAdsClient $googleAdsClient,
-        $customerId
+        int $customerId
     ) {
         // Creates a keyword plan.
         $keywordPlan = new KeywordPlan([
@@ -183,14 +183,14 @@ class AddKeywordPlan
      * Creates the campaign for the keyword plan.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $keywordPlanResource the keyword plan resource
      * @return string the newly created campaign resource
      */
     private static function createKeywordPlanCampaign(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $keywordPlanResource
+        int $customerId,
+        string $keywordPlanResource
     ) {
         // Creates a keyword plan campaign.
         $keywordPlanCampaign = new KeywordPlanCampaign([
@@ -237,7 +237,7 @@ class AddKeywordPlan
      * Creates the ad group for the keyword plan.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $planCampaignResource the resource name of the campaign under which the
      *     ad group is created
      * @return string the newly created ad group resource
@@ -245,8 +245,8 @@ class AddKeywordPlan
 
     private static function createKeywordPlanAdGroup(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $planCampaignResource
+        int $customerId,
+        string $planCampaignResource
     ) {
         // Creates a keyword plan ad group.
         $keywordPlanAdGroup = new KeywordPlanAdGroup([
@@ -275,14 +275,14 @@ class AddKeywordPlan
      * Creates keywords for the keyword plan.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $planAdGroupResource the resource name of the ad group under which the
      *     keywords are created
      */
     private static function createKeywordPlanKeywords(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $planAdGroupResource
+        int $customerId,
+        string $planAdGroupResource
     ) {
         // Creates the keywords for the keyword plan.
         $keywordPlanKeyword1 = new KeywordPlanKeyword([
@@ -335,14 +335,14 @@ class AddKeywordPlan
      * Creates negative keywords for the keyword plan.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $planCampaignResource the resource name of the campaign under which
      *     the keywords are created
      */
     private static function createKeywordPlanNegativeKeywords(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $planCampaignResource
+        int $customerId,
+        string $planCampaignResource
     ) {
         // Creates a negative keyword for the keyword plan.
         $keywordPlanNegativeKeyword = new KeywordPlanNegativeKeyword([

--- a/examples/Planning/GenerateForecastMetrics.php
+++ b/examples/Planning/GenerateForecastMetrics.php
@@ -96,11 +96,14 @@ class GenerateForecastMetrics
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $keywordPlanId the keyword plan ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $keywordPlanId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $keywordPlanId
+    ) {
         $keywordPlanServiceClient = $googleAdsClient->getKeywordPlanServiceClient();
 
         // Issues a request to generate forecast metrics based on the specific keyword plan ID.

--- a/examples/Planning/GenerateKeywordIdeas.php
+++ b/examples/Planning/GenerateKeywordIdeas.php
@@ -120,7 +120,7 @@ class GenerateKeywordIdeas
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int[] $locationIds the location IDs
      * @param int $languageId the language ID
      * @param string[] $keywords the list of keywords to use as a seed for ideas
@@ -128,11 +128,11 @@ class GenerateKeywordIdeas
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
+        int $customerId,
         array $locationIds,
-        $languageId,
+        int $languageId,
         array $keywords,
-        $pageUrl
+        string $pageUrl
     ) {
         $keywordPlanIdeaServiceClient = $googleAdsClient->getKeywordPlanIdeaServiceClient();
 

--- a/examples/Recommendations/ApplyRecommendation.php
+++ b/examples/Recommendations/ApplyRecommendation.php
@@ -98,13 +98,13 @@ class ApplyRecommendation
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $recommendationId the recommendation ID to apply
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $recommendationId
+        int $customerId,
+        string $recommendationId
     ) {
         $recommendationResourceName =
             ResourceNames::forRecommendation($customerId, $recommendationId);

--- a/examples/Recommendations/DismissRecommendation.php
+++ b/examples/Recommendations/DismissRecommendation.php
@@ -98,13 +98,13 @@ class DismissRecommendation
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param string $recommendationId the recommendation ID to dismiss
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $recommendationId
+        int $customerId,
+        string $recommendationId
     ) {
         $recommendationResourceName =
             ResourceNames::forRecommendation($customerId, $recommendationId);

--- a/examples/Recommendations/GetTextAdRecommendations.php
+++ b/examples/Recommendations/GetTextAdRecommendations.php
@@ -89,9 +89,9 @@ class GetTextAdRecommendations
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves recommendations for text ads.

--- a/examples/Remarketing/AddConversionAction.php
+++ b/examples/Remarketing/AddConversionAction.php
@@ -96,9 +96,9 @@ class AddConversionAction
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Creates a conversion action.
         $conversionAction = new ConversionAction([

--- a/examples/Reporting/GetHotelAdsPerformance.php
+++ b/examples/Reporting/GetHotelAdsPerformance.php
@@ -91,9 +91,9 @@ class GetHotelAdsPerformance
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves hotel-ads statistics for each campaign and ad group.

--- a/examples/Reporting/GetKeywordStats.php
+++ b/examples/Reporting/GetKeywordStats.php
@@ -91,9 +91,9 @@ class GetKeywordStats
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId)
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves all keyword statistics.

--- a/examples/ShoppingAds/AddShoppingProductAd.php
+++ b/examples/ShoppingAds/AddShoppingProductAd.php
@@ -126,7 +126,7 @@ class AddShoppingProductAd
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $merchantCenterAccountId the Merchant Center account ID
      * @param bool $shouldCreateDefaultListingGroup true if a default listing group should be
      *     created for the ad group. Set to false if the listing group will be constructed
@@ -134,9 +134,9 @@ class AddShoppingProductAd
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $merchantCenterAccountId,
-        $shouldCreateDefaultListingGroup
+        int $customerId,
+        int $merchantCenterAccountId,
+        bool $shouldCreateDefaultListingGroup
     ) {
         // Creates a budget to be used by the campaign that will be created below.
         $budgetResourceName = self::addCampaignBudget($googleAdsClient, $customerId);
@@ -169,10 +169,10 @@ class AddShoppingProductAd
      * Creates a new campaign budget in the specified client account.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return string the resource name of the newly created budget
      */
-    private static function addCampaignBudget(GoogleAdsClient $googleAdsClient, $customerId)
+    private static function addCampaignBudget(GoogleAdsClient $googleAdsClient, int $customerId)
     {
         // Creates a campaign budget.
         $budget = new CampaignBudget([
@@ -208,7 +208,7 @@ class AddShoppingProductAd
      * Creates a new shopping product campaign in the specified client account.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $budgetResourceName the resource name of budget for a new campaign
      * @param int $merchantCenterAccountId the Merchant Center account ID
      * @return string the resource name of the newly created campaign
@@ -216,9 +216,9 @@ class AddShoppingProductAd
     // [START addShoppingProductCampaign]
     private static function addStandardShoppingCampaign(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $budgetResourceName,
-        $merchantCenterAccountId
+        int $customerId,
+        string $budgetResourceName,
+        int $merchantCenterAccountId
     ) {
         // Creates a standard shopping campaign.
         $campaign = new Campaign([
@@ -277,7 +277,7 @@ class AddShoppingProductAd
      * Creates a new shopping product ad group in the specified campaign.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $campaignResourceName the resource name of campaign that a new ad group will
      *     belong to
      * @return string the resource name of the newly created ad group
@@ -285,8 +285,8 @@ class AddShoppingProductAd
     // [START addShoppingProductAdGroup]
     private static function addShoppingProductAdGroup(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignResourceName
+        int $customerId,
+        string $campaignResourceName
     ) {
         // Creates an ad group.
         $adGroup = new AdGroup([
@@ -324,15 +324,15 @@ class AddShoppingProductAd
      * Creates a new shopping product ad group ad in the specified ad group.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the resource name of ad group that a new ad group ad will
      *     belong to
      */
     // [START addShoppingProductAdGroupAd]
     private static function addShoppingProductAdGroupAd(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupResourceName
+        int $customerId,
+        string $adGroupResourceName
     ) {
         // Creates a new shopping product ad.
         $ad = new Ad(['shopping_product_ad' => new ShoppingProductAdInfo()]);
@@ -370,15 +370,15 @@ class AddShoppingProductAd
      * The criterion will contain the bid for a given listing group.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the resource name of ad group that the new listing group
      *     will belong to
      */
     // [START addDefaultShoppingListingGroup]
     private static function addDefaultShoppingListingGroup(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupResourceName
+        int $customerId,
+        string $adGroupResourceName
     ) {
         // Creates a new ad group criterion. This will contain the "default" listing group (All
         // products).

--- a/examples/ShoppingAds/AddShoppingProductListingGroupTree.php
+++ b/examples/ShoppingAds/AddShoppingProductListingGroupTree.php
@@ -121,7 +121,7 @@ class AddShoppingProductListingGroupTree
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
      * @param bool $shouldReplaceExistingTree true if it should replace the existing listing group
      *     tree on the ad group, if it already exists. The example will throw a
@@ -130,9 +130,9 @@ class AddShoppingProductListingGroupTree
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId,
-        $shouldReplaceExistingTree
+        int $customerId,
+        int $adGroupId,
+        bool $shouldReplaceExistingTree
     ) {
         // 1) Optional: Remove the existing listing group tree, if it already exists on the ad
         // group.
@@ -280,14 +280,14 @@ class AddShoppingProductListingGroupTree
      * group.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ID of ad group that the existing listing group tree will be
      *     removed from
      */
     private static function removeListingGroupTree(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $adGroupId
+        int $customerId,
+        int $adGroupId
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves a listing group tree.
@@ -333,7 +333,7 @@ class AddShoppingProductListingGroupTree
      * Creates a new criterion containing a subdivision listing group node. If the parent ad group
      * criterion resource name is not specified, this method creates a root node.
      *
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
      * @param string|null $parentAdGroupCriterionResourceName the resource name of the parent of
      *     this criterion. If null, this method will create a root of the tree
@@ -342,9 +342,9 @@ class AddShoppingProductListingGroupTree
      * @return AdGroupCriterion the ad group criterion that contains the listing group root node
      */
     private static function createListingGroupSubdivision(
-        $customerId,
-        $adGroupId,
-        $parentAdGroupCriterionResourceName = null,
+        int $customerId,
+        int $adGroupId,
+        string $parentAdGroupCriterionResourceName = null,
         ListingDimensionInfo $listingDimensionInfo = null
     ) {
         static $tempId = 0;
@@ -386,7 +386,7 @@ class AddShoppingProductListingGroupTree
     /**
      * Creates a new criterion containing a biddable unit listing group node.
      *
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $adGroupId the ad group ID
      * @param string $parentAdGroupCriterionResourceName the resource name of the parent of this
      *     criterion
@@ -398,11 +398,11 @@ class AddShoppingProductListingGroupTree
      *     group node
      */
     private static function createListingGroupUnitBiddable(
-        $customerId,
-        $adGroupId,
-        $parentAdGroupCriterionResourceName,
+        int $customerId,
+        int $adGroupId,
+        string $parentAdGroupCriterionResourceName,
         ListingDimensionInfo $listingDimensionInfo,
-        $cpcBidMicros
+        int $cpcBidMicros
     ) {
         // Note: There are two approaches for creating new unit nodes:
         // (1) Set the ad group resource name on the criterion (no temporary ID required).

--- a/examples/ShoppingAds/AddShoppingSmartAd.php
+++ b/examples/ShoppingAds/AddShoppingSmartAd.php
@@ -135,7 +135,7 @@ class AddShoppingSmartAd
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param int $merchantCenterAccountId the Merchant Center account ID
      * @param bool $shouldCreateDefaultListingGroup indicates if a default listing
      *     group should be created for the ad group. Set to false if the listing group will be
@@ -182,7 +182,7 @@ class AddShoppingSmartAd
      * Creates a new campaign budget for Smart Shopping ads in the specified client account.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @return string the resource name of the newly created budget
      */
     private static function addCampaignBudget(GoogleAdsClient $googleAdsClient, int $customerId)
@@ -225,7 +225,7 @@ class AddShoppingSmartAd
      * Creates a new shopping campaign for Smart Shopping ads in the specified client account.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $budgetResourceName the resource name of budget for a new campaign
      * @param int $merchantCenterAccountId the Merchant Center account ID
      * @return string the resource name of the newly created campaign
@@ -298,7 +298,7 @@ class AddShoppingSmartAd
      * Creates a new ad group in the specified Smart Shopping campaign.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $campaignResourceName the resource name of the campaign that
      *     the new ad group will belong to
      * @return string the resource name of the newly created ad group
@@ -341,7 +341,7 @@ class AddShoppingSmartAd
      * Creates a new ad group ad in the specified Smart Shopping ad group.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the resource name of the ad group that
      *     the new ad group ad will belong to
      */
@@ -382,7 +382,7 @@ class AddShoppingSmartAd
      * API Shopping guide: https://developers.google.com/google-ads/api/docs/shopping-ads/overview.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID
+     * @param int $customerId the customer ID
      * @param string $adGroupResourceName the resource name of the ad group that
      *     the new listing group will belong to
      */

--- a/examples/Targeting/AddCampaignTargetingCriteria.php
+++ b/examples/Targeting/AddCampaignTargetingCriteria.php
@@ -113,16 +113,16 @@ class AddCampaignTargetingCriteria
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the campaign ID to add a criterion to
      * @param string $keywordText the keyword text to be added as a negative campaign criterion
      * @param int $locationId the location ID to be targeted
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
-        $customerId,
-        $campaignId,
-        $keywordText,
+        int $customerId,
+        int $campaignId,
+        string $keywordText,
         $locationId
     ) {
         $campaignResourceName = ResourceNames::forCampaign($customerId, $campaignId);
@@ -163,7 +163,7 @@ class AddCampaignTargetingCriteria
      * @return CampaignCriterionOperation the created campaign criterion operation
      */
     private static function createNegativeKeywordCampaignCriterionOperation(
-        $keywordText,
+        string $keywordText,
         $campaignResourceName
     ) {
         // Constructs a negative campaign criterion for the specified campaign ID using the
@@ -191,8 +191,8 @@ class AddCampaignTargetingCriteria
      * @return CampaignCriterionOperation the created campaign criterion operation
      */
     private static function createLocationCampaignCriterionOperation(
-        $locationId,
-        $campaignResourceName
+        int $locationId,
+        string $campaignResourceName
     ) {
         // Constructs a campaign criterion for the specified campaign ID using the specified
         // location ID.
@@ -220,7 +220,7 @@ class AddCampaignTargetingCriteria
      *      belongs to
      * @return CampaignCriterionOperation the created campaign criterion operation
      */
-    private static function createProximityCampaignCriterionOperation($campaignResourceName)
+    private static function createProximityCampaignCriterionOperation(string $campaignResourceName)
     {
         // Constructs a campaign criterion as a proximity.
         $campaignCriterion = new CampaignCriterion([

--- a/examples/Targeting/GetCampaignTargetingCriteria.php
+++ b/examples/Targeting/GetCampaignTargetingCriteria.php
@@ -97,11 +97,14 @@ class GetCampaignTargetingCriteria
      * Runs the example.
      *
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
-     * @param int $customerId the client customer ID without hyphens
+     * @param int $customerId the customer ID
      * @param int $campaignId the campaign ID for which campaign criteria will be retrieved
      */
-    public static function runExample(GoogleAdsClient $googleAdsClient, $customerId, $campaignId)
-    {
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $campaignId
+    ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
         // Creates a query that retrieves campaign criteria.
         $query = 'SELECT campaign.id, campaign_criterion.campaign, '

--- a/examples/Targeting/GetGeoTargetConstantByNames.php
+++ b/examples/Targeting/GetGeoTargetConstantByNames.php
@@ -112,8 +112,8 @@ class GetGeoTargetConstantByNames
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
         array $locationNames,
-        $locale,
-        $countryCode
+        string $locale,
+        string $countryCode
     ) {
         $geoTargetConstantServiceClient = $googleAdsClient->getGeoTargetConstantServiceClient();
 

--- a/src/Google/Ads/GoogleAds/Util/V1/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V1/ResourceNames.php
@@ -1364,7 +1364,7 @@ final class ResourceNames
      * Generates resource name for a recommendation.
      *
      * @param int $customerId the customer ID
-     * @param int $recommendationId the recommendation ID
+     * @param string $recommendationId the recommendation ID
      * @return string the recommendation resource name
      */
     public static function forRecommendation($customerId, $recommendationId)

--- a/src/Google/Ads/GoogleAds/Util/V2/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V2/ResourceNames.php
@@ -1364,7 +1364,7 @@ final class ResourceNames
      * Generates resource name for a recommendation.
      *
      * @param int $customerId the customer ID
-     * @param int $recommendationId the recommendation ID
+     * @param string $recommendationId the recommendation ID
      * @return string the recommendation resource name
      */
     public static function forRecommendation($customerId, $recommendationId)


### PR DESCRIPTION
- "client customer ID" is replaced with just "customer ID", which is the often used word in Google Ads API. "without hyphens" is also stripped because I made all of them of type hint "int" 
- Also fixed some minor issues in the example files.
- Recommendation ID is technically a string by design, so I leave it as is.