### PR TITLE
Add init google ads failures in client

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClient.php
@@ -17,6 +17,9 @@
 
 namespace Google\Ads\GoogleAds\Lib\V1;
 
+use Google\Ads\GoogleAds\V1\Errors\GoogleAdsFailure;
+use Google\Protobuf\DescriptorPool;
+
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
  */
@@ -42,5 +45,13 @@ final class GoogleAdsClient
         $this->logger = $builder->getLogger();
         $this->logLevel = $builder->getLogLevel();
         $this->proxy = $builder->getProxy();
+
+        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
+        // class and prevent exceptions from being thrown.
+        if (is_null(
+            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
+        )) {
+            new GoogleAdsFailure();
+        }
     }
 }

--- a/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V1/GoogleAdsClient.php
@@ -17,8 +17,7 @@
 
 namespace Google\Ads\GoogleAds\Lib\V1;
 
-use Google\Ads\GoogleAds\V1\Errors\GoogleAdsFailure;
-use Google\Protobuf\DescriptorPool;
+use Google\Ads\GoogleAds\Util\V1\GoogleAdsFailures;
 
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
@@ -46,12 +45,6 @@ final class GoogleAdsClient
         $this->logLevel = $builder->getLogLevel();
         $this->proxy = $builder->getProxy();
 
-        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
-        // class and prevent exceptions from being thrown.
-        if (is_null(
-            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
-        )) {
-            new GoogleAdsFailure();
-        }
+        GoogleAdsFailures::init();
     }
 }

--- a/src/Google/Ads/GoogleAds/Lib/V2/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V2/GoogleAdsClient.php
@@ -17,8 +17,7 @@
 
 namespace Google\Ads\GoogleAds\Lib\V2;
 
-use Google\Ads\GoogleAds\V2\Errors\GoogleAdsFailure;
-use Google\Protobuf\DescriptorPool;
+use Google\Ads\GoogleAds\Util\V2\GoogleAdsFailures;
 
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
@@ -46,12 +45,6 @@ final class GoogleAdsClient
         $this->logLevel = $builder->getLogLevel();
         $this->proxy = $builder->getProxy();
 
-        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
-        // class and prevent exceptions from being thrown.
-        if (is_null(
-            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
-        )) {
-            new GoogleAdsFailure();
-        }
+        GoogleAdsFailures::init();
     }
 }

--- a/src/Google/Ads/GoogleAds/Lib/V2/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V2/GoogleAdsClient.php
@@ -17,6 +17,9 @@
 
 namespace Google\Ads\GoogleAds\Lib\V2;
 
+use Google\Ads\GoogleAds\V2\Errors\GoogleAdsFailure;
+use Google\Protobuf\DescriptorPool;
+
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
  */
@@ -42,5 +45,13 @@ final class GoogleAdsClient
         $this->logger = $builder->getLogger();
         $this->logLevel = $builder->getLogLevel();
         $this->proxy = $builder->getProxy();
+
+        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
+        // class and prevent exceptions from being thrown.
+        if (is_null(
+            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
+        )) {
+            new GoogleAdsFailure();
+        }
     }
 }

--- a/src/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailures.php
+++ b/src/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailures.php
@@ -57,7 +57,7 @@ final class GoogleAdsFailures
     }
 
     /**
-     * Initialize the class
+     * Initializes
      */
     public static function init() {
         // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure

--- a/src/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailures.php
+++ b/src/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailures.php
@@ -59,7 +59,8 @@ final class GoogleAdsFailures
     /**
      * Initializes
      */
-    public static function init() {
+    public static function init()
+    {
         // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
         // class and prevent exceptions from being thrown.
         if (is_null(

--- a/src/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailures.php
+++ b/src/Google/Ads/GoogleAds/Util/V1/GoogleAdsFailures.php
@@ -32,14 +32,7 @@ final class GoogleAdsFailures
      */
     public static function fromAny(Any $any)
     {
-        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
-        // class and prevent exceptions from being thrown.
-        if (is_null(
-            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
-        )) {
-            new GoogleAdsFailure();
-        }
-
+        self::init();
         $ret = $any->unpack();
         if (!$ret instanceof GoogleAdsFailure) {
             throw new \InvalidArgumentException("Message did not contain a GoogleAdsFailure");
@@ -61,5 +54,18 @@ final class GoogleAdsFailures
             $result[] = GoogleAdsFailures::fromAny($any);
         }
         return $result;
+    }
+
+    /**
+     * Initialize the class
+     */
+    public static function init() {
+        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
+        // class and prevent exceptions from being thrown.
+        if (is_null(
+            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
+        )) {
+            new GoogleAdsFailure();
+        }
     }
 }

--- a/src/Google/Ads/GoogleAds/Util/V2/GoogleAdsFailures.php
+++ b/src/Google/Ads/GoogleAds/Util/V2/GoogleAdsFailures.php
@@ -57,7 +57,7 @@ final class GoogleAdsFailures
     }
 
     /**
-     * Initialize the class
+     * Initializes
      */
     public static function init() {
         // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure

--- a/src/Google/Ads/GoogleAds/Util/V2/GoogleAdsFailures.php
+++ b/src/Google/Ads/GoogleAds/Util/V2/GoogleAdsFailures.php
@@ -59,7 +59,8 @@ final class GoogleAdsFailures
     /**
      * Initializes
      */
-    public static function init() {
+    public static function init()
+    {
         // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
         // class and prevent exceptions from being thrown.
         if (is_null(

--- a/src/Google/Ads/GoogleAds/Util/V2/GoogleAdsFailures.php
+++ b/src/Google/Ads/GoogleAds/Util/V2/GoogleAdsFailures.php
@@ -32,14 +32,7 @@ final class GoogleAdsFailures
      */
     public static function fromAny(Any $any)
     {
-        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
-        // class and prevent exceptions from being thrown.
-        if (is_null(
-            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
-        )) {
-            new GoogleAdsFailure();
-        }
-
+        self::init();
         $ret = $any->unpack();
         if (!$ret instanceof GoogleAdsFailure) {
             throw new \InvalidArgumentException("Message did not contain a GoogleAdsFailure");
@@ -61,5 +54,18 @@ final class GoogleAdsFailures
             $result[] = GoogleAdsFailures::fromAny($any);
         }
         return $result;
+    }
+
+    /**
+     * Initialize the class
+     */
+    public static function init() {
+        // This initialization is needed to populate the descriptor pool with the GoogleAdsFailure
+        // class and prevent exceptions from being thrown.
+        if (is_null(
+            DescriptorPool::getGeneratedPool()->getDescriptorByClassName(GoogleAdsFailure::class)
+        )) {
+            new GoogleAdsFailure();
+        }
     }
 }


### PR DESCRIPTION
Fixes #210 which is the same as #154 but in the specific context of REST transport.

#154 was considered fixed with #155 and #156 but it turns out it only covered the specific case of the gRPC transport. In the specific case of REST transport, the JSON response is decoded in a different way making a [direct call](https://github.com/protocolbuffers/protobuf/blob/master/php/src/Google/Protobuf/Internal/Message.php#L1080) to the `unpack` method of `Any`. This fix now also initializes in the `GoogleAdsClient` constructor, the most generic location of the client library.