### PR TITLE
Add UseCustomClientTimeouts code example

### DIFF
--- a/examples/Misc/SetCustomClientTimeouts.php
+++ b/examples/Misc/SetCustomClientTimeouts.php
@@ -186,12 +186,15 @@ class SetCustomClientTimeouts
                     // When making an unary call, an optional argument is provided and can be
                     // used to override the default retry settings with given values.
                     'retrySettings' => [
-                        // Sets the timeout that is used for the first try.
-                        'initialRpcTimeoutMillis' => self::CLIENT_TIMEOUT_MILLIS,
-                        // Sets the maximum timeout that can be used for any given try.
-                        'maxRpcTimeoutMillis' => self::CLIENT_TIMEOUT_MILLIS,
                         // Sets the maximum accumulative timeout of the call, it includes all tries.
-                        'totalTimeoutMillis' => self::CLIENT_TIMEOUT_MILLIS
+                        'totalTimeoutMillis' => self::CLIENT_TIMEOUT_MILLIS,
+                        // Sets the timeout that is used for the first try to one tenth of the
+                        // maximum accumulative timeout of the call.
+                        'initialRpcTimeoutMillis' => self::CLIENT_TIMEOUT_MILLIS / 10,
+                        // Sets the maximum timeout that can be used for any given try to one fifth
+                        // of the maximum accumulative timeout of the call (two times greater than
+                        // the timeout that is used for the first try).
+                        'maxRpcTimeoutMillis' => self::CLIENT_TIMEOUT_MILLIS / 5
                     ]
                 ]
             );

