### PR TITLE
Update AddDynamicFeed advanced operation example

### DIFF
--- a/examples/AdvancedOperations/AddDynamicPageFeed.php
+++ b/examples/AdvancedOperations/AddDynamicPageFeed.php
@@ -293,7 +293,7 @@ class AddDynamicPageFeed
         // Creates a label attribute.
         $labelAttributeValue = new FeedItemAttributeValue([
             'feed_attribute_id' => $feedDetails['Label'],
-            'string_value' => new StringValue(['value' => $dsaPageUrlLabel])
+            'string_values' => [new StringValue(['value' => $dsaPageUrlLabel])]
         ]);
 
         // Creates one operation per URL.
@@ -302,7 +302,7 @@ class AddDynamicPageFeed
             // Creates a url attribute.
             $urlAttributeValue = new FeedItemAttributeValue([
                 'feed_attribute_id' => $feedDetails['Page URL'],
-                'string_value' => new StringValue(['value' => $url])
+                'string_values' => [new StringValue(['value' => $url])]
             ]);
      
             // Creates a feed item.


### PR DESCRIPTION
When running the example the feed and feed items were created, but the Page URL and the Label contents were empty. The reason behind the empty values lies in the use of "string_value" property in the constructor of FeedItemAttributeValue class. Since the feed attributes of created feed have URL_LIST and STRING_LIST as their type, the Page URL and the Label must be arrays. 
This commit changes the key from "string_value" to "string_values" in the calls of FeedItemAttributeValue class on createFeedItems() method and put the property values inside arrays. 