### PR TITLE
Added UpdateSitelink and UpdateCampaignExtensionSetting examples

### DIFF
--- a/examples/Extensions/UpdateCampaignExtensionSetting.php
+++ b/examples/Extensions/UpdateCampaignExtensionSetting.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\Extensions;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsException;
+use Google\Ads\GoogleAds\Util\FieldMasks;
+use Google\Ads\GoogleAds\Util\V3\ResourceNames;
+use Google\Ads\GoogleAds\V3\Enums\ExtensionTypeEnum\ExtensionType;
+use Google\Ads\GoogleAds\V3\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V3\Resources\CampaignExtensionSetting;
+use Google\Ads\GoogleAds\V3\Services\CampaignExtensionSettingOperation;
+use Google\ApiCore\ApiException;
+use Google\Protobuf\StringValue;
+
+/**
+ * Updates the campaign extension setting to replace its extension feed items.
+ * Note that this doesn't completely remove your old extension feed items.
+ * See https://developers.google.com/google-ads/api/docs/extensions/extension-settings for details.
+ */
+class UpdateCampaignExtensionSetting
+{
+    private const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+    private const CAMPAIGN_ID = 'INSERT_CAMPAIGN_ID_HERE';
+    private const EXTENSION_FEED_ITEM_RESOURCE_NAME1
+        = 'INSERT_EXTENSION_FEED_ITEM_RESOURCE_NAME1_HERE';
+    private const EXTENSION_FEED_ITEM_RESOURCE_NAME2
+        = 'INSERT_EXTENSION_FEED_ITEM_RESOURCE_NAME2_HERE';
+
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::CAMPAIGN_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::EXTENSION_FEED_ITEM_RESOURCE_NAMES => GetOpt::MULTIPLE_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
+                $options[ArgumentNames::CAMPAIGN_ID] ?: self::CAMPAIGN_ID,
+                $options[ArgumentNames::EXTENSION_FEED_ITEM_RESOURCE_NAMES] ?:
+                    [
+                        self::EXTENSION_FEED_ITEM_RESOURCE_NAME1,
+                        self::EXTENSION_FEED_ITEM_RESOURCE_NAME2
+                    ]
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the client customer ID
+     * @param int $campaignId the campaign ID
+     * @param string $extensionFeedItemResourceNames the extension feed item resource names to
+     *     replace
+     */
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $campaignId,
+        array $extensionFeedItemResourceNames
+    ) {
+        // Transforms the specified resource names to the array of StringValue, as required by
+        // the API.
+        $extensionFeedItems = array_map(function ($resourceName) {
+            return new StringValue(['value' => $resourceName]);
+        }, $extensionFeedItemResourceNames);
+
+        // Creates a campaign extension setting using the specified campaign ID and extension feed
+        // item resource names.
+        $campaignExtensionSetting = new CampaignExtensionSetting([
+            'resource_name' => ResourceNames::forCampaignExtensionSetting(
+                $customerId,
+                $campaignId,
+                ExtensionType::SITELINK
+            ),
+            'extension_feed_items' => $extensionFeedItems
+        ]);
+
+        // Constructs an operation that will update the campaign extension setting, using the
+        // FieldMasks utility to derive the update mask. This mask tells the Google Ads API which
+        // attributes of the campaign extension setting you want to change.
+        $campaignExtensionSettingOperation = new CampaignExtensionSettingOperation();
+        $campaignExtensionSettingOperation->setUpdate($campaignExtensionSetting);
+        $campaignExtensionSettingOperation->setUpdateMask(
+            FieldMasks::allSetFieldsOf($campaignExtensionSetting)
+        );
+
+        // Issues a mutate request to update the campaign extension setting.
+        $campaignExtensionSettingServiceClient =
+            $googleAdsClient->getCampaignExtensionSettingServiceClient();
+        $response = $campaignExtensionSettingServiceClient->mutateCampaignExtensionSettings(
+            $customerId,
+            [$campaignExtensionSettingOperation]
+        );
+
+        // Prints the resource name of the updated campaign extension setting.
+        /** @var CampaignExtensionSetting $updatedCampaignExtensionSetting */
+        $updatedCampaignExtensionSetting = $response->getResults()[0];
+        printf(
+            "Updated a campaign extension setting with resource name: '%s'%s",
+            $updatedCampaignExtensionSetting->getResourceName(),
+            PHP_EOL
+        );
+    }
+}
+
+UpdateCampaignExtensionSetting::main();

