### PR TITLE
Add GetKeywordBidSimulations code example

### DIFF
--- a/examples/Optimization/GetKeywordBidSimulations.php
+++ b/examples/Optimization/GetKeywordBidSimulations.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\Optimization;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsException;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\Lib\V3\GoogleAdsServerStreamDecorator;
+use Google\Ads\GoogleAds\V3\Common\CpcBidSimulationPoint;
+use Google\Ads\GoogleAds\V3\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V3\Services\GoogleAdsRow;
+use Google\ApiCore\ApiException;
+
+/**
+ * This example gets all available keyword bid simulations for a given ad group.
+ * To get ad groups, run GetAdGroups.php.
+ */
+class GetKeywordBidSimulations
+{
+    private const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+    private const AD_GROUP_ID = 'INSERT_AD_GROUP_ID_HERE';
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT,
+            ArgumentNames::AD_GROUP_ID => GetOpt::REQUIRED_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())
+            ->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID,
+                $options[ArgumentNames::AD_GROUP_ID] ?: self::AD_GROUP_ID
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     * @param int $adGroupId the ad group ID to get the keyword bid simulations for
+     */
+    public static function runExample(
+        GoogleAdsClient $googleAdsClient,
+        int $customerId,
+        int $adGroupId
+    ) {
+        $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
+
+        // Creates a query that retrieves the keyword bid simulations.
+        $query = sprintf(
+            'SELECT ad_group_criterion_simulation.ad_group_id, ' .
+            'ad_group_criterion_simulation.criterion_id, ' .
+            'ad_group_criterion_simulation.start_date, ' .
+            'ad_group_criterion_simulation.end_date, ' .
+            'ad_group_criterion_simulation.cpc_bid_point_list.points ' .
+            'FROM ad_group_criterion_simulation ' .
+            'WHERE ad_group_criterion_simulation.type = CPC_BID ' .
+            'AND ad_group_criterion_simulation.ad_group_id = %d',
+            $adGroupId
+        );
+
+        // Issues a search stream request.
+        /** @var GoogleAdsServerStreamDecorator $stream */
+        $stream =
+            $googleAdsServiceClient->searchStream($customerId, $query);
+
+        // Iterates over all rows in all messages and prints the requested field values for
+        // the keyword bid simulation in each row.
+        foreach ($stream->iterateAllElements() as $googleAdsRow) {
+            /** @var GoogleAdsRow $googleAdsRow */
+            $simulation = $googleAdsRow->getAdGroupCriterionSimulation();
+            printf(
+                'Found keyword bid simulation for ad group ID %d, ' .
+                'criterion ID %d, start date "%s", end date "%s", and points:%s',
+                $simulation->getAdGroupIdUnwrapped(),
+                $simulation->getCriterionIdUnwrapped(),
+                $simulation->getStartDateUnwrapped(),
+                $simulation->getEndDateUnwrapped(),
+                PHP_EOL
+            );
+            foreach ($simulation->getCpcBidPointList()->getPoints() as $point) {
+                /** @var CpcBidSimulationPoint $point */
+                printf(
+                    '  bid: %d => clicks: %d, cost: %d, impressions: %d, ' .
+                    'biddable conversions: %.2f, biddable conversions value: %.2f%s',
+                    $point->getCpcBidMicrosUnwrapped(),
+                    $point->getClicksUnwrapped(),
+                    $point->getCostMicrosUnwrapped(),
+                    $point->getImpressionsUnwrapped(),
+                    $point->getBiddableConversionsUnwrapped(),
+                    $point->getBiddableConversionsValueUnwrapped(),
+                    PHP_EOL
+                );
+            }
+
+            print PHP_EOL;
+        }
+    }
+}
+
+GetKeywordBidSimulations::main();

--- a/examples/Planning/GetKeywordBidSimulations.php
+++ b/examples/Planning/GetKeywordBidSimulations.php
@@ -121,8 +121,7 @@ class GetKeywordBidSimulations
 
         // Issues a search stream request.
         /** @var GoogleAdsServerStreamDecorator $stream */
-        $stream =
-            $googleAdsServiceClient->searchStream($customerId, $query);
+        $stream = $googleAdsServiceClient->searchStream($customerId, $query);
 
         // Iterates over all rows in all messages and prints the requested field values for
         // the keyword bid simulation in each row.

--- a/examples/Planning/GetKeywordBidSimulations.php
+++ b/examples/Planning/GetKeywordBidSimulations.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-namespace Google\Ads\GoogleAds\Examples\Optimization;
+namespace Google\Ads\GoogleAds\Examples\Planning;
 
 require __DIR__ . '/../../vendor/autoload.php';
 


### PR DESCRIPTION
Golden ported from [AdWords API](https://github.com/googleads/googleads-php-lib/blob/7666bfade1e4a6695542dd89c0272a09537e407a/examples/AdWords/v201809/Optimization/GetKeywordBidSimulations.php)

Used in the [Bid Landscape Guide](https://developers.google.com/adwords/api/docs/guides/bid-landscapes)

Change-Id: Ia829b44ad72143157674ed1294893fd556daa71f