### PR TITLE
Added Responsive Search Ads examples.

### DIFF
--- a/examples/BasicOperations/AddResponsiveSearchAd.php
+++ b/examples/BasicOperations/AddResponsiveSearchAd.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\BasicOperations;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsException;
+use Google\Ads\GoogleAds\Util\V3\ResourceNames;
+use Google\Ads\GoogleAds\V3\Common\AdTextAsset;
+use Google\Ads\GoogleAds\V3\Common\ResponsiveSearchAdInfo;
+use Google\Ads\GoogleAds\V3\Enums\AdGroupAdStatusEnum\AdGroupAdStatus;
+use Google\Ads\GoogleAds\V3\Enums\ServedAssetFieldTypeEnum\ServedAssetFieldType;
+use Google\Ads\GoogleAds\V3\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V3\Resources\Ad;
+use Google\Ads\GoogleAds\V3\Resources\AdGroupAd;
+use Google\Ads\GoogleAds\V3\Services\AdGroupAdOperation;
+use Google\ApiCore\ApiException;
+use Google\Protobuf\StringValue;
+
+/**
+ * This example adds a responsive search ad to a given ad group. To get ad groups,
+ * run GetAdGroups.php.
+ */
+class AddResponsiveSearchAd
+{
+    private const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+    private const AD_GROUP_ID = 'INSERT_AD_GROUP_ID_HERE';
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::AD_GROUP_ID => GetOpt::REQUIRED_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
+                $options[ArgumentNames::AD_GROUP_ID] ?: self::AD_GROUP_ID
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     * @param int $adGroupId the ad group ID to add a responsive search ad to
+     */
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $adGroupId
+    ) {
+        $adGroupResourceName =
+            new StringValue(['value' => ResourceNames::forAdGroup($customerId, $adGroupId)]);
+
+        // Creates an ad and sets responsive search ad info.
+        $ad = new Ad([
+            'responsive_search_ad' => new ResponsiveSearchAdInfo([
+                'headlines' => [
+                    // Sets a pinning to always choose this asset for HEADLINE_1. Pinning is
+                    // optional; if no pinning is set, then headlines and descriptions will be
+                    // rotated and the ones that perform best will be used more often.
+                    self::createAdTextAsset(
+                        'Cruise to Mars #' . uniqid(),
+                        ServedAssetFieldType::HEADLINE_1
+                    ),
+                    self::createAdTextAsset('Best Space Cruise Line'),
+                    self::createAdTextAsset('Experience the Stars')
+                ],
+                'descriptions' => [
+                    self::createAdTextAsset('Buy your tickets now'),
+                    self::createAdTextAsset('Visit the Red Planet')
+                ],
+                'path1' => new StringValue(['value' => 'all-inclusive']),
+                'path2' => new StringValue(['value' => 'deals'])
+            ]),
+            'final_urls' => [new StringValue(['value' => 'http://www.example.com'])]
+        ]);
+
+        // Creates an ad group ad to hold the above ad.
+        $adGroupAd = new AdGroupAd([
+            'ad_group' => $adGroupResourceName,
+            'status' => AdGroupAdStatus::PAUSED,
+            'ad' => $ad
+        ]);
+
+        // Creates an ad group ad operation.
+        $adGroupAdOperation = new AdGroupAdOperation();
+        $adGroupAdOperation->setCreate($adGroupAd);
+
+        // Issues a mutate request to add the ad group ad.
+        $adGroupAdServiceClient = $googleAdsClient->getAdGroupAdServiceClient();
+        $response = $adGroupAdServiceClient->mutateAdGroupAds($customerId, [$adGroupAdOperation]);
+
+        $createdAdGroupAdResourceName = $response->getResults()[0]->getResourceName();
+        printf(
+            "Created responsive search ad with resource name '%s'.%s",
+            $createdAdGroupAdResourceName,
+            PHP_EOL
+        );
+    }
+
+    /**
+     * Creates an ad text asset with the specified text and pin field enum value.
+     *
+     * @param string $text the text to be set
+     * @param int|null $pinField the enum value of the pin field
+     * @return AdTextAsset the created ad text asset
+     */
+    private static function createAdTextAsset(string $text, int $pinField = null): AdTextAsset
+    {
+        $adTextAsset = new AdTextAsset(['text' => new StringValue(['value' => $text])]);
+        if (!is_null($pinField)) {
+            $adTextAsset->setPinnedField($pinField);
+        }
+        return $adTextAsset;
+    }
+}
+
+AddResponsiveSearchAd::main();

