### PR TITLE
Added examples of updating and removing flights feed item string attribute values

### DIFF
--- a/examples/Remarketing/RemoveFlightsFeedItemStringAttributeValue.php
+++ b/examples/Remarketing/RemoveFlightsFeedItemStringAttributeValue.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\Remarketing;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Examples\Utils\Feeds;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\Lib\V2\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V2\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V2\GoogleAdsException;
+use Google\Ads\GoogleAds\Util\FieldMasks;
+use Google\Ads\GoogleAds\Util\V2\ResourceNames;
+use Google\Ads\GoogleAds\V2\Enums\FlightPlaceholderFieldEnum\FlightPlaceholderField;
+use Google\Ads\GoogleAds\V2\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V2\Resources\FeedItemAttributeValue;
+use Google\Ads\GoogleAds\V2\Services\FeedItemOperation;
+use Google\ApiCore\ApiException;
+use Google\Protobuf\Int64Value;
+
+/**
+ * Removes a feed item attribute value of a feed item in a flights feed. To create a flights feed,
+ * run the AddFlightsFeed example. This example is specific to feeds of type DYNAMIC_FLIGHT.
+ * The attribute you are removing must be present on the feed.
+ */
+class RemoveFlightsFeedItemStringAttributeValue
+{
+    const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+    const FEED_ID = 'INSERT_FEED_ID_HERE';
+    const FEED_ITEM_ID = 'INSERT_FEED_ITEM_ID_HERE';
+    const FLIGHT_PLACEHOLDER_FIELD_NAME = 'INSERT_FLIGHT_PLACEHOLDER_FIELD_NAME_HERE';
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FEED_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FEED_ITEM_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME => GetOpt::REQUIRED_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())
+            ->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
+                $options[ArgumentNames::FEED_ID] ?: self::FEED_ID,
+                $options[ArgumentNames::FEED_ITEM_ID] ?: self::FEED_ITEM_ID,
+                $options[ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME]
+                    ?: self::FLIGHT_PLACEHOLDER_FIELD_NAME
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     * @param int $feedId the ID of feed containing the feed item to be updated
+     * @param int $feedItemId ID of the feed item to be updated
+     * @param string $flightPlaceholderFieldName the flight placeholder field name for the attribute
+     *     to be removed
+     */
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $feedId,
+        int $feedItemId,
+        string $flightPlaceholderFieldName
+    ) {
+        // Gets a map of the placeholder values to feed attributes.
+        $placeHoldersToFeedAttributesMap = Feeds::flightPlaceholderFieldsMapFor(
+            ResourceNames::forFeed($customerId, $feedId),
+            $customerId,
+            $googleAdsClient
+        );
+        // Gets the ID of the feed attribute for the placeholder field.
+        $attributeId = $placeHoldersToFeedAttributesMap[
+            FlightPlaceholderField::value($flightPlaceholderFieldName)]->getIdUnwrapped();
+        // Creates the feed item attribute value that will be removed.
+        $removedFeedItemAttributeValue = new FeedItemAttributeValue([
+            'feed_attribute_id' => new Int64Value(['value' => $attributeId])
+        ]);
+
+        // Retrieves the feed item and its associated attributes based on the resource name.
+        $feedItem = Feeds::feedItemFor(
+            ResourceNames::forFeedItem($customerId, $feedId, $feedItemId),
+            $customerId,
+            $googleAdsClient
+        );
+        // Gets the index of the attribute value that will be removed in the feed item.
+        $attributeIndex = Feeds::attributeIndexFor($removedFeedItemAttributeValue, $feedItem);
+        // Any feed item attribute values that are not included in the feed item will be removed,
+        // which is why you must retain all other feed attribute values here.
+        $feedItemAttributeValues = array_filter(
+            iterator_to_array($feedItem->getAttributeValues()->getIterator()),
+            function ($index) use ($attributeIndex) {
+                return $index !== $attributeIndex;
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+        $feedItem->setAttributeValues($feedItemAttributeValues);
+
+        // Creates the feed item operation.
+        $operation = new FeedItemOperation();
+        $operation->setUpdate($feedItem);
+        $operation->setUpdateMask(FieldMasks::allSetFieldsOf($feedItem));
+
+        // Issues a mutate request to update the feed item and print some information.
+        $feedItemServiceClient = $googleAdsClient->getFeedItemServiceClient();
+        $response = $feedItemServiceClient->mutateFeedItems($customerId, [$operation]);
+        printf(
+            "Feed item with resource name '%s' was updated to remove the value of"
+            . " placeholder field type '%s'.%s",
+            $response->getResults()[0]->getResourceName(),
+            $flightPlaceholderFieldName,
+            PHP_EOL
+        );
+    }
+}
+
+RemoveFlightsFeedItemStringAttributeValue::main();

--- a/examples/Remarketing/RemoveFlightsFeedItemStringAttributeValue.php
+++ b/examples/Remarketing/RemoveFlightsFeedItemStringAttributeValue.php
@@ -129,7 +129,8 @@ class RemoveFlightsFeedItemStringAttributeValue
         // Gets the ID of the feed attribute for the placeholder field.
         $attributeId = $placeHoldersToFeedAttributesMap[
             FlightPlaceholderField::value($flightPlaceholderFieldName)]->getIdUnwrapped();
-        // Creates the feed item attribute value that will be removed.
+        // Creates the feed item attribute value that will be removed, so only the feed attribute ID
+        // is needed.
         $removedFeedItemAttributeValue = new FeedItemAttributeValue([
             'feed_attribute_id' => new Int64Value(['value' => $attributeId])
         ]);

--- a/examples/Remarketing/RemoveFlightsFeedItemStringAttributeValue.php
+++ b/examples/Remarketing/RemoveFlightsFeedItemStringAttributeValue.php
@@ -56,7 +56,7 @@ class RemoveFlightsFeedItemStringAttributeValue
             ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
             ArgumentNames::FEED_ID => GetOpt::REQUIRED_ARGUMENT,
             ArgumentNames::FEED_ITEM_ID => GetOpt::REQUIRED_ARGUMENT,
-            ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME => GetOpt::REQUIRED_ARGUMENT
+            ArgumentNames::FEED_PLACEHOLDER_FIELD_NAME => GetOpt::REQUIRED_ARGUMENT
         ]);
 
         // Generate a refreshable OAuth2 credential for authentication.