--- a/examples/Misc/UseCustomClientTimeouts.php
+++ b/examples/Misc/UseCustomClientTimeouts.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Examples\Misc;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentNames;
+use Google\Ads\GoogleAds\Examples\Utils\ArgumentParser;
+use Google\Ads\GoogleAds\Lib\V5\GoogleAdsClient;
+use Google\Ads\GoogleAds\Lib\V5\GoogleAdsClientBuilder;
+use Google\Ads\GoogleAds\Lib\V5\GoogleAdsException;
+use Google\Ads\GoogleAds\Lib\OAuth2TokenBuilder;
+use Google\Ads\GoogleAds\Lib\V5\GoogleAdsServerStreamDecorator;
+use Google\Ads\GoogleAds\V5\Errors\GoogleAdsError;
+use Google\Ads\GoogleAds\V5\Services\GoogleAdsRow;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\ApiStatus;
+
+/** This example illustrates the use of custom client timeouts. */
+class UseCustomClientTimeouts
+{
+    private const CUSTOMER_ID = 'INSERT_CUSTOMER_ID_HERE';
+
+    private const CUSTOM_CLIENT_TIMEOUT = 5 * 60 * 1000; // 5 minutes in millis
+
+    public static function main()
+    {
+        // Either pass the required parameters for this example on the command line, or insert them
+        // into the constants above.
+        $options = (new ArgumentParser())->parseCommandArguments([
+            ArgumentNames::CUSTOMER_ID => GetOpt::REQUIRED_ARGUMENT
+        ]);
+
+        // Generate a refreshable OAuth2 credential for authentication.
+        $oAuth2Credential = (new OAuth2TokenBuilder())->fromFile()->build();
+
+        // Construct a Google Ads client configured from a properties file and the
+        // OAuth2 credentials above.
+        $googleAdsClient = (new GoogleAdsClientBuilder())
+            ->fromFile()
+            ->withOAuth2Credential($oAuth2Credential)
+            ->build();
+
+        try {
+            self::runExample(
+                $googleAdsClient,
+                $options[ArgumentNames::CUSTOMER_ID] ?: self::CUSTOMER_ID
+            );
+        } catch (GoogleAdsException $googleAdsException) {
+            printf(
+                "Request with ID '%s' has failed.%sGoogle Ads failure details:%s",
+                $googleAdsException->getRequestId(),
+                PHP_EOL,
+                PHP_EOL
+            );
+            foreach ($googleAdsException->getGoogleAdsFailure()->getErrors() as $error) {
+                /** @var GoogleAdsError $error */
+                printf(
+                    "\t%s: %s%s",
+                    $error->getErrorCode()->getErrorCode(),
+                    $error->getMessage(),
+                    PHP_EOL
+                );
+            }
+            exit(1);
+        } catch (ApiException $apiException) {
+            printf(
+                "ApiException was thrown with message '%s'.%s",
+                $apiException->getMessage(),
+                PHP_EOL
+            );
+            exit(1);
+        }
+    }
+
+    /**
+     * Runs the example.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     */
+    public static function runExample(GoogleAdsClient $googleAdsClient, int $customerId)
+    {
+        self::serverStreamingCall($googleAdsClient, $customerId);
+        self::unaryCall($googleAdsClient, $customerId);
+    }
+
+    /**
+     * Makes a server streaming call using a custom client timeout.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     */
+    private static function serverStreamingCall(GoogleAdsClient $googleAdsClient, int $customerId)
+    {
+        $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
+        // Creates a query that retrieves all campaign IDs.
+        $query = 'SELECT campaign.id FROM campaign';
+
+        $output = '';
+        try {
+            // Issues a search stream request.
+            /** @var GoogleAdsServerStreamDecorator $stream */
+            $stream = $googleAdsServiceClient->searchStream(
+                $customerId,
+                $query,
+                ['timeoutMillis' => self::CUSTOM_CLIENT_TIMEOUT]
+            );
+            // Iterates over all rows in all messages and collects the campaign IDs.
+            foreach ($stream->iterateAllElements() as $googleAdsRow) {
+                /** @var GoogleAdsRow $googleAdsRow */
+                $output .= ' ' . $googleAdsRow->getCampaign()->getId();
+            }
+            print 'The server streaming call completed before the timeout.' . PHP_EOL;
+        } catch (ApiException $exception) {
+            if ($exception->getStatus() === ApiStatus::DEADLINE_EXCEEDED) {
+                print 'The server streaming call did not complete before the timeout.' . PHP_EOL;
+            } else {
+                // Bubbles up if the exception is not about timeout.
+                throw $exception;
+            }
+        } finally {
+            print 'All campaign IDs retrieved:' . ($output ?: ' None') . PHP_EOL;
+        }
+    }
+
+    /**
+     * Makes an unary call using a custom client timeout.
+     *
+     * @param GoogleAdsClient $googleAdsClient the Google Ads API client
+     * @param int $customerId the customer ID
+     */
+    private static function unaryCall(GoogleAdsClient $googleAdsClient, int $customerId)
+    {
+        $googleAdsServiceClient = $googleAdsClient->getGoogleAdsServiceClient();
+        // Creates a query that retrieves all campaign IDs.
+        $query = 'SELECT campaign.id FROM campaign';
+
+        $output = '';
+        try {
+            // Issues a search request.
+            $response = $googleAdsServiceClient->search(
+                $customerId,
+                $query,
+                [
+                    'timeoutMillis' => self::CUSTOM_CLIENT_TIMEOUT,
+                    'retrySettings' => [
+                        'initialRpcTimeoutMillis' => self::CUSTOM_CLIENT_TIMEOUT,
+                        'maxRpcTimeoutMillis' => self::CUSTOM_CLIENT_TIMEOUT,
+                        'totalTimeoutMillis' => self::CUSTOM_CLIENT_TIMEOUT
+                    ]
+                ]
+            );
+            // Iterates over all rows in all messages and collects the campaign IDs.
+            foreach ($response->iterateAllElements() as $googleAdsRow) {
+                /** @var GoogleAdsRow $googleAdsRow */
+                $output .= ' ' . $googleAdsRow->getCampaign()->getId();
+            }
+            print 'The unary call completed before the timeout.' . PHP_EOL;
+        } catch (ApiException $exception) {
+            if ($exception->getStatus() === ApiStatus::DEADLINE_EXCEEDED) {
+                print 'The unary call did not complete before the timeout.' . PHP_EOL;
+            } else {
+                // Bubbles up if the exception is not about timeout.
+                throw $exception;
+            }
+        } finally {
+            print 'All campaign IDs retrieved:' . ($output ?: ' None') . PHP_EOL;
+        }
+    }
+}
+
+UseCustomClientTimeouts::main();


### PR DESCRIPTION
This new golden will be used to include code in the guides about timeouts e.g. [PHP](https://developers.google.com/google-ads/api/docs/client-libs/php/timeout).

Change-Id: I07b892b5d9e9286d040870b813837de82003a80f