### PR TITLE
Provide guidance about the loginCustomerId format

### DIFF
--- a/examples/Authentication/google_ads_php.ini
+++ b/examples/Authentication/google_ads_php.ini
@@ -5,7 +5,8 @@ developerToken = "INSERT_DEVELOPER_TOKEN_HERE"
 
 ; Required for manager accounts only: Specify the login customer ID used to authenticate API calls.
 ; This will be the customer ID of the authenticated manager account. You can also specify this later
-; in code if your application uses multiple manager account + OAuth pairs.
+; in code if your application uses multiple manager account + OAuth pairs. It should be set
+; without dashes, for example: 1234567890 instead of 123-456-7890.
 ; loginCustomerId = "INSERT_LOGIN_CUSTOMER_ID_HERE"
 
 ; This header is only required for methods that update the resources of an entity when permissioned


### PR DESCRIPTION
The loginCustomerId, if applicable, needs to be specified without dashes, just like the linkedCustomerId. However, while the comment before linkedCustomerId specifies this requirement, the same was not specified before the loginCustomerId. This usually results in a INVALID_LOGIN_CUSTOMER_ID error, without specifying how to remediate the same. Hence, adding guidance about the proper format for the loginCustomerId would be very helpful.