@@ -75,7 +75,7 @@ class RemoveFlightsFeedItemStringAttributeValue
                 $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
                 $options[ArgumentNames::FEED_ID] ?: self::FEED_ID,
                 $options[ArgumentNames::FEED_ITEM_ID] ?: self::FEED_ITEM_ID,
-                $options[ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME]
+                $options[ArgumentNames::FEED_PLACEHOLDER_FIELD_NAME]
                     ?: self::FLIGHT_PLACEHOLDER_FIELD_NAME
             );
         } catch (GoogleAdsException $googleAdsException) {

--- a/examples/Remarketing/UpdateFlightsFeedItemStringAttributeValue.php
+++ b/examples/Remarketing/UpdateFlightsFeedItemStringAttributeValue.php
@@ -49,7 +49,7 @@ class UpdateFlightsFeedItemStringAttributeValue
     const FEED_ID = 'INSERT_FEED_ID_HERE';
     const FEED_ITEM_ID = 'INSERT_FEED_ITEM_ID_HERE';
     const FLIGHT_PLACEHOLDER_FIELD_NAME = 'INSERT_FLIGHT_PLACEHOLDER_FIELD_NAME_HERE';
-    const ATTRIBUTE_VALUE = 'INSERT_ATTRIBUTE_VALUE_HERE';
+    const FEED_ITEM_ATTRIBUTE_VALUE = 'INSERT_ATTRIBUTE_VALUE_HERE';
     const PAGE_SIZE = 1000;
 
     public static function main()
@@ -61,7 +61,7 @@ class UpdateFlightsFeedItemStringAttributeValue
             ArgumentNames::FEED_ID => GetOpt::REQUIRED_ARGUMENT,
             ArgumentNames::FEED_ITEM_ID => GetOpt::REQUIRED_ARGUMENT,
             ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME => GetOpt::REQUIRED_ARGUMENT,
-            ArgumentNames::ATTRIBUTE_VALUE => GetOpt::REQUIRED_ARGUMENT
+            ArgumentNames::FEED_ITEM_ATTRIBUTE_VALUE => GetOpt::REQUIRED_ARGUMENT
         ]);
 
         // Generate a refreshable OAuth2 credential for authentication.