--- a/examples/Extensions/UpdateSitelink.php
+++ b/examples/Extensions/UpdateSitelink.php
@@ -104,7 +104,7 @@ class UpdateSitelink
      * @param GoogleAdsClient $googleAdsClient the Google Ads API client
      * @param int $customerId the client customer ID
      * @param int $feedItemId the feed item ID
-     * @param string $sitelinkText the new sitelink text to update
+     * @param string $sitelinkText the new sitelink text to update to
      */
     public static function runExample(
         GoogleAdsClient $googleAdsClient,
@@ -127,7 +127,7 @@ class UpdateSitelink
         $extensionFeedItemOperation->setUpdate($extensionFeedItem);
         $extensionFeedItemOperation->setUpdateMask(FieldMasks::allSetFieldsOf($extensionFeedItem));
 
-        // Issues a mutate request to update the extension feed items.
+        // Issues a mutate request to update the extension feed item.
         $extensionFeedItemServiceClient = $googleAdsClient->getExtensionFeedItemServiceClient();
         $response = $extensionFeedItemServiceClient->mutateExtensionFeedItems(
             $customerId,

--- a/examples/Extensions/UpdateSitelink.php
+++ b/examples/Extensions/UpdateSitelink.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\Extensions;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsException;
+use Google\Ads\GoogleAds\Util\FieldMasks;
+use Google\Ads\GoogleAds\Util\V3\ResourceNames;
+use Google\Ads\GoogleAds\V3\Common\SitelinkFeedItem;
+use Google\Ads\GoogleAds\V3\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V3\Resources\ExtensionFeedItem;
+use Google\Ads\GoogleAds\V3\Services\ExtensionFeedItemOperation;
+use Google\Ads\GoogleAds\V3\Services\GoogleAdsRow;
+use Google\Ads\GoogleAds\V3\Services\SearchGoogleAdsStreamResponse;
+use Google\ApiCore\ApiException;
+use Google\Protobuf\StringValue;
+
+/**
+ * Updates the sitelink extension feed item with the specified link text and URL.
+ */
+class UpdateSitelink
+{
+    private const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+    private const FEED_ITEM_ID = 'INSERT_FEED_ITEM_ID_HERE';
+    private const SITELINK_TEXT = 'INSERT_SITELINK_TEXT_HERE';
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::FEED_ITEM_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::SITELINK_TEXT => GetOpt::REQUIRED_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
+                $options[ArgumentNames::FEED_ITEM_ID] ?: self::FEED_ITEM_ID,
+                $options[ArgumentNames::SITELINK_TEXT] ?: self::SITELINK_TEXT
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the client customer ID
+     * @param int $feedItemId the feed item ID
+     * @param string $sitelinkText the new sitelink text to update
+     */
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $feedItemId,
+        string $sitelinkText
+    ) {
+        // Creates an extension feed item using the specified feed item ID and sitelink text.
+        $extensionFeedItem = new ExtensionFeedItem([
+            'resource_name' => ResourceNames::forExtensionFeedItem($customerId, $feedItemId),
+            'sitelink_feed_item' => new SitelinkFeedItem([
+                'link_text' => new StringValue(['value' => $sitelinkText])
+            ])
+        ]);
+
+        // Constructs an operation that will update the extension feed item, using the FieldMasks
+        // utility to derive the update mask. This mask tells the Google Ads API which attributes of
+        // the extension feed item you want to change.
+        $extensionFeedItemOperation = new ExtensionFeedItemOperation();
+        $extensionFeedItemOperation->setUpdate($extensionFeedItem);
+        $extensionFeedItemOperation->setUpdateMask(FieldMasks::allSetFieldsOf($extensionFeedItem));
+
+        // Issues a mutate request to update the extension feed items.
+        $extensionFeedItemServiceClient = $googleAdsClient->getExtensionFeedItemServiceClient();
+        $response = $extensionFeedItemServiceClient->mutateExtensionFeedItems(
+            $customerId,
+            [$extensionFeedItemOperation]
+        );
+
+        // Prints the resource name of the updated extension feed item.
+        /** @var ExtensionFeedItem $updatedExtensionFeedItem */
+        $updatedExtensionFeedItem = $response->getResults()[0];
+        printf(
+            "Updated extension feed item with resource name: '%s'.%s",
+            $updatedExtensionFeedItem->getResourceName(),
+            PHP_EOL
+        );
+    }
+}
+
+UpdateSitelink::main();

--- a/examples/Extensions/UpdateSitelinkCampaignExtensionSetting.php
+++ b/examples/Extensions/UpdateSitelinkCampaignExtensionSetting.php
@@ -39,7 +39,8 @@ use Google\Protobuf\StringValue;
 /**
  * Updates the sitelink campaign extension setting to replace its extension feed items.
  * Note that this doesn't completely remove your old extension feed items.
- * See https://developers.google.com/google-ads/api/docs/extensions/extension-settings for details.
+ * See https://developers.google.com/google-ads/api/docs/extensions/extension-settings/overview
+ * for details.
  */
 class UpdateSitelinkCampaignExtensionSetting
 {
@@ -49,7 +50,6 @@ class UpdateSitelinkCampaignExtensionSetting
         = 'INSERT_EXTENSION_FEED_ITEM_RESOURCE_NAME1_HERE';
     private const EXTENSION_FEED_ITEM_RESOURCE_NAME2
         = 'INSERT_EXTENSION_FEED_ITEM_RESOURCE_NAME2_HERE';
-
 
     public static function main()
     {
@@ -159,7 +159,7 @@ class UpdateSitelinkCampaignExtensionSetting
         /** @var CampaignExtensionSetting $updatedCampaignExtensionSetting */
         $updatedCampaignExtensionSetting = $response->getResults()[0];
         printf(
-            "Updated a campaign extension setting with resource name: '%s'%s",
+            "Updated a campaign extension setting with resource name: '%s'.%s",
             $updatedCampaignExtensionSetting->getResourceName(),
             PHP_EOL
         );

--- a/examples/Extensions/UpdateSitelinkCampaignExtensionSetting.php
+++ b/examples/Extensions/UpdateSitelinkCampaignExtensionSetting.php
@@ -37,11 +37,11 @@ use Google\ApiCore\ApiException;
 use Google\Protobuf\StringValue;
 
 /**
- * Updates the campaign extension setting to replace its extension feed items.
+ * Updates the sitelink campaign extension setting to replace its extension feed items.
  * Note that this doesn't completely remove your old extension feed items.
  * See https://developers.google.com/google-ads/api/docs/extensions/extension-settings for details.
  */
-class UpdateCampaignExtensionSetting
+class UpdateSitelinkCampaignExtensionSetting
 {
     private const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
     private const CAMPAIGN_ID = 'INSERT_CAMPAIGN_ID_HERE';
@@ -166,4 +166,4 @@ class UpdateCampaignExtensionSetting
     }
 }
 
-UpdateCampaignExtensionSetting::main();
+UpdateSitelinkCampaignExtensionSetting::main();

--- a/examples/Utils/ArgumentNames.php
+++ b/examples/Utils/ArgumentNames.php
@@ -74,6 +74,7 @@ final class ArgumentNames
     const RESTATEMENT_VALUE = 'restatementValue';
     const SHOULD_CREATE_DEFAULT_LISTING_GROUP = 'shouldCreateDefaultListingGroup';
     const SHOULD_REPLACE_EXISTING_TREE = 'shouldReplaceExistingTree';
+    const SITELINK_TEXT = 'sitelinkText';
     const SQUARE_MARKETING_IMAGE_ASSET_RESOURCE_NAME = 'squareMarketingImageAssetResourceName';
 
     public static $ARGUMENTS_TO_DESCRIPTIONS = [
@@ -131,6 +132,7 @@ final class ArgumentNames
             'Whether it should create a default listing group',
         self::SHOULD_REPLACE_EXISTING_TREE =>
             'Whether it should replace the existing listing group tree on an ad group',
+        self::SITELINK_TEXT => 'The sitelink text',
         self::SQUARE_MARKETING_IMAGE_ASSET_RESOURCE_NAME =>
             'The resource name of square marketing image asset'
     ];

--- a/examples/Utils/ArgumentNames.php
+++ b/examples/Utils/ArgumentNames.php
@@ -49,6 +49,7 @@ final class ArgumentNames
     const CRITERION_ID = 'criterionId';
     const CUSTOMER_ID = 'customerId';
     const DRAFT_ID = 'draftId';
+    const EXTENSION_FEED_ITEM_RESOURCE_NAMES = 'extensionFeedItemResourceNames';
     const FEED_ID = 'feedId';
     const FEED_ITEM_ID = 'feedItemId';
     const FEED_ITEM_IDS = 'feedItemIds';
@@ -104,6 +105,7 @@ final class ArgumentNames
         self::CRITERION_ID => 'The criterion ID',
         self::CUSTOMER_ID => 'The customer ID without dashes',
         self::DRAFT_ID => 'The draft ID',
+        self::EXTENSION_FEED_ITEM_RESOURCE_NAMES => 'The extension feed item resource names',
         self::FEED_ID => 'The feed ID',
         self::FEED_ITEM_ID => 'The feed item ID',
         self::FEED_ITEM_IDS => 'The feed item IDs',

--- a/src/Google/Ads/GoogleAds/Util/V1/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V1/ResourceNames.php
@@ -18,6 +18,7 @@
 
 namespace Google\Ads\GoogleAds\Util\V1;
 
+use Google\Ads\GoogleAds\V1\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V1\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V1\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V1\Services\AdGroupAdLabelServiceClient;
@@ -283,7 +284,7 @@ final class ResourceNames
     {
         return AdGroupExtensionSettingServiceClient::adGroupExtensionSettingName(
             $customerId,
-            "{$adGroupId}~{$extensionType}"
+            sprintf("%s~%s", $adGroupId, ExtensionType::name($extensionType))
         );
     }
 
@@ -574,7 +575,7 @@ final class ResourceNames
     {
         return CampaignExtensionSettingServiceClient::campaignExtensionSettingName(
             $customerId,
-            "{$campaignId}~{$extensionType}"
+            sprintf("%s~%s", $campaignId, ExtensionType::name($extensionType))
         );
     }
 
@@ -737,7 +738,7 @@ final class ResourceNames
     {
         return CustomerExtensionSettingServiceClient::customerExtensionSettingName(
             $customerId,
-            $extensionType
+            ExtensionType::name($extensionType)
         );
     }
 

--- a/src/Google/Ads/GoogleAds/Util/V2/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V2/ResourceNames.php
@@ -18,6 +18,7 @@
 
 namespace Google\Ads\GoogleAds\Util\V2;
 
+use Google\Ads\GoogleAds\V2\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V2\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V2\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V2\Services\AdGroupAdLabelServiceClient;
@@ -283,7 +284,7 @@ final class ResourceNames
     {
         return AdGroupExtensionSettingServiceClient::adGroupExtensionSettingName(
             $customerId,
-            "{$adGroupId}~{$extensionType}"
+            sprintf("%s~%s", $adGroupId, ExtensionType::name($extensionType))
         );
     }
 
@@ -574,7 +575,7 @@ final class ResourceNames
     {
         return CampaignExtensionSettingServiceClient::campaignExtensionSettingName(
             $customerId,
-            "{$campaignId}~{$extensionType}"
+            sprintf("%s~%s", $campaignId, ExtensionType::name($extensionType))
         );
     }
 
@@ -737,7 +738,7 @@ final class ResourceNames
     {
         return CustomerExtensionSettingServiceClient::customerExtensionSettingName(
             $customerId,
-            $extensionType
+            ExtensionType::name($extensionType)
         );
     }
 

--- a/src/Google/Ads/GoogleAds/Util/V3/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V3/ResourceNames.php
@@ -18,6 +18,7 @@
 
 namespace Google\Ads\GoogleAds\Util\V3;
 
+use Google\Ads\GoogleAds\V3\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V3\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V3\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V3\Services\AdGroupAdLabelServiceClient;
@@ -588,7 +589,7 @@ final class ResourceNames
     {
         return CampaignExtensionSettingServiceClient::campaignExtensionSettingName(
             $customerId,
-            "{$campaignId}~{$extensionType}"
+            sprintf("%s~%s", $campaignId, ExtensionType::name($extensionType))
         );
     }
 

--- a/src/Google/Ads/GoogleAds/Util/V3/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V3/ResourceNames.php
@@ -298,7 +298,7 @@ final class ResourceNames
     {
         return AdGroupExtensionSettingServiceClient::adGroupExtensionSettingName(
             $customerId,
-            "{$adGroupId}~{$extensionType}"
+            sprintf("%s~%s", $adGroupId, ExtensionType::name($extensionType))
         );
     }
 
@@ -763,7 +763,7 @@ final class ResourceNames
     {
         return CustomerExtensionSettingServiceClient::customerExtensionSettingName(
             $customerId,
-            $extensionType
+            ExtensionType::name($extensionType)
         );
     }
 

--- a/tests/Google/Ads/GoogleAds/Util/V1/ResourceNamesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V1/ResourceNamesTest.php
@@ -18,6 +18,7 @@
 
 namespace Google\Ads\GoogleAds\Util\V1;
 
+use Google\Ads\GoogleAds\V1\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V1\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V1\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V1\Services\AdGroupAdLabelServiceClient;
@@ -361,12 +362,12 @@ class ResourceNamesTest extends TestCase
     public function testGetNameForAdGroupExtensionSetting()
     {
         $adGroupId = 111111;
-        $extensionType = 3333333;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/adGroupExtensionSettings/%s~%s',
             self::CUSTOMER_ID,
             $adGroupId,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -379,7 +380,10 @@ class ResourceNamesTest extends TestCase
 
         $names = AdGroupExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
-        $this->assertEquals("{$adGroupId}~{$extensionType}", $names['ad_group_extension_setting']);
+        $this->assertEquals(
+            sprintf('%s~%s', $adGroupId, ExtensionType::name($extensionType)),
+            $names['ad_group_extension_setting']
+        );
     }
 
     /**
@@ -787,12 +791,12 @@ class ResourceNamesTest extends TestCase
     public function testGetNameForCampaignExtensionSetting()
     {
         $campaignId = 111111;
-        $extensionType = 3333333;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/campaignExtensionSettings/%s~%s',
             self::CUSTOMER_ID,
             $campaignId,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -806,7 +810,7 @@ class ResourceNamesTest extends TestCase
         $names = CampaignExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
         $this->assertEquals(
-            "{$campaignId}~{$extensionType}",
+            sprintf('%s~%s', $campaignId, ExtensionType::name($extensionType)),
             $names['campaign_extension_setting']
         );
     }
@@ -1052,11 +1056,11 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerExtensionSetting()
     {
-        $extensionType = 66666666;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/customerExtensionSettings/%s',
             self::CUSTOMER_ID,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -1065,7 +1069,10 @@ class ResourceNamesTest extends TestCase
 
         $names = CustomerExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
-        $this->assertEquals($extensionType, $names['customer_extension_setting']);
+        $this->assertEquals(
+            ExtensionType::name($extensionType),
+            $names['customer_extension_setting']
+        );
     }
 
     /**

--- a/tests/Google/Ads/GoogleAds/Util/V2/ResourceNamesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V2/ResourceNamesTest.php
@@ -18,6 +18,7 @@
 
 namespace Google\Ads\GoogleAds\Util\V2;
 
+use Google\Ads\GoogleAds\V2\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V2\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V2\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V2\Services\AdGroupAdLabelServiceClient;
@@ -361,12 +362,12 @@ class ResourceNamesTest extends TestCase
     public function testGetNameForAdGroupExtensionSetting()
     {
         $adGroupId = 111111;
-        $extensionType = 3333333;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/adGroupExtensionSettings/%s~%s',
             self::CUSTOMER_ID,
             $adGroupId,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -379,7 +380,10 @@ class ResourceNamesTest extends TestCase
 
         $names = AdGroupExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
-        $this->assertEquals("{$adGroupId}~{$extensionType}", $names['ad_group_extension_setting']);
+        $this->assertEquals(
+            sprintf('%s~%s', $adGroupId, ExtensionType::name($extensionType)),
+            $names['ad_group_extension_setting']
+        );
     }
 
     /**
@@ -787,12 +791,12 @@ class ResourceNamesTest extends TestCase
     public function testGetNameForCampaignExtensionSetting()
     {
         $campaignId = 111111;
-        $extensionType = 3333333;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/campaignExtensionSettings/%s~%s',
             self::CUSTOMER_ID,
             $campaignId,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -806,7 +810,7 @@ class ResourceNamesTest extends TestCase
         $names = CampaignExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
         $this->assertEquals(
-            "{$campaignId}~{$extensionType}",
+            sprintf('%s~%s', $campaignId, ExtensionType::name($extensionType)),
             $names['campaign_extension_setting']
         );
     }
@@ -1052,11 +1056,11 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerExtensionSetting()
     {
-        $extensionType = 66666666;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/customerExtensionSettings/%s',
             self::CUSTOMER_ID,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -1065,7 +1069,10 @@ class ResourceNamesTest extends TestCase
 
         $names = CustomerExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
-        $this->assertEquals($extensionType, $names['customer_extension_setting']);
+        $this->assertEquals(
+            ExtensionType::name($extensionType),
+            $names['customer_extension_setting']
+        );
     }
 
     /**

--- a/tests/Google/Ads/GoogleAds/Util/V3/ResourceNamesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V3/ResourceNamesTest.php
@@ -18,6 +18,7 @@
 
 namespace Google\Ads\GoogleAds\Util\V3;
 
+use Google\Ads\GoogleAds\V3\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V3\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V3\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V3\Services\AdGroupAdLabelServiceClient;
@@ -807,12 +808,12 @@ class ResourceNamesTest extends TestCase
     public function testGetNameForCampaignExtensionSetting()
     {
         $campaignId = 111111;
-        $extensionType = 3333333;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/campaignExtensionSettings/%s~%s',
             self::CUSTOMER_ID,
             $campaignId,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -826,7 +827,7 @@ class ResourceNamesTest extends TestCase
         $names = CampaignExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
         $this->assertEquals(
-            "{$campaignId}~{$extensionType}",
+            sprintf('%s~%s', $campaignId, ExtensionType::name($extensionType)),
             $names['campaign_extension_setting']
         );
     }

--- a/tests/Google/Ads/GoogleAds/Util/V3/ResourceNamesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V3/ResourceNamesTest.php
@@ -382,12 +382,12 @@ class ResourceNamesTest extends TestCase
     public function testGetNameForAdGroupExtensionSetting()
     {
         $adGroupId = 111111;
-        $extensionType = 3333333;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/adGroupExtensionSettings/%s~%s',
             self::CUSTOMER_ID,
             $adGroupId,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -400,7 +400,10 @@ class ResourceNamesTest extends TestCase
 
         $names = AdGroupExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
-        $this->assertEquals("{$adGroupId}~{$extensionType}", $names['ad_group_extension_setting']);
+        $this->assertEquals(
+            sprintf('%s~%s', $adGroupId, ExtensionType::name($extensionType)),
+            $names['ad_group_extension_setting']
+        );
     }
 
     /**
@@ -1089,11 +1092,11 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerExtensionSetting()
     {
-        $extensionType = 66666666;
+        $extensionType = ExtensionType::SITELINK;
         $expectedResourceName = sprintf(
             'customers/%s/customerExtensionSettings/%s',
             self::CUSTOMER_ID,
-            $extensionType
+            'SITELINK'
         );
         $this->assertEquals(
             $expectedResourceName,
@@ -1102,7 +1105,10 @@ class ResourceNamesTest extends TestCase
 
         $names = CustomerExtensionSettingServiceClient::parseName($expectedResourceName);
         $this->assertEquals(self::CUSTOMER_ID, $names['customer']);
-        $this->assertEquals($extensionType, $names['customer_extension_setting']);
+        $this->assertEquals(
+            ExtensionType::name($extensionType),
+            $names['customer_extension_setting']
+        );
     }
 
     /**


### PR DESCRIPTION
They'll be used as code in [this page](https://developers.google.com/google-ads/api/docs/extensions/extension-settings/update-extensions) and the second part of [this page](https://developers.google.com/google-ads/api/docs/extensions/extension-settings/remove-extensions), respectively.

The second part of [this page](https://developers.google.com/google-ads/api/docs/extensions/extension-settings/remove-extensions) may looks unmatched with the file name of UpdateCampaignExtensionSetting, but I think they make sense in its own context.
The guide aims to explain the process in its flow (which is a bigger picture of all tasks related to extension setting), whereas the code example name should be more specific and tie to its content.