### PR TITLE
Fully test PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ php:
   - 7.3
   - 7.4
 
-matrix:
-  allow_failures:
-    - php: 7.4
-
 branches:
   only:
   - /.*/


### PR DESCRIPTION
Some test failures are related to the implementation of the getopt-php project. Please wait for https://github.com/getopt-php/getopt-php/pull/161 to be released before merging this PR.