--- a/examples/BasicOperations/GetResponsiveSearchAds.php
+++ b/examples/BasicOperations/GetResponsiveSearchAds.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\BasicOperations;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsException;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\V3\Common\AdTextAsset;
+use Google\Ads\GoogleAds\V3\Enums\AdGroupAdStatusEnum\AdGroupAdStatus;
+use Google\Ads\GoogleAds\V3\Enums\ServedAssetFieldTypeEnum\ServedAssetFieldType;
+use Google\Ads\GoogleAds\V3\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V3\Services\GoogleAdsRow;
+use Google\ApiCore\ApiException;
+use Google\Protobuf\Internal\RepeatedField;
+
+/**
+ * This example gets non-removed responsive search ads in a specified ad group.
+ * To add responsive search ads, run BasicOperations/AddResponsiveSearchAd.php.
+ * To get ad groups, run BasicOperations/GetAdGroups.php.
+ */
+class GetResponsiveSearchAds
+{
+    private const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+    // Optional: Specify an ad group ID below to restrict search to only a given ad group.
+    private const AD_GROUP_ID = null;
+
+    private const PAGE_SIZE = 1000;
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::AD_GROUP_ID => GetOpt::OPTIONAL_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
+                $options[ArgumentNames::AD_GROUP_ID] ?: self::AD_GROUP_ID
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     * @param int|null $adGroupId the ad group ID for which responsive search ads will be retrieved.
+     *     If `null`, returns from all ad groups
+     */
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        ?int $adGroupId
+    ) {
+        $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
+        // Creates a query that retrieves responsive search ads.
+        $query =
+            'SELECT ad_group.id, '
+            . 'ad_group_ad.ad.id, '
+            . 'ad_group_ad.ad.responsive_search_ad.headlines, '
+            . 'ad_group_ad.ad.responsive_search_ad.descriptions, '
+            . 'ad_group_ad.status '
+            . 'FROM ad_group_ad '
+            . 'WHERE ad_group_ad.ad.type = RESPONSIVE_SEARCH_AD '
+            . 'AND ad_group_ad.status != "REMOVED"';
+        if (!is_null($adGroupId)) {
+            $query .= " AND ad_group.id = $adGroupId";
+        }
+
+        // Issues a search request by specifying page size.
+        $response =
+            $googleAdsServiceClient->search($customerId, $query, ['pageSize' => self::PAGE_SIZE]);
+
+        // Iterates over all rows in all pages and prints the requested field values for
+        // the responsive search ad in each row.
+        foreach ($response->iterateAllElements() as $googleAdsRow) {
+            /** @var GoogleAdsRow $googleAdsRow */
+            $ad = $googleAdsRow->getAdGroupAd()->getAd();
+            printf(
+                "Responsive search ad with resource name '%s' and status '%s' was found.%s",
+                $ad->getResourceName(),
+                AdGroupAdStatus::name($googleAdsRow->getAdGroupAd()->getStatus()),
+                PHP_EOL
+            );
+            $responsiveSearchAdInfo = $ad->getResponsiveSearchAd();
+            printf(
+                'Headlines:%1$s%2$sDescriptions:%1$s%3$s%1$s',
+                PHP_EOL,
+                self::convertAdTextAssetsToString($responsiveSearchAdInfo->getHeadlines()),
+                self::convertAdTextAssetsToString($responsiveSearchAdInfo->getDescriptions())
+            );
+        }
+    }
+
+    /**
+     * Converts the list of AdTextAsset objects into a string representation.
+     *
+     * @param RepeatedField $assets the list of AdTextAsset objects
+     * @return string the string representation of the provided list of AdTextAsset objects
+     */
+    private static function convertAdTextAssetsToString(RepeatedField $assets): string
+    {
+        $result = '';
+        foreach ($assets as $asset) {
+            /** @var AdTextAsset $asset */
+            $result .= sprintf(
+                "\t%s pinned to %s.%s",
+                $asset->getTextUnwrapped(),
+                ServedAssetFieldType::name($asset->getPinnedField()),
+                PHP_EOL
+            );
+        }
+        return $result;
+    }
+}
+
+GetResponsiveSearchAds::main();

--- a/examples/BasicOperations/GetResponsiveSearchAds.php
+++ b/examples/BasicOperations/GetResponsiveSearchAds.php
@@ -111,6 +111,7 @@ class GetResponsiveSearchAds
         ?int $adGroupId
     ) {
         $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
+
         // Creates a query that retrieves responsive search ads.
         $query =
             'SELECT ad_group.id, '
@@ -131,8 +132,10 @@ class GetResponsiveSearchAds
 
         // Iterates over all rows in all pages and prints the requested field values for
         // the responsive search ad in each row.
+        $isEmptyResult = true;
         foreach ($response->iterateAllElements() as $googleAdsRow) {
             /** @var GoogleAdsRow $googleAdsRow */
+            $isEmptyResult = false;
             $ad = $googleAdsRow->getAdGroupAd()->getAd();
             printf(
                 "Responsive search ad with resource name '%s' and status '%s' was found.%s",
@@ -147,6 +150,9 @@ class GetResponsiveSearchAds
                 self::convertAdTextAssetsToString($responsiveSearchAdInfo->getHeadlines()),
                 self::convertAdTextAssetsToString($responsiveSearchAdInfo->getDescriptions())
             );
+        }
+        if ($isEmptyResult) {
+            print 'No responsive search ads were found.' . PHP_EOL;
         }
     }
 


### PR DESCRIPTION
Based on https://github.com/googleads/google-ads-python/pull/223.

The difference is in GetResponsiveSearchAds:
* The check for emptiness of ResponsiveSearchAdInfo is excluded. As far as I checked, both headlines and descriptions need at least one member, so it's not possible that the ResponsiveSearchAdInfo will be empty.
* Due to the convenience of the language, the private function is implemented in a bit different way. It'll return the concatenation of assets directly, instead of returning an array of strings.
