### PR TITLE
Remove additional properties.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "googleads/google-ads-php",
-  "author": "Google LLC",
-  "url": "https://github.com/googleads/google-ads-php",
+  "homepage": "https://github.com/googleads/google-ads-php",
   "description": "Google Ads API client for PHP",
   "require": {
     "php": ">=7.3",


### PR DESCRIPTION
This PR fixes all errors returned by `composer validate`:

```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
The property author is not defined and the definition does not allow additional properties
The property url is not defined and the definition does not allow additional properties
```

Change-Id: I69c813863a10a9c120e5ca26bcaecc0b9c18e233