@@ -82,7 +82,8 @@ class UpdateFlightsFeedItemStringAttributeValue
                 $options[ArgumentNames::FEED_ITEM_ID] ?: self::FEED_ITEM_ID,
                 $options[ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME]
                     ?: self::FLIGHT_PLACEHOLDER_FIELD_NAME,
-                $options[ArgumentNames::ATTRIBUTE_VALUE] ?: self::ATTRIBUTE_VALUE
+                $options[ArgumentNames::FEED_ITEM_ATTRIBUTE_VALUE]
+                    ?: self::FEED_ITEM_ATTRIBUTE_VALUE
             );
         } catch (GoogleAdsException $googleAdsException) {
             printf(

--- a/examples/Remarketing/UpdateFlightsFeedItemStringAttributeValue.php
+++ b/examples/Remarketing/UpdateFlightsFeedItemStringAttributeValue.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\Remarketing;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Examples\Utils\Feeds;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\Lib\V2\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V2\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V2\GoogleAdsException;
+use Google\Ads\GoogleAds\Util\FieldMasks;
+use Google\Ads\GoogleAds\Util\V2\ResourceNames;
+use Google\Ads\GoogleAds\V2\Enums\FlightPlaceholderFieldEnum\FlightPlaceholderField;
+use Google\Ads\GoogleAds\V2\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V2\Resources\FeedItemAttributeValue;
+use Google\Ads\GoogleAds\V2\Services\FeedItemOperation;
+use Google\ApiCore\ApiException;
+use Google\Protobuf\Int64Value;
+use Google\Protobuf\StringValue;
+
+/**
+ * Updates a feed item attribute value in a flights feed. To create a flights feed,
+ * run the AddFlightsFeed example. This example is specific to feeds of type DYNAMIC_FLIGHT.
+ * The attribute you are updating must be present on the feed. This example is
+ * specifically for updating the StringValue of an attribute.
+ */
+class UpdateFlightsFeedItemStringAttributeValue
+{
+    const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+    const FEED_ID = 'INSERT_FEED_ID_HERE';
+    const FEED_ITEM_ID = 'INSERT_FEED_ITEM_ID_HERE';
+    const FLIGHT_PLACEHOLDER_FIELD_NAME = 'INSERT_FLIGHT_PLACEHOLDER_FIELD_NAME_HERE';
+    const ATTRIBUTE_VALUE = 'INSERT_ATTRIBUTE_VALUE_HERE';
+    const PAGE_SIZE = 1000;
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FEED_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FEED_ITEM_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::ATTRIBUTE_VALUE => GetOpt::REQUIRED_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())
+            ->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
+                $options[ArgumentNames::FEED_ID] ?: self::FEED_ID,
+                $options[ArgumentNames::FEED_ITEM_ID] ?: self::FEED_ITEM_ID,
+                $options[ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME]
+                    ?: self::FLIGHT_PLACEHOLDER_FIELD_NAME,
+                $options[ArgumentNames::ATTRIBUTE_VALUE] ?: self::ATTRIBUTE_VALUE
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     * @param int $feedId the ID of feed containing the feed item to be updated
+     * @param int $feedItemId ID of the feed item to be updated
+     * @param string $flightPlaceholderFieldName the flight placeholder field name for the attribute
+     *     to be updated
+     * @param string $attributeValue the new value to set the feed attribute to
+     */
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $feedId,
+        int $feedItemId,
+        string $flightPlaceholderFieldName,
+        string $attributeValue
+    ) {
+        // Gets a map of the placeholder values to feed attributes.
+        $placeHoldersToFeedAttributesMap = Feeds::flightPlaceholderFieldsMapFor(
+            ResourceNames::forFeed($customerId, $feedId),
+            $customerId,
+            $googleAdsClient
+        );
+        // Gets the ID of the feed attribute for the placeholder field. This is needed to specify
+        // which feed item attribute value will be updated in the given feed item.
+        $attributeId = $placeHoldersToFeedAttributesMap[
+            FlightPlaceholderField::value($flightPlaceholderFieldName)]->getIdUnwrapped();
+        // Creates the updated feed item attribute value.
+        $updatedFeedItemAttributeValue = new FeedItemAttributeValue([
+            'feed_attribute_id' => new Int64Value(['value' => $attributeId]),
+            'string_value' => new StringValue(['value' => $attributeValue])
+        ]);
+
+        // Retrieves the feed item and its associated attributes based on the resource name.
+        $feedItem = Feeds::feedItemFor(
+            ResourceNames::forFeedItem($customerId, $feedId, $feedItemId),
+            $customerId,
+            $googleAdsClient
+        );
+        // Gets the index of the attribute value that will be updated in the feed item.
+        $attributeIndex = Feeds::attributeIndexFor($updatedFeedItemAttributeValue, $feedItem);
+        // Any feed item attribute values that are not included in the updated feed item will be
+        // removed from the feed item, which is why you must create the feed item from the existing
+        // feed item and its attribute values. Then, update only the field that you want.
+        $feedItemAttributeValues = $feedItem->getAttributeValues();
+        $feedItemAttributeValues[$attributeIndex] = $updatedFeedItemAttributeValue;
+        $feedItem->setAttributeValues($feedItemAttributeValues);
+
+        // Creates the feed item operation.
+        $operation = new FeedItemOperation();
+        $operation->setUpdate($feedItem);
+        $operation->setUpdateMask(FieldMasks::allSetFieldsOf($feedItem));
+
+        // Issues a mutate request to update the feed item and print some information.
+        $feedItemServiceClient = $googleAdsClient->getFeedItemServiceClient();
+        $response = $feedItemServiceClient->mutateFeedItems($customerId, [$operation]);
+        printf(
+            "Feed item with resource name '%s' was updated.%s",
+            $response->getResults()[0]->getResourceName(),
+            PHP_EOL
+        );
+    }
+}
+
+UpdateFlightsFeedItemStringAttributeValue::main();

