### PR TITLE
Fixing AdGroupAd status to be ENABLED for Hotels

### DIFF
--- a/examples/HotelAds/AddHotelAd.php
+++ b/examples/HotelAds/AddHotelAd.php
@@ -328,7 +328,7 @@ class AddHotelAds
         // Creates a new ad group ad and sets the hotel ad to it.
         $adGroupAd = new AdGroupAd([
             'ad' => $ad,
-            'status' => AdGroupAdStatus::PAUSED,
+            'status' => AdGroupAdStatus::ENABLED,
             // Sets the ad group.
             'ad_group' => new StringValue(['value' => $adGroupResourceName])
         ]);


### PR DESCRIPTION
There was a change for Hotels that causes an error when setting AdGroupAd to PAUSED and should always be ENABLED.