### PR TITLE
Change for an empty string for the sequence token

### DIFF
--- a/examples/CampaignManagement/AddCompleteCampaignsUsingMutateJob.php
+++ b/examples/CampaignManagement/AddCompleteCampaignsUsingMutateJob.php
@@ -187,7 +187,7 @@ class AddCompleteCampaignsUsingMutateJob
     ) {
         $response = $mutateJobServiceClient->addMutateJobOperations(
             $mutateJobResourceName,
-            null,
+            '',
             self::buildAllOperations($customerId)
         );
         printf(


### PR DESCRIPTION
`null` works fine when using the PHP implementation of Protobuf but fails when using the C implementation. I change for an empty string as it always works.