--- a/examples/Remarketing/UpdateFlightsFeedItemStringAttributeValue.php
+++ b/examples/Remarketing/UpdateFlightsFeedItemStringAttributeValue.php
@@ -60,7 +60,7 @@ class UpdateFlightsFeedItemStringAttributeValue
             ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
             ArgumentNames::FEED_ID => GetOpt::REQUIRED_ARGUMENT,
             ArgumentNames::FEED_ITEM_ID => GetOpt::REQUIRED_ARGUMENT,
-            ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FEED_PLACEHOLDER_FIELD_NAME => GetOpt::REQUIRED_ARGUMENT,
             ArgumentNames::FEED_ITEM_ATTRIBUTE_VALUE => GetOpt::REQUIRED_ARGUMENT
         ]);
 
@@ -80,7 +80,7 @@ class UpdateFlightsFeedItemStringAttributeValue
                 $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
                 $options[ArgumentNames::FEED_ID] ?: self::FEED_ID,
                 $options[ArgumentNames::FEED_ITEM_ID] ?: self::FEED_ITEM_ID,
-                $options[ArgumentNames::FLIGHT_PLACEHOLDER_FIELD_NAME]
+                $options[ArgumentNames::FEED_PLACEHOLDER_FIELD_NAME]
                     ?: self::FLIGHT_PLACEHOLDER_FIELD_NAME,
                 $options[ArgumentNames::FEED_ITEM_ATTRIBUTE_VALUE]
                     ?: self::FEED_ITEM_ATTRIBUTE_VALUE
@@ -155,7 +155,7 @@ class UpdateFlightsFeedItemStringAttributeValue
         $attributeIndex = Feeds::attributeIndexFor($updatedFeedItemAttributeValue, $feedItem);
         // Any feed item attribute values that are not included in the updated feed item will be
         // removed from the feed item, which is why you must create the feed item from the existing
-        // feed item and its attribute values. Then, update only the field that you want.
+        // feed item and its attribute values. Then, update only the attribute that you want.
         $feedItemAttributeValues = $feedItem->getAttributeValues();
         $feedItemAttributeValues[$attributeIndex] = $updatedFeedItemAttributeValue;
         $feedItem->setAttributeValues($feedItemAttributeValues);

