### PR TITLE
Add Google Ads API redirection in issues page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Google Ads API
+    url: https://developers.google.com/google-ads/api/support
+    about: Please ask general Google Ads API questions to the dedicated support

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Google Ads API
     url: https://developers.google.com/google-ads/api/support
-    about: Please ask general Google Ads API questions to the dedicated support
+    about: Please ask general Google Ads API questions to the dedicated support channels.


### PR DESCRIPTION
Learn more information about GitHub Template Chooser configuration [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser). Here is what we set with this PR:

- Allow the creation of `blank` issues: Anyone _can_ create an issue without selecting a template
- Refer users to Google Ads API Support's page for issues that are not strictly related to the library: A new button is added to the page where the user chooses the issue template (e.g., `Question` in [Google Jax repository's template selector](https://github.com/google/jax/issues/new/choose))
