### PR TITLE
Regen services

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/V5/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V5/ServiceClientFactoryTrait.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2020 Google LLC
+/**
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Lib\V5;
 
 use Google\Ads\GoogleAds\Lib\ConfigurationTrait;
 use Google\Ads\GoogleAds\V5\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V5\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AdGroupAudienceViewServiceClient;
@@ -73,6 +76,7 @@ use Google\Ads\GoogleAds\V5\Services\CustomerServiceClient;
 use Google\Ads\GoogleAds\V5\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V5\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DomainCategoryServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\ExpandedLandingPageViewServiceClient;
@@ -128,6 +132,7 @@ use Google\Ads\GoogleAds\V5\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\UserDataServiceClient;
 use Google\Ads\GoogleAds\V5\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V5\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V5\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\VideoServiceClient;
 
 /**
@@ -150,7 +155,7 @@ trait ServiceClientFactoryTrait
      *
      * @return array the client options
      */
-    public function getGoogleAdsClientOptions()
+    public function getGoogleAdsClientOptions(): array
     {
         $clientOptions = [
             self::$CREDENTIALS_LOADER_KEY => $this->getOAuth2Credential(),
@@ -206,7 +211,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountBudgetProposalServiceClient
      */
-    public function getAccountBudgetProposalServiceClient()
+    public function getAccountBudgetProposalServiceClient(): AccountBudgetProposalServiceClient
     {
         return new AccountBudgetProposalServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -214,7 +219,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountBudgetServiceClient
      */
-    public function getAccountBudgetServiceClient()
+    public function getAccountBudgetServiceClient(): AccountBudgetServiceClient
     {
         return new AccountBudgetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -222,31 +227,39 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountLinkServiceClient
      */
-    public function getAccountLinkServiceClient()
+    public function getAccountLinkServiceClient(): AccountLinkServiceClient
     {
         return new AccountLinkServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return AdGroupAdServiceClient
+     * @return AdGroupAdAssetViewServiceClient
      */
-    public function getAdGroupAdServiceClient()
+    public function getAdGroupAdAssetViewServiceClient(): AdGroupAdAssetViewServiceClient
     {
-        return new AdGroupAdServiceClient($this->getGoogleAdsClientOptions());
+        return new AdGroupAdAssetViewServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
      * @return AdGroupAdLabelServiceClient
      */
-    public function getAdGroupAdLabelServiceClient()
+    public function getAdGroupAdLabelServiceClient(): AdGroupAdLabelServiceClient
     {
         return new AdGroupAdLabelServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return AdGroupAdServiceClient
+     */
+    public function getAdGroupAdServiceClient(): AdGroupAdServiceClient
+    {
+        return new AdGroupAdServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return AdGroupAudienceViewServiceClient
      */
-    public function getAdGroupAudienceViewServiceClient()
+    public function getAdGroupAudienceViewServiceClient(): AdGroupAudienceViewServiceClient
     {
         return new AdGroupAudienceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -254,7 +267,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupBidModifierServiceClient
      */
-    public function getAdGroupBidModifierServiceClient()
+    public function getAdGroupBidModifierServiceClient(): AdGroupBidModifierServiceClient
     {
         return new AdGroupBidModifierServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -262,7 +275,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionLabelServiceClient
      */
-    public function getAdGroupCriterionLabelServiceClient()
+    public function getAdGroupCriterionLabelServiceClient(): AdGroupCriterionLabelServiceClient
     {
         return new AdGroupCriterionLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -270,7 +283,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionServiceClient
      */
-    public function getAdGroupCriterionServiceClient()
+    public function getAdGroupCriterionServiceClient(): AdGroupCriterionServiceClient
     {
         return new AdGroupCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -278,7 +291,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionSimulationServiceClient
      */
-    public function getAdGroupCriterionSimulationServiceClient()
+    public function getAdGroupCriterionSimulationServiceClient(): AdGroupCriterionSimulationServiceClient
     {
         return new AdGroupCriterionSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -286,7 +299,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupExtensionSettingServiceClient
      */
-    public function getAdGroupExtensionSettingServiceClient()
+    public function getAdGroupExtensionSettingServiceClient(): AdGroupExtensionSettingServiceClient
     {
         return new AdGroupExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -294,7 +307,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupFeedServiceClient
      */
-    public function getAdGroupFeedServiceClient()
+    public function getAdGroupFeedServiceClient(): AdGroupFeedServiceClient
     {
         return new AdGroupFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -302,7 +315,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupLabelServiceClient
      */
-    public function getAdGroupLabelServiceClient()
+    public function getAdGroupLabelServiceClient(): AdGroupLabelServiceClient
     {
         return new AdGroupLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -310,7 +323,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupServiceClient
      */
-    public function getAdGroupServiceClient()
+    public function getAdGroupServiceClient(): AdGroupServiceClient
     {
         return new AdGroupServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -318,7 +331,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupSimulationServiceClient
      */
-    public function getAdGroupSimulationServiceClient()
+    public function getAdGroupSimulationServiceClient(): AdGroupSimulationServiceClient
     {
         return new AdGroupSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -326,7 +339,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdParameterServiceClient
      */
-    public function getAdParameterServiceClient()
+    public function getAdParameterServiceClient(): AdParameterServiceClient
     {
         return new AdParameterServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -334,7 +347,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdScheduleViewServiceClient
      */
-    public function getAdScheduleViewServiceClient()
+    public function getAdScheduleViewServiceClient(): AdScheduleViewServiceClient
     {
         return new AdScheduleViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -342,7 +355,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdServiceClient
      */
-    public function getAdServiceClient()
+    public function getAdServiceClient(): AdServiceClient
     {
         return new AdServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -350,7 +363,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AgeRangeViewServiceClient
      */
-    public function getAgeRangeViewServiceClient()
+    public function getAgeRangeViewServiceClient(): AgeRangeViewServiceClient
     {
         return new AgeRangeViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -358,7 +371,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AssetServiceClient
      */
-    public function getAssetServiceClient()
+    public function getAssetServiceClient(): AssetServiceClient
     {
         return new AssetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -366,7 +379,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BatchJobServiceClient
      */
-    public function getBatchJobServiceClient()
+    public function getBatchJobServiceClient(): BatchJobServiceClient
     {
         return new BatchJobServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -374,7 +387,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BiddingStrategyServiceClient
      */
-    public function getBiddingStrategyServiceClient()
+    public function getBiddingStrategyServiceClient(): BiddingStrategyServiceClient
     {
         return new BiddingStrategyServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -382,31 +395,31 @@ trait ServiceClientFactoryTrait
     /**
      * @return BillingSetupServiceClient
      */
-    public function getBillingSetupServiceClient()
+    public function getBillingSetupServiceClient(): BillingSetupServiceClient
     {
         return new BillingSetupServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return CampaignAudienceViewServiceClient
-     */
-    public function getCampaignAudienceViewServiceClient()
-    {
-        return new CampaignAudienceViewServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
      * @return CampaignAssetServiceClient
      */
-    public function getCampaignAssetServiceClient()
+    public function getCampaignAssetServiceClient(): CampaignAssetServiceClient
     {
         return new CampaignAssetServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return CampaignAudienceViewServiceClient
+     */
+    public function getCampaignAudienceViewServiceClient(): CampaignAudienceViewServiceClient
+    {
+        return new CampaignAudienceViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return CampaignBidModifierServiceClient
      */
-    public function getCampaignBidModifierServiceClient()
+    public function getCampaignBidModifierServiceClient(): CampaignBidModifierServiceClient
     {
         return new CampaignBidModifierServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -414,7 +427,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignBudgetServiceClient
      */
-    public function getCampaignBudgetServiceClient()
+    public function getCampaignBudgetServiceClient(): CampaignBudgetServiceClient
     {
         return new CampaignBudgetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -422,7 +435,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignCriterionServiceClient
      */
-    public function getCampaignCriterionServiceClient()
+    public function getCampaignCriterionServiceClient(): CampaignCriterionServiceClient
     {
         return new CampaignCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -430,7 +443,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignCriterionSimulationServiceClient
      */
-    public function getCampaignCriterionSimulationServiceClient()
+    public function getCampaignCriterionSimulationServiceClient(): CampaignCriterionSimulationServiceClient
     {
         return new CampaignCriterionSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -438,7 +451,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignDraftServiceClient
      */
-    public function getCampaignDraftServiceClient()
+    public function getCampaignDraftServiceClient(): CampaignDraftServiceClient
     {
         return new CampaignDraftServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -446,7 +459,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignExperimentServiceClient
      */
-    public function getCampaignExperimentServiceClient()
+    public function getCampaignExperimentServiceClient(): CampaignExperimentServiceClient
     {
         return new CampaignExperimentServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -454,7 +467,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignExtensionSettingServiceClient
      */
-    public function getCampaignExtensionSettingServiceClient()
+    public function getCampaignExtensionSettingServiceClient(): CampaignExtensionSettingServiceClient
     {
         return new CampaignExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -462,7 +475,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignFeedServiceClient
      */
-    public function getCampaignFeedServiceClient()
+    public function getCampaignFeedServiceClient(): CampaignFeedServiceClient
     {
         return new CampaignFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -470,7 +483,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignLabelServiceClient
      */
-    public function getCampaignLabelServiceClient()
+    public function getCampaignLabelServiceClient(): CampaignLabelServiceClient
     {
         return new CampaignLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -478,7 +491,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignServiceClient
      */
-    public function getCampaignServiceClient()
+    public function getCampaignServiceClient(): CampaignServiceClient
     {
         return new CampaignServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -486,7 +499,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignSharedSetServiceClient
      */
-    public function getCampaignSharedSetServiceClient()
+    public function getCampaignSharedSetServiceClient(): CampaignSharedSetServiceClient
     {
         return new CampaignSharedSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -494,7 +507,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CarrierConstantServiceClient
      */
-    public function getCarrierConstantServiceClient()
+    public function getCarrierConstantServiceClient(): CarrierConstantServiceClient
     {
         return new CarrierConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -502,7 +515,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ChangeStatusServiceClient
      */
-    public function getChangeStatusServiceClient()
+    public function getChangeStatusServiceClient(): ChangeStatusServiceClient
     {
         return new ChangeStatusServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -510,7 +523,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ClickViewServiceClient
      */
-    public function getClickViewServiceClient()
+    public function getClickViewServiceClient(): ClickViewServiceClient
     {
         return new ClickViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -518,7 +531,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionActionServiceClient
      */
-    public function getConversionActionServiceClient()
+    public function getConversionActionServiceClient(): ConversionActionServiceClient
     {
         return new ConversionActionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -526,7 +539,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionAdjustmentUploadServiceClient
      */
-    public function getConversionAdjustmentUploadServiceClient()
+    public function getConversionAdjustmentUploadServiceClient(): ConversionAdjustmentUploadServiceClient
     {
         return new ConversionAdjustmentUploadServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -534,7 +547,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionUploadServiceClient
      */
-    public function getConversionUploadServiceClient()
+    public function getConversionUploadServiceClient(): ConversionUploadServiceClient
     {
         return new ConversionUploadServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -542,7 +555,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CurrencyConstantServiceClient
      */
-    public function getCurrencyConstantServiceClient()
+    public function getCurrencyConstantServiceClient(): CurrencyConstantServiceClient
     {
         return new CurrencyConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -550,7 +563,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerClientLinkServiceClient
      */
-    public function getCustomerClientLinkServiceClient()
+    public function getCustomerClientLinkServiceClient(): CustomerClientLinkServiceClient
     {
         return new CustomerClientLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -558,7 +571,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerClientServiceClient
      */
-    public function getCustomerClientServiceClient()
+    public function getCustomerClientServiceClient(): CustomerClientServiceClient
     {
         return new CustomerClientServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -566,7 +579,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerExtensionSettingServiceClient
      */
-    public function getCustomerExtensionSettingServiceClient()
+    public function getCustomerExtensionSettingServiceClient(): CustomerExtensionSettingServiceClient
     {
         return new CustomerExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -574,7 +587,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerFeedServiceClient
      */
-    public function getCustomerFeedServiceClient()
+    public function getCustomerFeedServiceClient(): CustomerFeedServiceClient
     {
         return new CustomerFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -582,7 +595,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerLabelServiceClient
      */
-    public function getCustomerLabelServiceClient()
+    public function getCustomerLabelServiceClient(): CustomerLabelServiceClient
     {
         return new CustomerLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -590,7 +603,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerManagerLinkServiceClient
      */
-    public function getCustomerManagerLinkServiceClient()
+    public function getCustomerManagerLinkServiceClient(): CustomerManagerLinkServiceClient
     {
         return new CustomerManagerLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -598,7 +611,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerNegativeCriterionServiceClient
      */
-    public function getCustomerNegativeCriterionServiceClient()
+    public function getCustomerNegativeCriterionServiceClient(): CustomerNegativeCriterionServiceClient
     {
         return new CustomerNegativeCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -606,7 +619,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerServiceClient
      */
-    public function getCustomerServiceClient()
+    public function getCustomerServiceClient(): CustomerServiceClient
     {
         return new CustomerServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -614,31 +627,39 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomInterestServiceClient
      */
-    public function getCustomInterestServiceClient()
+    public function getCustomInterestServiceClient(): CustomInterestServiceClient
     {
         return new CustomInterestServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return DisplayKeywordViewServiceClient
-     */
-    public function getDisplayKeywordViewServiceClient()
-    {
-        return new DisplayKeywordViewServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
      * @return DetailPlacementViewServiceClient
      */
-    public function getDetailPlacementViewServiceClient()
+    public function getDetailPlacementViewServiceClient(): DetailPlacementViewServiceClient
     {
         return new DetailPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return DisplayKeywordViewServiceClient
+     */
+    public function getDisplayKeywordViewServiceClient(): DisplayKeywordViewServiceClient
+    {
+        return new DisplayKeywordViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
+     * @return DistanceViewServiceClient
+     */
+    public function getDistanceViewServiceClient(): DistanceViewServiceClient
+    {
+        return new DistanceViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return DomainCategoryServiceClient
      */
-    public function getDomainCategoryServiceClient()
+    public function getDomainCategoryServiceClient(): DomainCategoryServiceClient
     {
         return new DomainCategoryServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -646,31 +667,31 @@ trait ServiceClientFactoryTrait
     /**
      * @return DynamicSearchAdsSearchTermViewServiceClient
      */
-    public function getDynamicSearchAdsSearchTermViewServiceClient()
+    public function getDynamicSearchAdsSearchTermViewServiceClient(): DynamicSearchAdsSearchTermViewServiceClient
     {
         return new DynamicSearchAdsSearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return ExtensionFeedItemServiceClient
-     */
-    public function getExtensionFeedItemServiceClient()
-    {
-        return new ExtensionFeedItemServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
      * @return ExpandedLandingPageViewServiceClient
      */
-    public function getExpandedLandingPageViewServiceClient()
+    public function getExpandedLandingPageViewServiceClient(): ExpandedLandingPageViewServiceClient
     {
         return new ExpandedLandingPageViewServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return ExtensionFeedItemServiceClient
+     */
+    public function getExtensionFeedItemServiceClient(): ExtensionFeedItemServiceClient
+    {
+        return new ExtensionFeedItemServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return FeedItemServiceClient
      */
-    public function getFeedItemServiceClient()
+    public function getFeedItemServiceClient(): FeedItemServiceClient
     {
         return new FeedItemServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -678,7 +699,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemTargetServiceClient
      */
-    public function getFeedItemTargetServiceClient()
+    public function getFeedItemTargetServiceClient(): FeedItemTargetServiceClient
     {
         return new FeedItemTargetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -686,7 +707,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedMappingServiceClient
      */
-    public function getFeedMappingServiceClient()
+    public function getFeedMappingServiceClient(): FeedMappingServiceClient
     {
         return new FeedMappingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -694,7 +715,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedPlaceholderViewServiceClient
      */
-    public function getFeedPlaceholderViewServiceClient()
+    public function getFeedPlaceholderViewServiceClient(): FeedPlaceholderViewServiceClient
     {
         return new FeedPlaceholderViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -702,7 +723,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedServiceClient
      */
-    public function getFeedServiceClient()
+    public function getFeedServiceClient(): FeedServiceClient
     {
         return new FeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -710,7 +731,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GenderViewServiceClient
      */
-    public function getGenderViewServiceClient()
+    public function getGenderViewServiceClient(): GenderViewServiceClient
     {
         return new GenderViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -718,7 +739,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GeographicViewServiceClient
      */
-    public function getGeographicViewServiceClient()
+    public function getGeographicViewServiceClient(): GeographicViewServiceClient
     {
         return new GeographicViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -726,7 +747,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GeoTargetConstantServiceClient
      */
-    public function getGeoTargetConstantServiceClient()
+    public function getGeoTargetConstantServiceClient(): GeoTargetConstantServiceClient
     {
         return new GeoTargetConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -734,7 +755,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GoogleAdsFieldServiceClient
      */
-    public function getGoogleAdsFieldServiceClient()
+    public function getGoogleAdsFieldServiceClient(): GoogleAdsFieldServiceClient
     {
         return new GoogleAdsFieldServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -742,39 +763,15 @@ trait ServiceClientFactoryTrait
     /**
      * @return GoogleAdsServiceClient
      */
-    public function getGoogleAdsServiceClient()
+    public function getGoogleAdsServiceClient(): GoogleAdsServiceClient
     {
         return new GoogleAdsServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return HotelPerformanceViewServiceClient
-     */
-    public function getHotelPerformanceViewServiceClient()
-    {
-        return new HotelPerformanceViewServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
-     * @return IncomeRangeViewServiceClient
-     */
-    public function getIncomeRangeViewServiceClient()
-    {
-        return new IncomeRangeViewServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
-     * @return InvoiceServiceClient
-     */
-    public function getInvoiceServiceClient()
-    {
-        return new InvoiceServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
      * @return GroupPlacementViewServiceClient
      */
-    public function getGroupPlacementViewServiceClient()
+    public function getGroupPlacementViewServiceClient(): GroupPlacementViewServiceClient
     {
         return new GroupPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -782,47 +779,71 @@ trait ServiceClientFactoryTrait
     /**
      * @return HotelGroupViewServiceClient
      */
-    public function getHotelGroupViewServiceClient()
+    public function getHotelGroupViewServiceClient(): HotelGroupViewServiceClient
     {
         return new HotelGroupViewServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return KeywordPlanAdGroupServiceClient
+     * @return HotelPerformanceViewServiceClient
      */
-    public function getKeywordPlanAdGroupServiceClient()
+    public function getHotelPerformanceViewServiceClient(): HotelPerformanceViewServiceClient
     {
-        return new KeywordPlanAdGroupServiceClient($this->getGoogleAdsClientOptions());
+        return new HotelPerformanceViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
+     * @return IncomeRangeViewServiceClient
+     */
+    public function getIncomeRangeViewServiceClient(): IncomeRangeViewServiceClient
+    {
+        return new IncomeRangeViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
+     * @return InvoiceServiceClient
+     */
+    public function getInvoiceServiceClient(): InvoiceServiceClient
+    {
+        return new InvoiceServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
      * @return KeywordPlanAdGroupKeywordServiceClient
      */
-    public function getKeywordPlanAdGroupKeywordServiceClient()
+    public function getKeywordPlanAdGroupKeywordServiceClient(): KeywordPlanAdGroupKeywordServiceClient
     {
         return new KeywordPlanAdGroupKeywordServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return KeywordPlanCampaignServiceClient
+     * @return KeywordPlanAdGroupServiceClient
      */
-    public function getKeywordPlanCampaignServiceClient()
+    public function getKeywordPlanAdGroupServiceClient(): KeywordPlanAdGroupServiceClient
     {
-        return new KeywordPlanCampaignServiceClient($this->getGoogleAdsClientOptions());
+        return new KeywordPlanAdGroupServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
      * @return KeywordPlanCampaignKeywordServiceClient
      */
-    public function getKeywordPlanCampaignKeywordServiceClient()
+    public function getKeywordPlanCampaignKeywordServiceClient(): KeywordPlanCampaignKeywordServiceClient
     {
         return new KeywordPlanCampaignKeywordServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return KeywordPlanCampaignServiceClient
+     */
+    public function getKeywordPlanCampaignServiceClient(): KeywordPlanCampaignServiceClient
+    {
+        return new KeywordPlanCampaignServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return KeywordPlanIdeaServiceClient
      */
-    public function getKeywordPlanIdeaServiceClient()
+    public function getKeywordPlanIdeaServiceClient(): KeywordPlanIdeaServiceClient
     {
         return new KeywordPlanIdeaServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -830,7 +851,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanServiceClient
      */
-    public function getKeywordPlanServiceClient()
+    public function getKeywordPlanServiceClient(): KeywordPlanServiceClient
     {
         return new KeywordPlanServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -838,7 +859,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordViewServiceClient
      */
-    public function getKeywordViewServiceClient()
+    public function getKeywordViewServiceClient(): KeywordViewServiceClient
     {
         return new KeywordViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -846,7 +867,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LabelServiceClient
      */
-    public function getLabelServiceClient()
+    public function getLabelServiceClient(): LabelServiceClient
     {
         return new LabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -854,7 +875,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LandingPageViewServiceClient
      */
-    public function getLandingPageViewServiceClient()
+    public function getLandingPageViewServiceClient(): LandingPageViewServiceClient
     {
         return new LandingPageViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -862,7 +883,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LanguageConstantServiceClient
      */
-    public function getLanguageConstantServiceClient()
+    public function getLanguageConstantServiceClient(): LanguageConstantServiceClient
     {
         return new LanguageConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -870,7 +891,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LocationViewServiceClient
      */
-    public function getLocationViewServiceClient()
+    public function getLocationViewServiceClient(): LocationViewServiceClient
     {
         return new LocationViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -878,7 +899,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ManagedPlacementViewServiceClient
      */
-    public function getManagedPlacementViewServiceClient()
+    public function getManagedPlacementViewServiceClient(): ManagedPlacementViewServiceClient
     {
         return new ManagedPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -886,7 +907,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MediaFileServiceClient
      */
-    public function getMediaFileServiceClient()
+    public function getMediaFileServiceClient(): MediaFileServiceClient
     {
         return new MediaFileServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -894,7 +915,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MerchantCenterLinkServiceClient
      */
-    public function getMerchantCenterLinkServiceClient()
+    public function getMerchantCenterLinkServiceClient(): MerchantCenterLinkServiceClient
     {
         return new MerchantCenterLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -902,7 +923,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MobileAppCategoryConstantServiceClient
      */
-    public function getMobileAppCategoryConstantServiceClient()
+    public function getMobileAppCategoryConstantServiceClient(): MobileAppCategoryConstantServiceClient
     {
         return new MobileAppCategoryConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -910,7 +931,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MobileDeviceConstantServiceClient
      */
-    public function getMobileDeviceConstantServiceClient()
+    public function getMobileDeviceConstantServiceClient(): MobileDeviceConstantServiceClient
     {
         return new MobileDeviceConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -918,7 +939,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return OfflineUserDataJobServiceClient
      */
-    public function getOfflineUserDataJobServiceClient()
+    public function getOfflineUserDataJobServiceClient(): OfflineUserDataJobServiceClient
     {
         return new OfflineUserDataJobServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -926,15 +947,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return OperatingSystemVersionConstantServiceClient
      */
-    public function getOperatingSystemVersionConstantServiceClient()
+    public function getOperatingSystemVersionConstantServiceClient(): OperatingSystemVersionConstantServiceClient
     {
         return new OperatingSystemVersionConstantServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return PaidOrganicSearchTermViewServiceClient
+     */
+    public function getPaidOrganicSearchTermViewServiceClient(): PaidOrganicSearchTermViewServiceClient
+    {
+        return new PaidOrganicSearchTermViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return ParentalStatusViewServiceClient
      */
-    public function getParentalStatusViewServiceClient()
+    public function getParentalStatusViewServiceClient(): ParentalStatusViewServiceClient
     {
         return new ParentalStatusViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -942,7 +971,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return PaymentsAccountServiceClient
      */
-    public function getPaymentsAccountServiceClient()
+    public function getPaymentsAccountServiceClient(): PaymentsAccountServiceClient
     {
         return new PaymentsAccountServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -950,23 +979,15 @@ trait ServiceClientFactoryTrait
     /**
      * @return ProductBiddingCategoryConstantServiceClient
      */
-    public function getProductBiddingCategoryConstantServiceClient()
+    public function getProductBiddingCategoryConstantServiceClient(): ProductBiddingCategoryConstantServiceClient
     {
         return new ProductBiddingCategoryConstantServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return PaidOrganicSearchTermViewServiceClient
-     */
-    public function getPaidOrganicSearchTermViewServiceClient()
-    {
-        return new PaidOrganicSearchTermViewServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
      * @return ProductGroupViewServiceClient
      */
-    public function getProductGroupViewServiceClient()
+    public function getProductGroupViewServiceClient(): ProductGroupViewServiceClient
     {
         return new ProductGroupViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -974,7 +995,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ReachPlanServiceClient
      */
-    public function getReachPlanServiceClient()
+    public function getReachPlanServiceClient(): ReachPlanServiceClient
     {
         return new ReachPlanServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -982,7 +1003,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return RecommendationServiceClient
      */
-    public function getRecommendationServiceClient()
+    public function getRecommendationServiceClient(): RecommendationServiceClient
     {
         return new RecommendationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -990,7 +1011,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return RemarketingActionServiceClient
      */
-    public function getRemarketingActionServiceClient()
+    public function getRemarketingActionServiceClient(): RemarketingActionServiceClient
     {
         return new RemarketingActionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -998,7 +1019,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SearchTermViewServiceClient
      */
-    public function getSearchTermViewServiceClient()
+    public function getSearchTermViewServiceClient(): SearchTermViewServiceClient
     {
         return new SearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1006,7 +1027,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SharedCriterionServiceClient
      */
-    public function getSharedCriterionServiceClient()
+    public function getSharedCriterionServiceClient(): SharedCriterionServiceClient
     {
         return new SharedCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1014,7 +1035,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SharedSetServiceClient
      */
-    public function getSharedSetServiceClient()
+    public function getSharedSetServiceClient(): SharedSetServiceClient
     {
         return new SharedSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1022,7 +1043,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ShoppingPerformanceViewServiceClient
      */
-    public function getShoppingPerformanceViewServiceClient()
+    public function getShoppingPerformanceViewServiceClient(): ShoppingPerformanceViewServiceClient
     {
         return new ShoppingPerformanceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1030,31 +1051,31 @@ trait ServiceClientFactoryTrait
     /**
      * @return ThirdPartyAppAnalyticsLinkServiceClient
      */
-    public function getThirdPartyAppAnalyticsLinkServiceClient()
+    public function getThirdPartyAppAnalyticsLinkServiceClient(): ThirdPartyAppAnalyticsLinkServiceClient
     {
         return new ThirdPartyAppAnalyticsLinkServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
-     * @return TopicViewServiceClient
-     */
-    public function getTopicViewServiceClient()
-    {
-        return new TopicViewServiceClient($this->getGoogleAdsClientOptions());
-    }
-
-    /**
      * @return TopicConstantServiceClient
      */
-    public function getTopicConstantServiceClient()
+    public function getTopicConstantServiceClient(): TopicConstantServiceClient
     {
         return new TopicConstantServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return TopicViewServiceClient
+     */
+    public function getTopicViewServiceClient(): TopicViewServiceClient
+    {
+        return new TopicViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return UserDataServiceClient
      */
-    public function getUserDataServiceClient()
+    public function getUserDataServiceClient(): UserDataServiceClient
     {
         return new UserDataServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1062,7 +1083,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserInterestServiceClient
      */
-    public function getUserInterestServiceClient()
+    public function getUserInterestServiceClient(): UserInterestServiceClient
     {
         return new UserInterestServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1070,15 +1091,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserListServiceClient
      */
-    public function getUserListServiceClient()
+    public function getUserListServiceClient(): UserListServiceClient
     {
         return new UserListServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return UserLocationViewServiceClient
+     */
+    public function getUserLocationViewServiceClient(): UserLocationViewServiceClient
+    {
+        return new UserLocationViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return VideoServiceClient
      */
-    public function getVideoServiceClient()
+    public function getVideoServiceClient(): VideoServiceClient
     {
         return new VideoServiceClient($this->getGoogleAdsClientOptions());
     }

--- a/src/Google/Ads/GoogleAds/Lib/V6/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V6/ServiceClientFactoryTrait.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2020 Google LLC
+/**
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Lib\V6;
 
 use Google\Ads\GoogleAds\Lib\ConfigurationTrait;
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V6\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAudienceViewServiceClient;
@@ -77,6 +80,7 @@ use Google\Ads\GoogleAds\V6\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V6\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DomainCategoryServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ExpandedLandingPageViewServiceClient;
@@ -134,6 +138,7 @@ use Google\Ads\GoogleAds\V6\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserDataServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V6\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\VideoServiceClient;
 
 /**
@@ -156,7 +161,7 @@ trait ServiceClientFactoryTrait
      *
      * @return array the client options
      */
-    public function getGoogleAdsClientOptions()
+    public function getGoogleAdsClientOptions(): array
     {
         $clientOptions = [
             self::$CREDENTIALS_LOADER_KEY => $this->getOAuth2Credential(),
@@ -212,7 +217,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountBudgetProposalServiceClient
      */
-    public function getAccountBudgetProposalServiceClient()
+    public function getAccountBudgetProposalServiceClient(): AccountBudgetProposalServiceClient
     {
         return new AccountBudgetProposalServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -220,7 +225,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountBudgetServiceClient
      */
-    public function getAccountBudgetServiceClient()
+    public function getAccountBudgetServiceClient(): AccountBudgetServiceClient
     {
         return new AccountBudgetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -228,15 +233,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountLinkServiceClient
      */
-    public function getAccountLinkServiceClient()
+    public function getAccountLinkServiceClient(): AccountLinkServiceClient
     {
         return new AccountLinkServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return AdGroupAdAssetViewServiceClient
+     */
+    public function getAdGroupAdAssetViewServiceClient(): AdGroupAdAssetViewServiceClient
+    {
+        return new AdGroupAdAssetViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return AdGroupAdLabelServiceClient
      */
-    public function getAdGroupAdLabelServiceClient()
+    public function getAdGroupAdLabelServiceClient(): AdGroupAdLabelServiceClient
     {
         return new AdGroupAdLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -244,7 +257,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupAdServiceClient
      */
-    public function getAdGroupAdServiceClient()
+    public function getAdGroupAdServiceClient(): AdGroupAdServiceClient
     {
         return new AdGroupAdServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -252,7 +265,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupAudienceViewServiceClient
      */
-    public function getAdGroupAudienceViewServiceClient()
+    public function getAdGroupAudienceViewServiceClient(): AdGroupAudienceViewServiceClient
     {
         return new AdGroupAudienceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -260,7 +273,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupBidModifierServiceClient
      */
-    public function getAdGroupBidModifierServiceClient()
+    public function getAdGroupBidModifierServiceClient(): AdGroupBidModifierServiceClient
     {
         return new AdGroupBidModifierServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -268,7 +281,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionLabelServiceClient
      */
-    public function getAdGroupCriterionLabelServiceClient()
+    public function getAdGroupCriterionLabelServiceClient(): AdGroupCriterionLabelServiceClient
     {
         return new AdGroupCriterionLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -276,7 +289,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionServiceClient
      */
-    public function getAdGroupCriterionServiceClient()
+    public function getAdGroupCriterionServiceClient(): AdGroupCriterionServiceClient
     {
         return new AdGroupCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -284,7 +297,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionSimulationServiceClient
      */
-    public function getAdGroupCriterionSimulationServiceClient()
+    public function getAdGroupCriterionSimulationServiceClient(): AdGroupCriterionSimulationServiceClient
     {
         return new AdGroupCriterionSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -292,7 +305,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupExtensionSettingServiceClient
      */
-    public function getAdGroupExtensionSettingServiceClient()
+    public function getAdGroupExtensionSettingServiceClient(): AdGroupExtensionSettingServiceClient
     {
         return new AdGroupExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -300,7 +313,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupFeedServiceClient
      */
-    public function getAdGroupFeedServiceClient()
+    public function getAdGroupFeedServiceClient(): AdGroupFeedServiceClient
     {
         return new AdGroupFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -308,7 +321,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupLabelServiceClient
      */
-    public function getAdGroupLabelServiceClient()
+    public function getAdGroupLabelServiceClient(): AdGroupLabelServiceClient
     {
         return new AdGroupLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -316,7 +329,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupServiceClient
      */
-    public function getAdGroupServiceClient()
+    public function getAdGroupServiceClient(): AdGroupServiceClient
     {
         return new AdGroupServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -324,7 +337,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupSimulationServiceClient
      */
-    public function getAdGroupSimulationServiceClient()
+    public function getAdGroupSimulationServiceClient(): AdGroupSimulationServiceClient
     {
         return new AdGroupSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -332,7 +345,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdParameterServiceClient
      */
-    public function getAdParameterServiceClient()
+    public function getAdParameterServiceClient(): AdParameterServiceClient
     {
         return new AdParameterServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -340,7 +353,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdScheduleViewServiceClient
      */
-    public function getAdScheduleViewServiceClient()
+    public function getAdScheduleViewServiceClient(): AdScheduleViewServiceClient
     {
         return new AdScheduleViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -348,7 +361,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdServiceClient
      */
-    public function getAdServiceClient()
+    public function getAdServiceClient(): AdServiceClient
     {
         return new AdServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -356,7 +369,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AgeRangeViewServiceClient
      */
-    public function getAgeRangeViewServiceClient()
+    public function getAgeRangeViewServiceClient(): AgeRangeViewServiceClient
     {
         return new AgeRangeViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -364,7 +377,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AssetServiceClient
      */
-    public function getAssetServiceClient()
+    public function getAssetServiceClient(): AssetServiceClient
     {
         return new AssetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -372,7 +385,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BatchJobServiceClient
      */
-    public function getBatchJobServiceClient()
+    public function getBatchJobServiceClient(): BatchJobServiceClient
     {
         return new BatchJobServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -380,7 +393,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BiddingStrategyServiceClient
      */
-    public function getBiddingStrategyServiceClient()
+    public function getBiddingStrategyServiceClient(): BiddingStrategyServiceClient
     {
         return new BiddingStrategyServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -388,7 +401,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BillingSetupServiceClient
      */
-    public function getBillingSetupServiceClient()
+    public function getBillingSetupServiceClient(): BillingSetupServiceClient
     {
         return new BillingSetupServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -396,7 +409,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignAssetServiceClient
      */
-    public function getCampaignAssetServiceClient()
+    public function getCampaignAssetServiceClient(): CampaignAssetServiceClient
     {
         return new CampaignAssetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -404,7 +417,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignAudienceViewServiceClient
      */
-    public function getCampaignAudienceViewServiceClient()
+    public function getCampaignAudienceViewServiceClient(): CampaignAudienceViewServiceClient
     {
         return new CampaignAudienceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -412,7 +425,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignBidModifierServiceClient
      */
-    public function getCampaignBidModifierServiceClient()
+    public function getCampaignBidModifierServiceClient(): CampaignBidModifierServiceClient
     {
         return new CampaignBidModifierServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -420,7 +433,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignBudgetServiceClient
      */
-    public function getCampaignBudgetServiceClient()
+    public function getCampaignBudgetServiceClient(): CampaignBudgetServiceClient
     {
         return new CampaignBudgetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -428,7 +441,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignCriterionServiceClient
      */
-    public function getCampaignCriterionServiceClient()
+    public function getCampaignCriterionServiceClient(): CampaignCriterionServiceClient
     {
         return new CampaignCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -436,7 +449,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignCriterionSimulationServiceClient
      */
-    public function getCampaignCriterionSimulationServiceClient()
+    public function getCampaignCriterionSimulationServiceClient(): CampaignCriterionSimulationServiceClient
     {
         return new CampaignCriterionSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -444,7 +457,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignDraftServiceClient
      */
-    public function getCampaignDraftServiceClient()
+    public function getCampaignDraftServiceClient(): CampaignDraftServiceClient
     {
         return new CampaignDraftServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -452,7 +465,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignExperimentServiceClient
      */
-    public function getCampaignExperimentServiceClient()
+    public function getCampaignExperimentServiceClient(): CampaignExperimentServiceClient
     {
         return new CampaignExperimentServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -460,7 +473,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignExtensionSettingServiceClient
      */
-    public function getCampaignExtensionSettingServiceClient()
+    public function getCampaignExtensionSettingServiceClient(): CampaignExtensionSettingServiceClient
     {
         return new CampaignExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -468,7 +481,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignFeedServiceClient
      */
-    public function getCampaignFeedServiceClient()
+    public function getCampaignFeedServiceClient(): CampaignFeedServiceClient
     {
         return new CampaignFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -476,7 +489,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignLabelServiceClient
      */
-    public function getCampaignLabelServiceClient()
+    public function getCampaignLabelServiceClient(): CampaignLabelServiceClient
     {
         return new CampaignLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -484,7 +497,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignServiceClient
      */
-    public function getCampaignServiceClient()
+    public function getCampaignServiceClient(): CampaignServiceClient
     {
         return new CampaignServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -492,7 +505,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignSharedSetServiceClient
      */
-    public function getCampaignSharedSetServiceClient()
+    public function getCampaignSharedSetServiceClient(): CampaignSharedSetServiceClient
     {
         return new CampaignSharedSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -500,7 +513,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CarrierConstantServiceClient
      */
-    public function getCarrierConstantServiceClient()
+    public function getCarrierConstantServiceClient(): CarrierConstantServiceClient
     {
         return new CarrierConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -508,7 +521,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ChangeStatusServiceClient
      */
-    public function getChangeStatusServiceClient()
+    public function getChangeStatusServiceClient(): ChangeStatusServiceClient
     {
         return new ChangeStatusServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -516,7 +529,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ClickViewServiceClient
      */
-    public function getClickViewServiceClient()
+    public function getClickViewServiceClient(): ClickViewServiceClient
     {
         return new ClickViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -524,7 +537,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CombinedAudienceServiceClient
      */
-    public function getCombinedAudienceServiceClient()
+    public function getCombinedAudienceServiceClient(): CombinedAudienceServiceClient
     {
         return new CombinedAudienceServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -532,7 +545,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionActionServiceClient
      */
-    public function getConversionActionServiceClient()
+    public function getConversionActionServiceClient(): ConversionActionServiceClient
     {
         return new ConversionActionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -540,7 +553,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionAdjustmentUploadServiceClient
      */
-    public function getConversionAdjustmentUploadServiceClient()
+    public function getConversionAdjustmentUploadServiceClient(): ConversionAdjustmentUploadServiceClient
     {
         return new ConversionAdjustmentUploadServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -548,7 +561,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionUploadServiceClient
      */
-    public function getConversionUploadServiceClient()
+    public function getConversionUploadServiceClient(): ConversionUploadServiceClient
     {
         return new ConversionUploadServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -556,7 +569,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CurrencyConstantServiceClient
      */
-    public function getCurrencyConstantServiceClient()
+    public function getCurrencyConstantServiceClient(): CurrencyConstantServiceClient
     {
         return new CurrencyConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -564,7 +577,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomAudienceServiceClient
      */
-    public function getCustomAudienceServiceClient()
+    public function getCustomAudienceServiceClient(): CustomAudienceServiceClient
     {
         return new CustomAudienceServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -572,7 +585,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerClientLinkServiceClient
      */
-    public function getCustomerClientLinkServiceClient()
+    public function getCustomerClientLinkServiceClient(): CustomerClientLinkServiceClient
     {
         return new CustomerClientLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -580,7 +593,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerClientServiceClient
      */
-    public function getCustomerClientServiceClient()
+    public function getCustomerClientServiceClient(): CustomerClientServiceClient
     {
         return new CustomerClientServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -588,7 +601,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerExtensionSettingServiceClient
      */
-    public function getCustomerExtensionSettingServiceClient()
+    public function getCustomerExtensionSettingServiceClient(): CustomerExtensionSettingServiceClient
     {
         return new CustomerExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -596,7 +609,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerFeedServiceClient
      */
-    public function getCustomerFeedServiceClient()
+    public function getCustomerFeedServiceClient(): CustomerFeedServiceClient
     {
         return new CustomerFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -604,7 +617,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerLabelServiceClient
      */
-    public function getCustomerLabelServiceClient()
+    public function getCustomerLabelServiceClient(): CustomerLabelServiceClient
     {
         return new CustomerLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -612,7 +625,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerManagerLinkServiceClient
      */
-    public function getCustomerManagerLinkServiceClient()
+    public function getCustomerManagerLinkServiceClient(): CustomerManagerLinkServiceClient
     {
         return new CustomerManagerLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -620,7 +633,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerNegativeCriterionServiceClient
      */
-    public function getCustomerNegativeCriterionServiceClient()
+    public function getCustomerNegativeCriterionServiceClient(): CustomerNegativeCriterionServiceClient
     {
         return new CustomerNegativeCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -628,7 +641,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerServiceClient
      */
-    public function getCustomerServiceClient()
+    public function getCustomerServiceClient(): CustomerServiceClient
     {
         return new CustomerServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -636,7 +649,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerUserAccessInvitationServiceClient
      */
-    public function getCustomerUserAccessInvitationServiceClient()
+    public function getCustomerUserAccessInvitationServiceClient(): CustomerUserAccessInvitationServiceClient
     {
         return new CustomerUserAccessInvitationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -644,7 +657,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerUserAccessServiceClient
      */
-    public function getCustomerUserAccessServiceClient()
+    public function getCustomerUserAccessServiceClient(): CustomerUserAccessServiceClient
     {
         return new CustomerUserAccessServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -652,7 +665,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomInterestServiceClient
      */
-    public function getCustomInterestServiceClient()
+    public function getCustomInterestServiceClient(): CustomInterestServiceClient
     {
         return new CustomInterestServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -660,7 +673,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return DetailPlacementViewServiceClient
      */
-    public function getDetailPlacementViewServiceClient()
+    public function getDetailPlacementViewServiceClient(): DetailPlacementViewServiceClient
     {
         return new DetailPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -668,15 +681,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return DisplayKeywordViewServiceClient
      */
-    public function getDisplayKeywordViewServiceClient()
+    public function getDisplayKeywordViewServiceClient(): DisplayKeywordViewServiceClient
     {
         return new DisplayKeywordViewServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return DistanceViewServiceClient
+     */
+    public function getDistanceViewServiceClient(): DistanceViewServiceClient
+    {
+        return new DistanceViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return DomainCategoryServiceClient
      */
-    public function getDomainCategoryServiceClient()
+    public function getDomainCategoryServiceClient(): DomainCategoryServiceClient
     {
         return new DomainCategoryServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -684,7 +705,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return DynamicSearchAdsSearchTermViewServiceClient
      */
-    public function getDynamicSearchAdsSearchTermViewServiceClient()
+    public function getDynamicSearchAdsSearchTermViewServiceClient(): DynamicSearchAdsSearchTermViewServiceClient
     {
         return new DynamicSearchAdsSearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -692,7 +713,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ExpandedLandingPageViewServiceClient
      */
-    public function getExpandedLandingPageViewServiceClient()
+    public function getExpandedLandingPageViewServiceClient(): ExpandedLandingPageViewServiceClient
     {
         return new ExpandedLandingPageViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -700,7 +721,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ExtensionFeedItemServiceClient
      */
-    public function getExtensionFeedItemServiceClient()
+    public function getExtensionFeedItemServiceClient(): ExtensionFeedItemServiceClient
     {
         return new ExtensionFeedItemServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -708,7 +729,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemServiceClient
      */
-    public function getFeedItemServiceClient()
+    public function getFeedItemServiceClient(): FeedItemServiceClient
     {
         return new FeedItemServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -716,7 +737,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemSetLinkServiceClient
      */
-    public function getFeedItemSetLinkServiceClient()
+    public function getFeedItemSetLinkServiceClient(): FeedItemSetLinkServiceClient
     {
         return new FeedItemSetLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -724,7 +745,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemSetServiceClient
      */
-    public function getFeedItemSetServiceClient()
+    public function getFeedItemSetServiceClient(): FeedItemSetServiceClient
     {
         return new FeedItemSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -732,7 +753,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemTargetServiceClient
      */
-    public function getFeedItemTargetServiceClient()
+    public function getFeedItemTargetServiceClient(): FeedItemTargetServiceClient
     {
         return new FeedItemTargetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -740,7 +761,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedMappingServiceClient
      */
-    public function getFeedMappingServiceClient()
+    public function getFeedMappingServiceClient(): FeedMappingServiceClient
     {
         return new FeedMappingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -748,7 +769,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedPlaceholderViewServiceClient
      */
-    public function getFeedPlaceholderViewServiceClient()
+    public function getFeedPlaceholderViewServiceClient(): FeedPlaceholderViewServiceClient
     {
         return new FeedPlaceholderViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -756,7 +777,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedServiceClient
      */
-    public function getFeedServiceClient()
+    public function getFeedServiceClient(): FeedServiceClient
     {
         return new FeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -764,7 +785,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GenderViewServiceClient
      */
-    public function getGenderViewServiceClient()
+    public function getGenderViewServiceClient(): GenderViewServiceClient
     {
         return new GenderViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -772,7 +793,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GeographicViewServiceClient
      */
-    public function getGeographicViewServiceClient()
+    public function getGeographicViewServiceClient(): GeographicViewServiceClient
     {
         return new GeographicViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -780,7 +801,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GeoTargetConstantServiceClient
      */
-    public function getGeoTargetConstantServiceClient()
+    public function getGeoTargetConstantServiceClient(): GeoTargetConstantServiceClient
     {
         return new GeoTargetConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -788,7 +809,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GoogleAdsFieldServiceClient
      */
-    public function getGoogleAdsFieldServiceClient()
+    public function getGoogleAdsFieldServiceClient(): GoogleAdsFieldServiceClient
     {
         return new GoogleAdsFieldServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -796,7 +817,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GoogleAdsServiceClient
      */
-    public function getGoogleAdsServiceClient()
+    public function getGoogleAdsServiceClient(): GoogleAdsServiceClient
     {
         return new GoogleAdsServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -804,7 +825,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GroupPlacementViewServiceClient
      */
-    public function getGroupPlacementViewServiceClient()
+    public function getGroupPlacementViewServiceClient(): GroupPlacementViewServiceClient
     {
         return new GroupPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -812,7 +833,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return HotelGroupViewServiceClient
      */
-    public function getHotelGroupViewServiceClient()
+    public function getHotelGroupViewServiceClient(): HotelGroupViewServiceClient
     {
         return new HotelGroupViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -820,7 +841,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return HotelPerformanceViewServiceClient
      */
-    public function getHotelPerformanceViewServiceClient()
+    public function getHotelPerformanceViewServiceClient(): HotelPerformanceViewServiceClient
     {
         return new HotelPerformanceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -828,7 +849,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return IncomeRangeViewServiceClient
      */
-    public function getIncomeRangeViewServiceClient()
+    public function getIncomeRangeViewServiceClient(): IncomeRangeViewServiceClient
     {
         return new IncomeRangeViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -836,7 +857,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return InvoiceServiceClient
      */
-    public function getInvoiceServiceClient()
+    public function getInvoiceServiceClient(): InvoiceServiceClient
     {
         return new InvoiceServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -844,7 +865,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanAdGroupKeywordServiceClient
      */
-    public function getKeywordPlanAdGroupKeywordServiceClient()
+    public function getKeywordPlanAdGroupKeywordServiceClient(): KeywordPlanAdGroupKeywordServiceClient
     {
         return new KeywordPlanAdGroupKeywordServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -852,7 +873,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanAdGroupServiceClient
      */
-    public function getKeywordPlanAdGroupServiceClient()
+    public function getKeywordPlanAdGroupServiceClient(): KeywordPlanAdGroupServiceClient
     {
         return new KeywordPlanAdGroupServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -860,7 +881,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanCampaignKeywordServiceClient
      */
-    public function getKeywordPlanCampaignKeywordServiceClient()
+    public function getKeywordPlanCampaignKeywordServiceClient(): KeywordPlanCampaignKeywordServiceClient
     {
         return new KeywordPlanCampaignKeywordServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -868,7 +889,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanCampaignServiceClient
      */
-    public function getKeywordPlanCampaignServiceClient()
+    public function getKeywordPlanCampaignServiceClient(): KeywordPlanCampaignServiceClient
     {
         return new KeywordPlanCampaignServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -876,7 +897,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanIdeaServiceClient
      */
-    public function getKeywordPlanIdeaServiceClient()
+    public function getKeywordPlanIdeaServiceClient(): KeywordPlanIdeaServiceClient
     {
         return new KeywordPlanIdeaServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -884,7 +905,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanServiceClient
      */
-    public function getKeywordPlanServiceClient()
+    public function getKeywordPlanServiceClient(): KeywordPlanServiceClient
     {
         return new KeywordPlanServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -892,7 +913,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordViewServiceClient
      */
-    public function getKeywordViewServiceClient()
+    public function getKeywordViewServiceClient(): KeywordViewServiceClient
     {
         return new KeywordViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -900,7 +921,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LabelServiceClient
      */
-    public function getLabelServiceClient()
+    public function getLabelServiceClient(): LabelServiceClient
     {
         return new LabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -908,7 +929,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LandingPageViewServiceClient
      */
-    public function getLandingPageViewServiceClient()
+    public function getLandingPageViewServiceClient(): LandingPageViewServiceClient
     {
         return new LandingPageViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -916,7 +937,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LanguageConstantServiceClient
      */
-    public function getLanguageConstantServiceClient()
+    public function getLanguageConstantServiceClient(): LanguageConstantServiceClient
     {
         return new LanguageConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -924,7 +945,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LocationViewServiceClient
      */
-    public function getLocationViewServiceClient()
+    public function getLocationViewServiceClient(): LocationViewServiceClient
     {
         return new LocationViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -932,7 +953,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ManagedPlacementViewServiceClient
      */
-    public function getManagedPlacementViewServiceClient()
+    public function getManagedPlacementViewServiceClient(): ManagedPlacementViewServiceClient
     {
         return new ManagedPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -940,7 +961,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MediaFileServiceClient
      */
-    public function getMediaFileServiceClient()
+    public function getMediaFileServiceClient(): MediaFileServiceClient
     {
         return new MediaFileServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -948,7 +969,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MerchantCenterLinkServiceClient
      */
-    public function getMerchantCenterLinkServiceClient()
+    public function getMerchantCenterLinkServiceClient(): MerchantCenterLinkServiceClient
     {
         return new MerchantCenterLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -956,7 +977,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MobileAppCategoryConstantServiceClient
      */
-    public function getMobileAppCategoryConstantServiceClient()
+    public function getMobileAppCategoryConstantServiceClient(): MobileAppCategoryConstantServiceClient
     {
         return new MobileAppCategoryConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -964,7 +985,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MobileDeviceConstantServiceClient
      */
-    public function getMobileDeviceConstantServiceClient()
+    public function getMobileDeviceConstantServiceClient(): MobileDeviceConstantServiceClient
     {
         return new MobileDeviceConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -972,7 +993,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return OfflineUserDataJobServiceClient
      */
-    public function getOfflineUserDataJobServiceClient()
+    public function getOfflineUserDataJobServiceClient(): OfflineUserDataJobServiceClient
     {
         return new OfflineUserDataJobServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -980,7 +1001,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return OperatingSystemVersionConstantServiceClient
      */
-    public function getOperatingSystemVersionConstantServiceClient()
+    public function getOperatingSystemVersionConstantServiceClient(): OperatingSystemVersionConstantServiceClient
     {
         return new OperatingSystemVersionConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -988,7 +1009,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return PaidOrganicSearchTermViewServiceClient
      */
-    public function getPaidOrganicSearchTermViewServiceClient()
+    public function getPaidOrganicSearchTermViewServiceClient(): PaidOrganicSearchTermViewServiceClient
     {
         return new PaidOrganicSearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -996,7 +1017,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ParentalStatusViewServiceClient
      */
-    public function getParentalStatusViewServiceClient()
+    public function getParentalStatusViewServiceClient(): ParentalStatusViewServiceClient
     {
         return new ParentalStatusViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1004,7 +1025,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return PaymentsAccountServiceClient
      */
-    public function getPaymentsAccountServiceClient()
+    public function getPaymentsAccountServiceClient(): PaymentsAccountServiceClient
     {
         return new PaymentsAccountServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1012,7 +1033,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ProductBiddingCategoryConstantServiceClient
      */
-    public function getProductBiddingCategoryConstantServiceClient()
+    public function getProductBiddingCategoryConstantServiceClient(): ProductBiddingCategoryConstantServiceClient
     {
         return new ProductBiddingCategoryConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1020,7 +1041,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ProductGroupViewServiceClient
      */
-    public function getProductGroupViewServiceClient()
+    public function getProductGroupViewServiceClient(): ProductGroupViewServiceClient
     {
         return new ProductGroupViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1028,7 +1049,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ReachPlanServiceClient
      */
-    public function getReachPlanServiceClient()
+    public function getReachPlanServiceClient(): ReachPlanServiceClient
     {
         return new ReachPlanServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1036,7 +1057,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return RecommendationServiceClient
      */
-    public function getRecommendationServiceClient()
+    public function getRecommendationServiceClient(): RecommendationServiceClient
     {
         return new RecommendationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1044,7 +1065,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return RemarketingActionServiceClient
      */
-    public function getRemarketingActionServiceClient()
+    public function getRemarketingActionServiceClient(): RemarketingActionServiceClient
     {
         return new RemarketingActionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1052,7 +1073,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SearchTermViewServiceClient
      */
-    public function getSearchTermViewServiceClient()
+    public function getSearchTermViewServiceClient(): SearchTermViewServiceClient
     {
         return new SearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1060,7 +1081,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SharedCriterionServiceClient
      */
-    public function getSharedCriterionServiceClient()
+    public function getSharedCriterionServiceClient(): SharedCriterionServiceClient
     {
         return new SharedCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1068,7 +1089,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SharedSetServiceClient
      */
-    public function getSharedSetServiceClient()
+    public function getSharedSetServiceClient(): SharedSetServiceClient
     {
         return new SharedSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1076,7 +1097,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ShoppingPerformanceViewServiceClient
      */
-    public function getShoppingPerformanceViewServiceClient()
+    public function getShoppingPerformanceViewServiceClient(): ShoppingPerformanceViewServiceClient
     {
         return new ShoppingPerformanceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1084,7 +1105,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ThirdPartyAppAnalyticsLinkServiceClient
      */
-    public function getThirdPartyAppAnalyticsLinkServiceClient()
+    public function getThirdPartyAppAnalyticsLinkServiceClient(): ThirdPartyAppAnalyticsLinkServiceClient
     {
         return new ThirdPartyAppAnalyticsLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1092,7 +1113,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return TopicConstantServiceClient
      */
-    public function getTopicConstantServiceClient()
+    public function getTopicConstantServiceClient(): TopicConstantServiceClient
     {
         return new TopicConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1100,7 +1121,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return TopicViewServiceClient
      */
-    public function getTopicViewServiceClient()
+    public function getTopicViewServiceClient(): TopicViewServiceClient
     {
         return new TopicViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1108,7 +1129,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserDataServiceClient
      */
-    public function getUserDataServiceClient()
+    public function getUserDataServiceClient(): UserDataServiceClient
     {
         return new UserDataServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1116,7 +1137,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserInterestServiceClient
      */
-    public function getUserInterestServiceClient()
+    public function getUserInterestServiceClient(): UserInterestServiceClient
     {
         return new UserInterestServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1124,15 +1145,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserListServiceClient
      */
-    public function getUserListServiceClient()
+    public function getUserListServiceClient(): UserListServiceClient
     {
         return new UserListServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return UserLocationViewServiceClient
+     */
+    public function getUserLocationViewServiceClient(): UserLocationViewServiceClient
+    {
+        return new UserLocationViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return VideoServiceClient
      */
-    public function getVideoServiceClient()
+    public function getVideoServiceClient(): VideoServiceClient
     {
         return new VideoServiceClient($this->getGoogleAdsClientOptions());
     }

--- a/src/Google/Ads/GoogleAds/Lib/V7/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/V7/ServiceClientFactoryTrait.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2020 Google LLC
+/**
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Lib\V7;
 
 use Google\Ads\GoogleAds\Lib\ConfigurationTrait;
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V7\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAssetServiceClient;
@@ -82,6 +85,7 @@ use Google\Ads\GoogleAds\V7\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V7\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DomainCategoryServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ExpandedLandingPageViewServiceClient;
@@ -140,6 +144,7 @@ use Google\Ads\GoogleAds\V7\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserDataServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V7\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\VideoServiceClient;
 use Google\Ads\GoogleAds\V7\Services\WebpageViewServiceClient;
 
@@ -163,7 +168,7 @@ trait ServiceClientFactoryTrait
      *
      * @return array the client options
      */
-    public function getGoogleAdsClientOptions()
+    public function getGoogleAdsClientOptions(): array
     {
         $clientOptions = [
             self::$CREDENTIALS_LOADER_KEY => $this->getOAuth2Credential(),
@@ -219,7 +224,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountBudgetProposalServiceClient
      */
-    public function getAccountBudgetProposalServiceClient()
+    public function getAccountBudgetProposalServiceClient(): AccountBudgetProposalServiceClient
     {
         return new AccountBudgetProposalServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -227,7 +232,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountBudgetServiceClient
      */
-    public function getAccountBudgetServiceClient()
+    public function getAccountBudgetServiceClient(): AccountBudgetServiceClient
     {
         return new AccountBudgetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -235,15 +240,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return AccountLinkServiceClient
      */
-    public function getAccountLinkServiceClient()
+    public function getAccountLinkServiceClient(): AccountLinkServiceClient
     {
         return new AccountLinkServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return AdGroupAdAssetViewServiceClient
+     */
+    public function getAdGroupAdAssetViewServiceClient(): AdGroupAdAssetViewServiceClient
+    {
+        return new AdGroupAdAssetViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return AdGroupAdLabelServiceClient
      */
-    public function getAdGroupAdLabelServiceClient()
+    public function getAdGroupAdLabelServiceClient(): AdGroupAdLabelServiceClient
     {
         return new AdGroupAdLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -251,7 +264,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupAdServiceClient
      */
-    public function getAdGroupAdServiceClient()
+    public function getAdGroupAdServiceClient(): AdGroupAdServiceClient
     {
         return new AdGroupAdServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -259,7 +272,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupAssetServiceClient
      */
-    public function getAdGroupAssetServiceClient()
+    public function getAdGroupAssetServiceClient(): AdGroupAssetServiceClient
     {
         return new AdGroupAssetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -267,7 +280,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupAudienceViewServiceClient
      */
-    public function getAdGroupAudienceViewServiceClient()
+    public function getAdGroupAudienceViewServiceClient(): AdGroupAudienceViewServiceClient
     {
         return new AdGroupAudienceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -275,7 +288,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupBidModifierServiceClient
      */
-    public function getAdGroupBidModifierServiceClient()
+    public function getAdGroupBidModifierServiceClient(): AdGroupBidModifierServiceClient
     {
         return new AdGroupBidModifierServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -283,7 +296,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionLabelServiceClient
      */
-    public function getAdGroupCriterionLabelServiceClient()
+    public function getAdGroupCriterionLabelServiceClient(): AdGroupCriterionLabelServiceClient
     {
         return new AdGroupCriterionLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -291,7 +304,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionServiceClient
      */
-    public function getAdGroupCriterionServiceClient()
+    public function getAdGroupCriterionServiceClient(): AdGroupCriterionServiceClient
     {
         return new AdGroupCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -299,7 +312,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupCriterionSimulationServiceClient
      */
-    public function getAdGroupCriterionSimulationServiceClient()
+    public function getAdGroupCriterionSimulationServiceClient(): AdGroupCriterionSimulationServiceClient
     {
         return new AdGroupCriterionSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -307,7 +320,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupExtensionSettingServiceClient
      */
-    public function getAdGroupExtensionSettingServiceClient()
+    public function getAdGroupExtensionSettingServiceClient(): AdGroupExtensionSettingServiceClient
     {
         return new AdGroupExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -315,7 +328,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupFeedServiceClient
      */
-    public function getAdGroupFeedServiceClient()
+    public function getAdGroupFeedServiceClient(): AdGroupFeedServiceClient
     {
         return new AdGroupFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -323,7 +336,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupLabelServiceClient
      */
-    public function getAdGroupLabelServiceClient()
+    public function getAdGroupLabelServiceClient(): AdGroupLabelServiceClient
     {
         return new AdGroupLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -331,7 +344,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupServiceClient
      */
-    public function getAdGroupServiceClient()
+    public function getAdGroupServiceClient(): AdGroupServiceClient
     {
         return new AdGroupServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -339,7 +352,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdGroupSimulationServiceClient
      */
-    public function getAdGroupSimulationServiceClient()
+    public function getAdGroupSimulationServiceClient(): AdGroupSimulationServiceClient
     {
         return new AdGroupSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -347,7 +360,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdParameterServiceClient
      */
-    public function getAdParameterServiceClient()
+    public function getAdParameterServiceClient(): AdParameterServiceClient
     {
         return new AdParameterServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -355,7 +368,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdScheduleViewServiceClient
      */
-    public function getAdScheduleViewServiceClient()
+    public function getAdScheduleViewServiceClient(): AdScheduleViewServiceClient
     {
         return new AdScheduleViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -363,7 +376,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AdServiceClient
      */
-    public function getAdServiceClient()
+    public function getAdServiceClient(): AdServiceClient
     {
         return new AdServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -371,7 +384,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AgeRangeViewServiceClient
      */
-    public function getAgeRangeViewServiceClient()
+    public function getAgeRangeViewServiceClient(): AgeRangeViewServiceClient
     {
         return new AgeRangeViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -379,7 +392,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return AssetServiceClient
      */
-    public function getAssetServiceClient()
+    public function getAssetServiceClient(): AssetServiceClient
     {
         return new AssetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -387,7 +400,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BatchJobServiceClient
      */
-    public function getBatchJobServiceClient()
+    public function getBatchJobServiceClient(): BatchJobServiceClient
     {
         return new BatchJobServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -395,7 +408,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BiddingStrategyServiceClient
      */
-    public function getBiddingStrategyServiceClient()
+    public function getBiddingStrategyServiceClient(): BiddingStrategyServiceClient
     {
         return new BiddingStrategyServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -403,7 +416,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BiddingStrategySimulationServiceClient
      */
-    public function getBiddingStrategySimulationServiceClient()
+    public function getBiddingStrategySimulationServiceClient(): BiddingStrategySimulationServiceClient
     {
         return new BiddingStrategySimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -411,7 +424,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return BillingSetupServiceClient
      */
-    public function getBillingSetupServiceClient()
+    public function getBillingSetupServiceClient(): BillingSetupServiceClient
     {
         return new BillingSetupServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -419,7 +432,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignAssetServiceClient
      */
-    public function getCampaignAssetServiceClient()
+    public function getCampaignAssetServiceClient(): CampaignAssetServiceClient
     {
         return new CampaignAssetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -427,7 +440,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignAudienceViewServiceClient
      */
-    public function getCampaignAudienceViewServiceClient()
+    public function getCampaignAudienceViewServiceClient(): CampaignAudienceViewServiceClient
     {
         return new CampaignAudienceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -435,7 +448,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignBidModifierServiceClient
      */
-    public function getCampaignBidModifierServiceClient()
+    public function getCampaignBidModifierServiceClient(): CampaignBidModifierServiceClient
     {
         return new CampaignBidModifierServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -443,7 +456,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignBudgetServiceClient
      */
-    public function getCampaignBudgetServiceClient()
+    public function getCampaignBudgetServiceClient(): CampaignBudgetServiceClient
     {
         return new CampaignBudgetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -451,7 +464,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignCriterionServiceClient
      */
-    public function getCampaignCriterionServiceClient()
+    public function getCampaignCriterionServiceClient(): CampaignCriterionServiceClient
     {
         return new CampaignCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -459,7 +472,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignCriterionSimulationServiceClient
      */
-    public function getCampaignCriterionSimulationServiceClient()
+    public function getCampaignCriterionSimulationServiceClient(): CampaignCriterionSimulationServiceClient
     {
         return new CampaignCriterionSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -467,7 +480,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignDraftServiceClient
      */
-    public function getCampaignDraftServiceClient()
+    public function getCampaignDraftServiceClient(): CampaignDraftServiceClient
     {
         return new CampaignDraftServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -475,7 +488,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignExperimentServiceClient
      */
-    public function getCampaignExperimentServiceClient()
+    public function getCampaignExperimentServiceClient(): CampaignExperimentServiceClient
     {
         return new CampaignExperimentServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -483,7 +496,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignExtensionSettingServiceClient
      */
-    public function getCampaignExtensionSettingServiceClient()
+    public function getCampaignExtensionSettingServiceClient(): CampaignExtensionSettingServiceClient
     {
         return new CampaignExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -491,7 +504,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignFeedServiceClient
      */
-    public function getCampaignFeedServiceClient()
+    public function getCampaignFeedServiceClient(): CampaignFeedServiceClient
     {
         return new CampaignFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -499,7 +512,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignLabelServiceClient
      */
-    public function getCampaignLabelServiceClient()
+    public function getCampaignLabelServiceClient(): CampaignLabelServiceClient
     {
         return new CampaignLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -507,7 +520,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignServiceClient
      */
-    public function getCampaignServiceClient()
+    public function getCampaignServiceClient(): CampaignServiceClient
     {
         return new CampaignServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -515,7 +528,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignSharedSetServiceClient
      */
-    public function getCampaignSharedSetServiceClient()
+    public function getCampaignSharedSetServiceClient(): CampaignSharedSetServiceClient
     {
         return new CampaignSharedSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -523,7 +536,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CampaignSimulationServiceClient
      */
-    public function getCampaignSimulationServiceClient()
+    public function getCampaignSimulationServiceClient(): CampaignSimulationServiceClient
     {
         return new CampaignSimulationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -531,7 +544,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CarrierConstantServiceClient
      */
-    public function getCarrierConstantServiceClient()
+    public function getCarrierConstantServiceClient(): CarrierConstantServiceClient
     {
         return new CarrierConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -539,7 +552,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ChangeStatusServiceClient
      */
-    public function getChangeStatusServiceClient()
+    public function getChangeStatusServiceClient(): ChangeStatusServiceClient
     {
         return new ChangeStatusServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -547,7 +560,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ClickViewServiceClient
      */
-    public function getClickViewServiceClient()
+    public function getClickViewServiceClient(): ClickViewServiceClient
     {
         return new ClickViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -555,7 +568,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CombinedAudienceServiceClient
      */
-    public function getCombinedAudienceServiceClient()
+    public function getCombinedAudienceServiceClient(): CombinedAudienceServiceClient
     {
         return new CombinedAudienceServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -563,7 +576,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionActionServiceClient
      */
-    public function getConversionActionServiceClient()
+    public function getConversionActionServiceClient(): ConversionActionServiceClient
     {
         return new ConversionActionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -571,7 +584,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionAdjustmentUploadServiceClient
      */
-    public function getConversionAdjustmentUploadServiceClient()
+    public function getConversionAdjustmentUploadServiceClient(): ConversionAdjustmentUploadServiceClient
     {
         return new ConversionAdjustmentUploadServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -579,7 +592,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionCustomVariableServiceClient
      */
-    public function getConversionCustomVariableServiceClient()
+    public function getConversionCustomVariableServiceClient(): ConversionCustomVariableServiceClient
     {
         return new ConversionCustomVariableServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -587,7 +600,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ConversionUploadServiceClient
      */
-    public function getConversionUploadServiceClient()
+    public function getConversionUploadServiceClient(): ConversionUploadServiceClient
     {
         return new ConversionUploadServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -595,7 +608,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CurrencyConstantServiceClient
      */
-    public function getCurrencyConstantServiceClient()
+    public function getCurrencyConstantServiceClient(): CurrencyConstantServiceClient
     {
         return new CurrencyConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -603,7 +616,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomAudienceServiceClient
      */
-    public function getCustomAudienceServiceClient()
+    public function getCustomAudienceServiceClient(): CustomAudienceServiceClient
     {
         return new CustomAudienceServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -611,7 +624,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerAssetServiceClient
      */
-    public function getCustomerAssetServiceClient()
+    public function getCustomerAssetServiceClient(): CustomerAssetServiceClient
     {
         return new CustomerAssetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -619,7 +632,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerClientLinkServiceClient
      */
-    public function getCustomerClientLinkServiceClient()
+    public function getCustomerClientLinkServiceClient(): CustomerClientLinkServiceClient
     {
         return new CustomerClientLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -627,7 +640,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerClientServiceClient
      */
-    public function getCustomerClientServiceClient()
+    public function getCustomerClientServiceClient(): CustomerClientServiceClient
     {
         return new CustomerClientServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -635,7 +648,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerExtensionSettingServiceClient
      */
-    public function getCustomerExtensionSettingServiceClient()
+    public function getCustomerExtensionSettingServiceClient(): CustomerExtensionSettingServiceClient
     {
         return new CustomerExtensionSettingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -643,7 +656,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerFeedServiceClient
      */
-    public function getCustomerFeedServiceClient()
+    public function getCustomerFeedServiceClient(): CustomerFeedServiceClient
     {
         return new CustomerFeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -651,7 +664,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerLabelServiceClient
      */
-    public function getCustomerLabelServiceClient()
+    public function getCustomerLabelServiceClient(): CustomerLabelServiceClient
     {
         return new CustomerLabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -659,7 +672,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerManagerLinkServiceClient
      */
-    public function getCustomerManagerLinkServiceClient()
+    public function getCustomerManagerLinkServiceClient(): CustomerManagerLinkServiceClient
     {
         return new CustomerManagerLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -667,7 +680,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerNegativeCriterionServiceClient
      */
-    public function getCustomerNegativeCriterionServiceClient()
+    public function getCustomerNegativeCriterionServiceClient(): CustomerNegativeCriterionServiceClient
     {
         return new CustomerNegativeCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -675,7 +688,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerServiceClient
      */
-    public function getCustomerServiceClient()
+    public function getCustomerServiceClient(): CustomerServiceClient
     {
         return new CustomerServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -683,7 +696,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerUserAccessInvitationServiceClient
      */
-    public function getCustomerUserAccessInvitationServiceClient()
+    public function getCustomerUserAccessInvitationServiceClient(): CustomerUserAccessInvitationServiceClient
     {
         return new CustomerUserAccessInvitationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -691,7 +704,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomerUserAccessServiceClient
      */
-    public function getCustomerUserAccessServiceClient()
+    public function getCustomerUserAccessServiceClient(): CustomerUserAccessServiceClient
     {
         return new CustomerUserAccessServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -699,7 +712,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return CustomInterestServiceClient
      */
-    public function getCustomInterestServiceClient()
+    public function getCustomInterestServiceClient(): CustomInterestServiceClient
     {
         return new CustomInterestServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -707,7 +720,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return DetailPlacementViewServiceClient
      */
-    public function getDetailPlacementViewServiceClient()
+    public function getDetailPlacementViewServiceClient(): DetailPlacementViewServiceClient
     {
         return new DetailPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -715,15 +728,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return DisplayKeywordViewServiceClient
      */
-    public function getDisplayKeywordViewServiceClient()
+    public function getDisplayKeywordViewServiceClient(): DisplayKeywordViewServiceClient
     {
         return new DisplayKeywordViewServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return DistanceViewServiceClient
+     */
+    public function getDistanceViewServiceClient(): DistanceViewServiceClient
+    {
+        return new DistanceViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return DomainCategoryServiceClient
      */
-    public function getDomainCategoryServiceClient()
+    public function getDomainCategoryServiceClient(): DomainCategoryServiceClient
     {
         return new DomainCategoryServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -731,7 +752,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return DynamicSearchAdsSearchTermViewServiceClient
      */
-    public function getDynamicSearchAdsSearchTermViewServiceClient()
+    public function getDynamicSearchAdsSearchTermViewServiceClient(): DynamicSearchAdsSearchTermViewServiceClient
     {
         return new DynamicSearchAdsSearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -739,7 +760,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ExpandedLandingPageViewServiceClient
      */
-    public function getExpandedLandingPageViewServiceClient()
+    public function getExpandedLandingPageViewServiceClient(): ExpandedLandingPageViewServiceClient
     {
         return new ExpandedLandingPageViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -747,7 +768,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ExtensionFeedItemServiceClient
      */
-    public function getExtensionFeedItemServiceClient()
+    public function getExtensionFeedItemServiceClient(): ExtensionFeedItemServiceClient
     {
         return new ExtensionFeedItemServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -755,7 +776,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemServiceClient
      */
-    public function getFeedItemServiceClient()
+    public function getFeedItemServiceClient(): FeedItemServiceClient
     {
         return new FeedItemServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -763,7 +784,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemSetLinkServiceClient
      */
-    public function getFeedItemSetLinkServiceClient()
+    public function getFeedItemSetLinkServiceClient(): FeedItemSetLinkServiceClient
     {
         return new FeedItemSetLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -771,7 +792,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemSetServiceClient
      */
-    public function getFeedItemSetServiceClient()
+    public function getFeedItemSetServiceClient(): FeedItemSetServiceClient
     {
         return new FeedItemSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -779,7 +800,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedItemTargetServiceClient
      */
-    public function getFeedItemTargetServiceClient()
+    public function getFeedItemTargetServiceClient(): FeedItemTargetServiceClient
     {
         return new FeedItemTargetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -787,7 +808,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedMappingServiceClient
      */
-    public function getFeedMappingServiceClient()
+    public function getFeedMappingServiceClient(): FeedMappingServiceClient
     {
         return new FeedMappingServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -795,7 +816,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedPlaceholderViewServiceClient
      */
-    public function getFeedPlaceholderViewServiceClient()
+    public function getFeedPlaceholderViewServiceClient(): FeedPlaceholderViewServiceClient
     {
         return new FeedPlaceholderViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -803,7 +824,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return FeedServiceClient
      */
-    public function getFeedServiceClient()
+    public function getFeedServiceClient(): FeedServiceClient
     {
         return new FeedServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -811,7 +832,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GenderViewServiceClient
      */
-    public function getGenderViewServiceClient()
+    public function getGenderViewServiceClient(): GenderViewServiceClient
     {
         return new GenderViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -819,7 +840,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GeographicViewServiceClient
      */
-    public function getGeographicViewServiceClient()
+    public function getGeographicViewServiceClient(): GeographicViewServiceClient
     {
         return new GeographicViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -827,7 +848,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GeoTargetConstantServiceClient
      */
-    public function getGeoTargetConstantServiceClient()
+    public function getGeoTargetConstantServiceClient(): GeoTargetConstantServiceClient
     {
         return new GeoTargetConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -835,7 +856,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GoogleAdsFieldServiceClient
      */
-    public function getGoogleAdsFieldServiceClient()
+    public function getGoogleAdsFieldServiceClient(): GoogleAdsFieldServiceClient
     {
         return new GoogleAdsFieldServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -843,7 +864,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GoogleAdsServiceClient
      */
-    public function getGoogleAdsServiceClient()
+    public function getGoogleAdsServiceClient(): GoogleAdsServiceClient
     {
         return new GoogleAdsServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -851,7 +872,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return GroupPlacementViewServiceClient
      */
-    public function getGroupPlacementViewServiceClient()
+    public function getGroupPlacementViewServiceClient(): GroupPlacementViewServiceClient
     {
         return new GroupPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -859,7 +880,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return HotelGroupViewServiceClient
      */
-    public function getHotelGroupViewServiceClient()
+    public function getHotelGroupViewServiceClient(): HotelGroupViewServiceClient
     {
         return new HotelGroupViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -867,7 +888,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return HotelPerformanceViewServiceClient
      */
-    public function getHotelPerformanceViewServiceClient()
+    public function getHotelPerformanceViewServiceClient(): HotelPerformanceViewServiceClient
     {
         return new HotelPerformanceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -875,7 +896,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return IncomeRangeViewServiceClient
      */
-    public function getIncomeRangeViewServiceClient()
+    public function getIncomeRangeViewServiceClient(): IncomeRangeViewServiceClient
     {
         return new IncomeRangeViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -883,7 +904,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return InvoiceServiceClient
      */
-    public function getInvoiceServiceClient()
+    public function getInvoiceServiceClient(): InvoiceServiceClient
     {
         return new InvoiceServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -891,7 +912,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanAdGroupKeywordServiceClient
      */
-    public function getKeywordPlanAdGroupKeywordServiceClient()
+    public function getKeywordPlanAdGroupKeywordServiceClient(): KeywordPlanAdGroupKeywordServiceClient
     {
         return new KeywordPlanAdGroupKeywordServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -899,7 +920,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanAdGroupServiceClient
      */
-    public function getKeywordPlanAdGroupServiceClient()
+    public function getKeywordPlanAdGroupServiceClient(): KeywordPlanAdGroupServiceClient
     {
         return new KeywordPlanAdGroupServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -907,7 +928,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanCampaignKeywordServiceClient
      */
-    public function getKeywordPlanCampaignKeywordServiceClient()
+    public function getKeywordPlanCampaignKeywordServiceClient(): KeywordPlanCampaignKeywordServiceClient
     {
         return new KeywordPlanCampaignKeywordServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -915,7 +936,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanCampaignServiceClient
      */
-    public function getKeywordPlanCampaignServiceClient()
+    public function getKeywordPlanCampaignServiceClient(): KeywordPlanCampaignServiceClient
     {
         return new KeywordPlanCampaignServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -923,7 +944,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanIdeaServiceClient
      */
-    public function getKeywordPlanIdeaServiceClient()
+    public function getKeywordPlanIdeaServiceClient(): KeywordPlanIdeaServiceClient
     {
         return new KeywordPlanIdeaServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -931,7 +952,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordPlanServiceClient
      */
-    public function getKeywordPlanServiceClient()
+    public function getKeywordPlanServiceClient(): KeywordPlanServiceClient
     {
         return new KeywordPlanServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -939,7 +960,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return KeywordViewServiceClient
      */
-    public function getKeywordViewServiceClient()
+    public function getKeywordViewServiceClient(): KeywordViewServiceClient
     {
         return new KeywordViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -947,7 +968,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LabelServiceClient
      */
-    public function getLabelServiceClient()
+    public function getLabelServiceClient(): LabelServiceClient
     {
         return new LabelServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -955,7 +976,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LandingPageViewServiceClient
      */
-    public function getLandingPageViewServiceClient()
+    public function getLandingPageViewServiceClient(): LandingPageViewServiceClient
     {
         return new LandingPageViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -963,7 +984,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LanguageConstantServiceClient
      */
-    public function getLanguageConstantServiceClient()
+    public function getLanguageConstantServiceClient(): LanguageConstantServiceClient
     {
         return new LanguageConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -971,7 +992,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LifeEventServiceClient
      */
-    public function getLifeEventServiceClient()
+    public function getLifeEventServiceClient(): LifeEventServiceClient
     {
         return new LifeEventServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -979,7 +1000,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return LocationViewServiceClient
      */
-    public function getLocationViewServiceClient()
+    public function getLocationViewServiceClient(): LocationViewServiceClient
     {
         return new LocationViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -987,7 +1008,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ManagedPlacementViewServiceClient
      */
-    public function getManagedPlacementViewServiceClient()
+    public function getManagedPlacementViewServiceClient(): ManagedPlacementViewServiceClient
     {
         return new ManagedPlacementViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -995,7 +1016,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MediaFileServiceClient
      */
-    public function getMediaFileServiceClient()
+    public function getMediaFileServiceClient(): MediaFileServiceClient
     {
         return new MediaFileServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1003,7 +1024,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MerchantCenterLinkServiceClient
      */
-    public function getMerchantCenterLinkServiceClient()
+    public function getMerchantCenterLinkServiceClient(): MerchantCenterLinkServiceClient
     {
         return new MerchantCenterLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1011,7 +1032,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MobileAppCategoryConstantServiceClient
      */
-    public function getMobileAppCategoryConstantServiceClient()
+    public function getMobileAppCategoryConstantServiceClient(): MobileAppCategoryConstantServiceClient
     {
         return new MobileAppCategoryConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1019,7 +1040,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return MobileDeviceConstantServiceClient
      */
-    public function getMobileDeviceConstantServiceClient()
+    public function getMobileDeviceConstantServiceClient(): MobileDeviceConstantServiceClient
     {
         return new MobileDeviceConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1027,7 +1048,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return OfflineUserDataJobServiceClient
      */
-    public function getOfflineUserDataJobServiceClient()
+    public function getOfflineUserDataJobServiceClient(): OfflineUserDataJobServiceClient
     {
         return new OfflineUserDataJobServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1035,7 +1056,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return OperatingSystemVersionConstantServiceClient
      */
-    public function getOperatingSystemVersionConstantServiceClient()
+    public function getOperatingSystemVersionConstantServiceClient(): OperatingSystemVersionConstantServiceClient
     {
         return new OperatingSystemVersionConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1043,7 +1064,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return PaidOrganicSearchTermViewServiceClient
      */
-    public function getPaidOrganicSearchTermViewServiceClient()
+    public function getPaidOrganicSearchTermViewServiceClient(): PaidOrganicSearchTermViewServiceClient
     {
         return new PaidOrganicSearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1051,7 +1072,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ParentalStatusViewServiceClient
      */
-    public function getParentalStatusViewServiceClient()
+    public function getParentalStatusViewServiceClient(): ParentalStatusViewServiceClient
     {
         return new ParentalStatusViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1059,7 +1080,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return PaymentsAccountServiceClient
      */
-    public function getPaymentsAccountServiceClient()
+    public function getPaymentsAccountServiceClient(): PaymentsAccountServiceClient
     {
         return new PaymentsAccountServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1067,7 +1088,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ProductBiddingCategoryConstantServiceClient
      */
-    public function getProductBiddingCategoryConstantServiceClient()
+    public function getProductBiddingCategoryConstantServiceClient(): ProductBiddingCategoryConstantServiceClient
     {
         return new ProductBiddingCategoryConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1075,7 +1096,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ProductGroupViewServiceClient
      */
-    public function getProductGroupViewServiceClient()
+    public function getProductGroupViewServiceClient(): ProductGroupViewServiceClient
     {
         return new ProductGroupViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1083,7 +1104,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ReachPlanServiceClient
      */
-    public function getReachPlanServiceClient()
+    public function getReachPlanServiceClient(): ReachPlanServiceClient
     {
         return new ReachPlanServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1091,7 +1112,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return RecommendationServiceClient
      */
-    public function getRecommendationServiceClient()
+    public function getRecommendationServiceClient(): RecommendationServiceClient
     {
         return new RecommendationServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1099,7 +1120,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return RemarketingActionServiceClient
      */
-    public function getRemarketingActionServiceClient()
+    public function getRemarketingActionServiceClient(): RemarketingActionServiceClient
     {
         return new RemarketingActionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1107,7 +1128,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SearchTermViewServiceClient
      */
-    public function getSearchTermViewServiceClient()
+    public function getSearchTermViewServiceClient(): SearchTermViewServiceClient
     {
         return new SearchTermViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1115,7 +1136,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SharedCriterionServiceClient
      */
-    public function getSharedCriterionServiceClient()
+    public function getSharedCriterionServiceClient(): SharedCriterionServiceClient
     {
         return new SharedCriterionServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1123,7 +1144,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return SharedSetServiceClient
      */
-    public function getSharedSetServiceClient()
+    public function getSharedSetServiceClient(): SharedSetServiceClient
     {
         return new SharedSetServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1131,7 +1152,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ShoppingPerformanceViewServiceClient
      */
-    public function getShoppingPerformanceViewServiceClient()
+    public function getShoppingPerformanceViewServiceClient(): ShoppingPerformanceViewServiceClient
     {
         return new ShoppingPerformanceViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1139,7 +1160,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return ThirdPartyAppAnalyticsLinkServiceClient
      */
-    public function getThirdPartyAppAnalyticsLinkServiceClient()
+    public function getThirdPartyAppAnalyticsLinkServiceClient(): ThirdPartyAppAnalyticsLinkServiceClient
     {
         return new ThirdPartyAppAnalyticsLinkServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1147,7 +1168,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return TopicConstantServiceClient
      */
-    public function getTopicConstantServiceClient()
+    public function getTopicConstantServiceClient(): TopicConstantServiceClient
     {
         return new TopicConstantServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1155,7 +1176,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return TopicViewServiceClient
      */
-    public function getTopicViewServiceClient()
+    public function getTopicViewServiceClient(): TopicViewServiceClient
     {
         return new TopicViewServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1163,7 +1184,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserDataServiceClient
      */
-    public function getUserDataServiceClient()
+    public function getUserDataServiceClient(): UserDataServiceClient
     {
         return new UserDataServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1171,7 +1192,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserInterestServiceClient
      */
-    public function getUserInterestServiceClient()
+    public function getUserInterestServiceClient(): UserInterestServiceClient
     {
         return new UserInterestServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1179,15 +1200,23 @@ trait ServiceClientFactoryTrait
     /**
      * @return UserListServiceClient
      */
-    public function getUserListServiceClient()
+    public function getUserListServiceClient(): UserListServiceClient
     {
         return new UserListServiceClient($this->getGoogleAdsClientOptions());
     }
 
     /**
+     * @return UserLocationViewServiceClient
+     */
+    public function getUserLocationViewServiceClient(): UserLocationViewServiceClient
+    {
+        return new UserLocationViewServiceClient($this->getGoogleAdsClientOptions());
+    }
+
+    /**
      * @return VideoServiceClient
      */
-    public function getVideoServiceClient()
+    public function getVideoServiceClient(): VideoServiceClient
     {
         return new VideoServiceClient($this->getGoogleAdsClientOptions());
     }
@@ -1195,7 +1224,7 @@ trait ServiceClientFactoryTrait
     /**
      * @return WebpageViewServiceClient
      */
-    public function getWebpageViewServiceClient()
+    public function getWebpageViewServiceClient(): WebpageViewServiceClient
     {
         return new WebpageViewServiceClient($this->getGoogleAdsClientOptions());
     }

--- a/tests/Google/Ads/GoogleAds/Lib/V5/ServiceClientFactoryTraitTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V5/ServiceClientFactoryTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Lib\V5;
 
 use Google\Ads\GoogleAds\V5\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V5\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V5\Services\AdGroupAudienceViewServiceClient;
@@ -72,6 +75,7 @@ use Google\Ads\GoogleAds\V5\Services\CustomerServiceClient;
 use Google\Ads\GoogleAds\V5\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V5\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DomainCategoryServiceClient;
 use Google\Ads\GoogleAds\V5\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\ExpandedLandingPageViewServiceClient;
@@ -127,6 +131,7 @@ use Google\Ads\GoogleAds\V5\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\UserDataServiceClient;
 use Google\Ads\GoogleAds\V5\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V5\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V5\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V5\Services\VideoServiceClient;
 use Google\Auth\FetchAuthTokenInterface;
 use Monolog\Handler\NullHandler;
@@ -190,6 +195,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             AccountLinkServiceClient::class,
             $this->googleAdsClient->getAccountLinkServiceClient()
+        );
+    }
+
+    public function testGetAdGroupAdAssetViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            AdGroupAdAssetViewServiceClient::class,
+            $this->googleAdsClient->getAdGroupAdAssetViewServiceClient()
         );
     }
 
@@ -598,6 +611,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             DisplayKeywordViewServiceClient::class,
             $this->googleAdsClient->getDisplayKeywordViewServiceClient()
+        );
+    }
+
+    public function testGetDistanceViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            DistanceViewServiceClient::class,
+            $this->googleAdsClient->getDistanceViewServiceClient()
         );
     }
 
@@ -1038,6 +1059,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             UserListServiceClient::class,
             $this->googleAdsClient->getUserListServiceClient()
+        );
+    }
+
+    public function testGetUserLocationViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            UserLocationViewServiceClient::class,
+            $this->googleAdsClient->getUserLocationViewServiceClient()
         );
     }
 

--- a/tests/Google/Ads/GoogleAds/Lib/V6/ServiceClientFactoryTraitTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V6/ServiceClientFactoryTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Lib\V6;
 
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V6\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAudienceViewServiceClient;
@@ -76,6 +79,7 @@ use Google\Ads\GoogleAds\V6\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V6\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DomainCategoryServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ExpandedLandingPageViewServiceClient;
@@ -133,6 +137,7 @@ use Google\Ads\GoogleAds\V6\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserDataServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V6\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\VideoServiceClient;
 use Google\Auth\FetchAuthTokenInterface;
 use Monolog\Handler\NullHandler;
@@ -196,6 +201,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             AccountLinkServiceClient::class,
             $this->googleAdsClient->getAccountLinkServiceClient()
+        );
+    }
+
+    public function testGetAdGroupAdAssetViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            AdGroupAdAssetViewServiceClient::class,
+            $this->googleAdsClient->getAdGroupAdAssetViewServiceClient()
         );
     }
 
@@ -636,6 +649,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             DisplayKeywordViewServiceClient::class,
             $this->googleAdsClient->getDisplayKeywordViewServiceClient()
+        );
+    }
+
+    public function testGetDistanceViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            DistanceViewServiceClient::class,
+            $this->googleAdsClient->getDistanceViewServiceClient()
         );
     }
 
@@ -1092,6 +1113,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             UserListServiceClient::class,
             $this->googleAdsClient->getUserListServiceClient()
+        );
+    }
+
+    public function testGetUserLocationViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            UserLocationViewServiceClient::class,
+            $this->googleAdsClient->getUserLocationViewServiceClient()
         );
     }
 

--- a/tests/Google/Ads/GoogleAds/Lib/V7/ServiceClientFactoryTraitTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V7/ServiceClientFactoryTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Lib\V7;
 
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V7\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAssetServiceClient;
@@ -81,6 +84,7 @@ use Google\Ads\GoogleAds\V7\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V7\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DomainCategoryServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ExpandedLandingPageViewServiceClient;
@@ -139,6 +143,7 @@ use Google\Ads\GoogleAds\V7\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserDataServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V7\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\VideoServiceClient;
 use Google\Ads\GoogleAds\V7\Services\WebpageViewServiceClient;
 use Google\Auth\FetchAuthTokenInterface;
@@ -203,6 +208,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             AccountLinkServiceClient::class,
             $this->googleAdsClient->getAccountLinkServiceClient()
+        );
+    }
+
+    public function testGetAdGroupAdAssetViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            AdGroupAdAssetViewServiceClient::class,
+            $this->googleAdsClient->getAdGroupAdAssetViewServiceClient()
         );
     }
 
@@ -686,6 +699,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         );
     }
 
+    public function testGetDistanceViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            DistanceViewServiceClient::class,
+            $this->googleAdsClient->getDistanceViewServiceClient()
+        );
+    }
+
     public function testGetDomainCategoryServiceClient()
     {
         $this->assertInstanceOf(
@@ -1147,6 +1168,14 @@ class ServiceClientFactoryTraitTest extends TestCase
         $this->assertInstanceOf(
             UserListServiceClient::class,
             $this->googleAdsClient->getUserListServiceClient()
+        );
+    }
+
+    public function testGetUserLocationViewServiceClient()
+    {
+        $this->assertInstanceOf(
+            UserLocationViewServiceClient::class,
+            $this->googleAdsClient->getUserLocationViewServiceClient()
         );
     }
 


### PR DESCRIPTION
Regenerates code of the Services trait and unit tests in all supported versions:

* Adds support of all missing services: AdGroupAdAssetViewServiceClient, DistanceViewServiceClient, UserLocationViewServiceClient
* Reorders some methods to be compliant with alphabetic order
* Declares all method return types

Change-Id: Ib1be6031a46bea686bdf5ba2ed97050d35f0beeb