--- a/examples/Utils/ArgumentNames.php
+++ b/examples/Utils/ArgumentNames.php
@@ -44,7 +44,7 @@ final class ArgumentNames
     const DRAFT_ID = 'draftId';
     const FEED_ID = 'feedId';
     const FEED_ITEM_ID = 'feedItemId';
-    const FLIGHT_PLACEHOLDER_FIELD_NAME = 'flightPlaceholderFieldName';
+    const FEED_PLACEHOLDER_FIELD_NAME = 'flightPlaceholderFieldName';
     const GMB_ACCESS_TOKEN = 'gmbAccessToken';
     const GMB_EMAIL_ADDRESS = 'gmbEmailAddress';
     const HOTEL_CENTER_ACCOUNT_ID = 'hotelCenterAccountId';
@@ -88,7 +88,7 @@ final class ArgumentNames
         self::DRAFT_ID => 'The draft ID',
         self::FEED_ID => 'The feed ID',
         self::FEED_ITEM_ID => 'The feed item ID',
-        self::FLIGHT_PLACEHOLDER_FIELD_NAME => 'The flight placeholder field name',
+        self::FEED_PLACEHOLDER_FIELD_NAME => 'The flight placeholder field name',
         self::GMB_ACCESS_TOKEN => 'The access token used for uploading GMB location feed data',
         self::GMB_EMAIL_ADDRESS => 'The email address associated with the GMB account',
         self::HOTEL_CENTER_ACCOUNT_ID => 'The hotel center account ID',

--- a/examples/Utils/ArgumentNames.php
+++ b/examples/Utils/ArgumentNames.php
@@ -26,6 +26,7 @@ final class ArgumentNames
     const AD_GROUP_ID = 'adGroupId';
     const AD_GROUP_IDS = 'adGroupIds';
     const ARTIFACT_NAME = 'artifactName';
+    const ATTRIBUTE_VALUE = 'attributeValue';
     const BASE_CAMPAIGN_ID = 'baseCampaignId';
     const BID_MODIFIER_VALUE = 'bidModifierValue';
     const BILLING_SETUP_ID = 'billingSetupId';
@@ -41,6 +42,9 @@ final class ArgumentNames
     const CRITERION_ID = 'criterionId';
     const CUSTOMER_ID = 'customerId';
     const DRAFT_ID = 'draftId';
+    const FEED_ID = 'feedId';
+    const FEED_ITEM_ID = 'feedItemId';
+    const FLIGHT_PLACEHOLDER_FIELD_NAME = 'flightPlaceholderField';
     const GMB_ACCESS_TOKEN = 'gmbAccessToken';
     const GMB_EMAIL_ADDRESS = 'gmbEmailAddress';
     const HOTEL_CENTER_ACCOUNT_ID = 'hotelCenterAccountId';
@@ -66,6 +70,7 @@ final class ArgumentNames
         self::AD_GROUP_ID => 'The ad group ID',
         self::AD_GROUP_IDS => 'The ad group IDs',
         self::ARTIFACT_NAME => 'The artifact name',
+        self::ATTRIBUTE_VALUE => 'The attribute value of the feed item',
         self::BASE_CAMPAIGN_ID => 'The base campaign ID',
         self::BID_MODIFIER_VALUE => 'The bid modifier value',
         self::BILLING_SETUP_ID => 'The billing setup ID',
@@ -81,6 +86,9 @@ final class ArgumentNames
         self::CRITERION_ID => 'The criterion ID',
         self::CUSTOMER_ID => 'The customer ID without dashes',
         self::DRAFT_ID => 'The draft ID',
+        self::FEED_ID => 'The feed ID',
+        self::FEED_ITEM_ID => 'The feed item ID',
+        self::FLIGHT_PLACEHOLDER_FIELD_NAME => 'The flight placeholder field',
         self::GMB_ACCESS_TOKEN => 'The access token used for uploading GMB location feed data',
         self::GMB_EMAIL_ADDRESS => 'The email address associated with the GMB account',
         self::HOTEL_CENTER_ACCOUNT_ID => 'The hotel center account ID',

