### PR TITLE
Workaround code example failure

### DIFF
--- a/examples/AdvancedOperations/AddDynamicPageFeed.php
+++ b/examples/AdvancedOperations/AddDynamicPageFeed.php
@@ -359,10 +359,9 @@ class AddDynamicPageFeed
         $dsaSetting->setFeeds([new StringValue(['value' => $feedResourceName])]);
 
         // Creates the campaign object to be updated.
-        $campaign = new Campaign([
-            'resource_name' => ResourceNames::forCampaign($customerId, $campaignId),
-            'dynamic_search_ads_setting' => $dsaSetting
-        ]);
+        $campaign = new Campaign();
+        $campaign->setResourceName(ResourceNames::forCampaign($customerId, $campaignId));
+        $campaign->setDynamicSearchAdsSetting($dsaSetting);
 
         // Creates the update operation and sets the update mask.
         $campaignOperation = new CampaignOperation();


### PR DESCRIPTION
I changed from array merge to regular setters because `'dynamic_search_ads_setting' => $dsaSetting` generates a segment fault when the protobuf PHP extension is enabled.

Change-Id: I2943f6479b00abd3ba6c51fc089b40b9bc387284