### PR TITLE
Fix UT asserts

### DIFF
--- a/tests/Google/Ads/GoogleAds/Util/FieldMasksTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/FieldMasksTest.php
@@ -54,9 +54,25 @@ class FieldMasksTest extends TestCase
     public function testFieldMaskCompare(
         $originalResource,
         $modifiedResource,
-        FieldMask $expectedFieldMask
+        FieldMask $expectedFieldMask,
+        string $description
     ) {
         $actualFieldMask = FieldMasks::compare($originalResource, $modifiedResource);
+        print "============ TEST '" . $description . "'" .  PHP_EOL;
+        print "- expected: ";
+        foreach ($expectedFieldMask->getPaths() as $path) {
+            print $path . " ";
+        };
+        print PHP_EOL . "- actual: ";
+        foreach ($actualFieldMask->getPaths() as $path) {
+            print $path . " ";
+        };
+        print PHP_EOL . "Testing with FieldMask instances...";
+        $this->assertEquals(
+            $expectedFieldMask,
+            $actualFieldMask
+        );
+        print PHP_EOL . "Testing with FieldMask JSON string...";
         $this->assertEquals(
             $expectedFieldMask->serializeToJsonString(),
             $actualFieldMask->serializeToJsonString()
@@ -70,7 +86,8 @@ class FieldMasksTest extends TestCase
             $testData[] = [
                 $testCase->getOriginalResource(),
                 $testCase->getModifiedResource(),
-                $testCase->getExpectedMask()
+                $testCase->getExpectedMask(),
+                $testCase->getDescription()
             ];
         }
         return $testData;
@@ -79,9 +96,27 @@ class FieldMasksTest extends TestCase
     /**
      * @dataProvider fieldMaskAllSetFieldsOfData
      */
-    public function testFieldMaskAllSetFieldsOf($resource, FieldMask $expectedFieldMask)
-    {
+    public function testFieldMaskAllSetFieldsOf(
+        $resource,
+        FieldMask $expectedFieldMask,
+        string $description
+    ) {
         $actualFieldMask = FieldMasks::allSetFieldsOf($resource);
+        print "============ TEST '" . $description . "'" .  PHP_EOL;
+        print "- expected: ";
+        foreach ($expectedFieldMask->getPaths() as $path) {
+            print $path . " ";
+        };
+        print PHP_EOL . "- actual: ";
+        foreach ($actualFieldMask->getPaths() as $path) {
+            print $path . " ";
+        };
+        print PHP_EOL . "Testing with FieldMask instances...";
+        $this->assertEquals(
+            $expectedFieldMask,
+            $actualFieldMask
+        );
+        print PHP_EOL . "Testing with FieldMask JSON string...";
         $this->assertEquals(
             $expectedFieldMask->serializeToJsonString(),
             $actualFieldMask->serializeToJsonString()
@@ -94,7 +129,11 @@ class FieldMasksTest extends TestCase
         $emptyResource = new Resource();
         foreach (self::loadTestCases() as $testCase) {
             $resource = $testCase->getModifiedResource();
-            $testData[] = [$resource, FieldMasks::compare($emptyResource, $resource)];
+            $testData[] = [
+                $resource,
+                FieldMasks::compare($emptyResource, $resource),
+                $testCase->getDescription(),
+            ];
         }
         return $testData;
     }

--- a/tests/Google/Ads/GoogleAds/Util/FieldMasksTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/FieldMasksTest.php
@@ -21,6 +21,7 @@ namespace Google\Ads\GoogleAds\Util;
 use Google\Ads\GoogleAds\Util\Testing\FieldMasksTestDataProvider;
 use Google\Ads\GoogleAds\Util\Testing\Resource;
 use Google\Ads\GoogleAds\Util\Testing\TestSuite;
+use Google\Protobuf\FieldMask;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -50,10 +51,16 @@ class FieldMasksTest extends TestCase
     /**
      * @dataProvider fieldMaskCompareData
      */
-    public function testFieldMaskCompare($originalResource, $modifiedResource, $expectedFieldMask)
-    {
+    public function testFieldMaskCompare(
+        $originalResource,
+        $modifiedResource,
+        FieldMask $expectedFieldMask
+    ) {
         $actualFieldMask = FieldMasks::compare($originalResource, $modifiedResource);
-        $this->assertEquals($expectedFieldMask, $actualFieldMask);
+        $this->assertEquals(
+            $expectedFieldMask->serializeToJsonString(),
+            $actualFieldMask->serializeToJsonString()
+        );
     }
 
     public function fieldMaskCompareData()
@@ -72,10 +79,13 @@ class FieldMasksTest extends TestCase
     /**
      * @dataProvider fieldMaskAllSetFieldsOfData
      */
-    public function testFieldMaskAllSetFieldsOf($resource, $expectedFieldMask)
+    public function testFieldMaskAllSetFieldsOf($resource, FieldMask $expectedFieldMask)
     {
         $actualFieldMask = FieldMasks::allSetFieldsOf($resource);
-        $this->assertEquals($expectedFieldMask, $actualFieldMask);
+        $this->assertEquals(
+            $expectedFieldMask->serializeToJsonString(),
+            $actualFieldMask->serializeToJsonString()
+        );
     }
 
     public function fieldMaskAllSetFieldsOfData()


### PR DESCRIPTION
Asserts always return true when comparing two FieldMask instances. I switch to a comparison of their JSON string representation instead.

KNOWN ISSUE: 2 UTs fail with this new way of assertion, I mark this PR as DRAFT for now until a fix is found.

Change-Id: I3b890a3bdcceb21876b157eda96d066938638387