--- a/examples/Utils/ArgumentNames.php
+++ b/examples/Utils/ArgumentNames.php
@@ -26,7 +26,7 @@ final class ArgumentNames
     const AD_GROUP_ID = 'adGroupId';
     const AD_GROUP_IDS = 'adGroupIds';
     const ARTIFACT_NAME = 'artifactName';
-    const ATTRIBUTE_VALUE = 'attributeValue';
+    const FEED_ITEM_ATTRIBUTE_VALUE = 'feedItemAttributeValue';
     const BASE_CAMPAIGN_ID = 'baseCampaignId';
     const BID_MODIFIER_VALUE = 'bidModifierValue';
     const BILLING_SETUP_ID = 'billingSetupId';
@@ -44,7 +44,7 @@ final class ArgumentNames
     const DRAFT_ID = 'draftId';
     const FEED_ID = 'feedId';
     const FEED_ITEM_ID = 'feedItemId';
-    const FLIGHT_PLACEHOLDER_FIELD_NAME = 'flightPlaceholderField';
+    const FLIGHT_PLACEHOLDER_FIELD_NAME = 'flightPlaceholderFieldName';
     const GMB_ACCESS_TOKEN = 'gmbAccessToken';
     const GMB_EMAIL_ADDRESS = 'gmbEmailAddress';
     const HOTEL_CENTER_ACCOUNT_ID = 'hotelCenterAccountId';
@@ -70,7 +70,7 @@ final class ArgumentNames
         self::AD_GROUP_ID => 'The ad group ID',
         self::AD_GROUP_IDS => 'The ad group IDs',
         self::ARTIFACT_NAME => 'The artifact name',
-        self::ATTRIBUTE_VALUE => 'The attribute value of the feed item',
+        self::FEED_ITEM_ATTRIBUTE_VALUE => 'The attribute value of the feed item',
         self::BASE_CAMPAIGN_ID => 'The base campaign ID',
         self::BID_MODIFIER_VALUE => 'The bid modifier value',
         self::BILLING_SETUP_ID => 'The billing setup ID',
@@ -88,7 +88,7 @@ final class ArgumentNames
         self::DRAFT_ID => 'The draft ID',
         self::FEED_ID => 'The feed ID',
         self::FEED_ITEM_ID => 'The feed item ID',
-        self::FLIGHT_PLACEHOLDER_FIELD_NAME => 'The flight placeholder field',
+        self::FLIGHT_PLACEHOLDER_FIELD_NAME => 'The flight placeholder field name',
         self::GMB_ACCESS_TOKEN => 'The access token used for uploading GMB location feed data',
         self::GMB_EMAIL_ADDRESS => 'The email address associated with the GMB account',
         self::HOTEL_CENTER_ACCOUNT_ID => 'The hotel center account ID',

--- a/examples/Utils/Feeds.php
+++ b/examples/Utils/Feeds.php
@@ -24,6 +24,9 @@ use Google\Ads\GoogleAds\V2\Resources\FeedItem;
 use Google\Ads\GoogleAds\V2\Resources\FeedItemAttributeValue;
 use Google\Ads\GoogleAds\V2\Services\GoogleAdsRow;
 
