### PR TITLE
Disregard connection exception during instantiation tests

### DIFF
--- a/tests/Google/Ads/GoogleAds/InstantiateClassesTest.php
+++ b/tests/Google/Ads/GoogleAds/InstantiateClassesTest.php
@@ -20,6 +20,7 @@ namespace Google\Ads\GoogleAds;
 
 use PHPUnit\Framework\TestCase;
 use Google\ApiCore\ValidationException;
+use GuzzleHttp\Exception\ConnectException;
 
 class InstantiateClassesTest extends TestCase
 {
@@ -55,6 +56,9 @@ class InstantiateClassesTest extends TestCase
             //Disregard
             return;
         } catch (ValidationException $exception) {
+            //Disregard
+            return;
+        } catch (ConnectException $exception) {
             //Disregard
             return;
         }


### PR DESCRIPTION
Starting with the version "7.0.0" of "guzzlehttp/guzzle", ConnectExceptions are thrown when our unit tests instantiate service classes with default their constructors. These errors are false positives and this PR is to disregard them.

Change-Id: I079c3ebfa3a4b0ee8e5ad4a9c2d677d493f087d2