### PR TITLE
Install protobuf 3.11.4 PHP extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 before_script:
   - composer install -o -vvv --no-interaction
   - pecl install grpc
-  - pecl install protobuf
+  - pecl install protobuf-3.11.4
   - "sudo echo '{\"type\": \"authorized_user\",\"client_id\": \"\",\"client_secret\": \"\",\"refresh_token\": \"\"}' >> $GOOGLE_APPLICATION_CREDENTIALS"
 
 script:


### PR DESCRIPTION
This is avoid installing latest which is not adequate with the current version of the library: it has to be "~3.11.4".