+/**
+ * Utilities that are shared between code examples related to feeds.
+ */
 final class Feeds
 {
     const PAGE_SIZE = 1000;
@@ -91,7 +94,7 @@ final class Feeds
     }
 
     /**
-     * Retrieves the place holder fields to field attributes map for a flights feed.
+     * Retrieves the place holder fields to feed attributes map for a flights feed.
      *
      * @see Feeds::placeholderFieldsMapFor()
      *
@@ -135,12 +138,11 @@ final class Feeds
     }
 
     /**
-     * Retrieves the place holder fields to field attributes map for a feed. The initial
+     * Retrieves the place holder fields to feed attributes map for a feed. The initial
      * query retrieves the feed attributes, or columns, of the feed. Each feed attribute will also
      * include the feed attribute ID, which will be used in a subsequent step.
      *
-     * The example then inserts a new key-value pair into a map for each
-     * feed attribute, which is the return value of the method:
+     * Then a map is created for the feed attributes (columns) and returned:
      * - The keys are the placeholder types that the columns will be.
      * - The values are the feed attributes.
      *
@@ -172,7 +174,6 @@ final class Feeds
         // values of each corresponding ID.
         $feedAttributes =
             iterator_to_array($googleAdsRow->getFeed()->getAttributes()->getIterator());
-
         return array_combine(array_map($mappingFunction, $feedAttributes), $feedAttributes);
     }
 }

--- a/examples/Utils/Feeds.php
+++ b/examples/Utils/Feeds.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\Utils;
+
+use Google\Ads\GoogleAds\Lib\V2\GoogleAdsClient;
+use Google\Ads\GoogleAds\V2\Enums\FlightPlaceholderFieldEnum\FlightPlaceholderField;
+use Google\Ads\GoogleAds\V2\Resources\FeedAttribute;
+use Google\Ads\GoogleAds\V2\Resources\FeedItem;
+use Google\Ads\GoogleAds\V2\Resources\FeedItemAttributeValue;
+use Google\Ads\GoogleAds\V2\Services\GoogleAdsRow;
+
+final class Feeds
+{
+    const PAGE_SIZE = 1000;
+
+    /**
+     * Retrieves a feed item and its attribute values given a resource name.
+     *
+     * @param string $feedItemResourceName the feed item resource name
+     * @param int $customerId the customer ID
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @return FeedItem the feed item
+     */
+    public static function feedItemFor(
+        string $feedItemResourceName,
+        int $customerId,
+        GoogleAdsClient $googleAdsClient
+    ) {
+        $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
+        // Constructs the query to get the feed item with attribute values.
+        $query = "SELECT feed_item.attribute_values FROM feed_item"
+            . " WHERE feed_item.resource_name = '$feedItemResourceName'";
+        // Issues a search request by specifying page size.
+        $response =
+            $googleAdsServiceClient->search($customerId, $query, ['pageSize' => self::PAGE_SIZE]);
+
+        // Returns the feed item attribute values, which belongs to the first item. We can ensure
+        // it belongs to the first one because we specified the feed item resource name in the
+        // query.
+        return $response->getIterator()->current()->getFeedItem();
+    }
+
+    /**
+     * Gets the index of the target feed item attribute value. This is needed to specify which feed
+     * item attribute value will be updated in the given feed item.
+     *
+     * @param FeedItemAttributeValue $targetFeedItemAttributeValue the new feed item attribute value
+     *     that will be updated
+     * @param FeedItem $feedItem the feed item that will be updated
+     */
+    public static function attributeIndexFor(
+        FeedItemAttributeValue $targetFeedItemAttributeValue,
+        FeedItem $feedItem
+    ) {
+        $attributeIndex = -1;
+        // Loops through attribute values to find the index of the feed item attribute value to
+        // update.
+        foreach ($feedItem->getAttributeValues() as $feedItemAttributeValue) {
+            /** @var FeedItemAttributeValue $feedItemAttributeValue */
+            $attributeIndex++;
+            // Checks if the current feedItemAttributeValue is the one we are updating
+            if ($feedItemAttributeValue->getFeedAttributeIdUnwrapped()
+                === $targetFeedItemAttributeValue->getFeedAttributeIdUnwrapped()) {
+                break;
+            }
+        }
+
+        if ($attributeIndex === -1) {
+            throw new \InvalidArgumentException(
+                'No matching feed attribute for feed item attribute ID: '
+                . $targetFeedItemAttributeValue->getFeedAttributeIdUnwrapped()
+            );
+        }
+
+        return $attributeIndex;
+    }
+
+    /**
+     * Retrieves the place holder fields to field attributes map for a flights feed.
+     *
+     * @see Feeds::placeholderFieldsMapFor()
+     *
+     * @param string $feedResourceName the feed resource name to get the attributes from
+     * @param int $customerId the customer ID
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @return array the map from placeholder fields to feed attributes
+     */
+    public static function flightPlaceholderFieldsMapFor(
+        string $feedResourceName,
+        int $customerId,
+        GoogleAdsClient $googleAdsClient
+    ) {
+        return self::placeholderFieldsMapFor(
+            $feedResourceName,
+            $customerId,
+            $googleAdsClient,
+            function (FeedAttribute $feedAttribute) {
+                switch ($feedAttribute->getNameUnwrapped()) {
+                    case 'Flight Description':
+                        return FlightPlaceholderField::FLIGHT_DESCRIPTION;
+                        break;
+                    case 'Destination ID':
+                        return FlightPlaceholderField::DESTINATION_ID;
+                        break;
+                    case 'Flight Price':
+                        return FlightPlaceholderField::FLIGHT_PRICE;
+                        break;
+                    case 'Flight Sale Price':
+                        return FlightPlaceholderField::FLIGHT_SALE_PRICE;
+                        break;
+                    case 'Final URLs':
+                        return FlightPlaceholderField::FINAL_URLS;
+                        break;
+                    // See FlightPlaceholderField.php for all available values.
+                    default:
+                        throw new \RuntimeException('Invalid feed attribute name.');
+                }
+            }
+        );
+    }
+
+    /**
+     * Retrieves the place holder fields to field attributes map for a feed. The initial
+     * query retrieves the feed attributes, or columns, of the feed. Each feed attribute will also
+     * include the feed attribute ID, which will be used in a subsequent step.
+     *
+     * The example then inserts a new key-value pair into a map for each
+     * feed attribute, which is the return value of the method:
+     * - The keys are the placeholder types that the columns will be.
+     * - The values are the feed attributes.
+     *
+     * @param string $feedResourceName the feed resource name to get the attributes from
+     * @param int $customerId the customer ID
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param callable $mappingFunction the function that maps feed attribute names to placeholder
+     *     fields
+     * @return array the map from placeholder fields to feed attributes
+     */
+    private static function placeholderFieldsMapFor(
+        string $feedResourceName,
+        int $customerId,
+        GoogleAdsClient $googleAdsClient,
+        callable $mappingFunction
+    ) {
+        $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
+        // Constructs the query to get the feed attributes for the specified feed resource name.
+        $query = "SELECT feed.attributes FROM feed WHERE feed.resource_name = '$feedResourceName'";
+        // Issues a search request by specifying page size.
+        $response =
+            $googleAdsServiceClient->search($customerId, $query, ['pageSize' => self::PAGE_SIZE]);
+
+        // Gets the first result because we only need the single feed we created previously.
+        /** @var GoogleAdsRow $googleAdsRow */
+        $googleAdsRow = $response->getIterator()->current();
+
+        // Gets the attributes list from the feed and creates a map with keys of each attribute and
+        // values of each corresponding ID.
+        $feedAttributes =
+            iterator_to_array($googleAdsRow->getFeed()->getAttributes()->getIterator());
+
+        return array_combine(array_map($mappingFunction, $feedAttributes), $feedAttributes);
+    }
+}

