### PR TITLE
Add PHP nightly to Travis matrix allowing failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - nightly
 
 matrix:
   allow_failures:
     - php: 7.4
+    - php: nightly
 
 branches:
   only:


### PR DESCRIPTION
This is to make sure that we do some early testing before fully supporting a new major version of PHP. This is likely to fail because dependencies usually need to upgrade too.