--- a/examples/Utils/Feeds.php
+++ b/examples/Utils/Feeds.php
@@ -64,7 +64,8 @@ final class Feeds
      *
      * @param FeedItemAttributeValue $targetFeedItemAttributeValue the new feed item attribute value
      *     that will be updated
-     * @param FeedItem $feedItem the feed item that will be updated
+     * @param FeedItem $feedItem the feed item that will be updated. It should be populated with
+     *     the current attribute values
      */
     public static function attributeIndexFor(
         FeedItemAttributeValue $targetFeedItemAttributeValue,
@@ -95,6 +96,7 @@ final class Feeds
 
     /**
      * Retrieves the place holder fields to feed attributes map for a flights feed.
+     * See FlightPlaceholderField.php for all available placeholder field values.
      *
      * @see Feeds::placeholderFieldsMapFor()
      *
@@ -112,7 +114,6 @@ final class Feeds
             $feedResourceName,
             $customerId,
             $googleAdsClient,
-            // See FlightPlaceholderField.php for all available placeholder values.
             [
                 'Flight Description' => FlightPlaceholderField::FLIGHT_DESCRIPTION,
                 'Destination ID' => FlightPlaceholderField::DESTINATION_ID,


### PR DESCRIPTION
* Some parts of AddFlightsFeed are extracted to be stored in Feeds Utils, so they can be shared in other examples.
* placeholderFieldsMapFor() is designed to be generic. That's why there is another similar function named flightPlaceholderFieldsMapFor(). In the future, if we need to create a similar example for real estate, for example, we can just supply a new callable to placeholderFieldsMapFor().


