### PR TITLE
Regen resources name builders

### DIFF
--- a/src/Google/Ads/GoogleAds/Util/V6/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V6/ResourceNames.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Util\V6;
 
-use Google\Ads\GoogleAds\V6\Enums\AssetFieldTypeEnum\AssetFieldType;
-use Google\Ads\GoogleAds\V6\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V6\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAudienceViewServiceClient;
@@ -62,6 +63,7 @@ use Google\Ads\GoogleAds\V6\Services\ClickViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CombinedAudienceServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CurrencyConstantServiceClient;
+use Google\Ads\GoogleAds\V6\Services\CustomAudienceServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomerClientLinkServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomerClientServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomerExtensionSettingServiceClient;
@@ -75,7 +77,9 @@ use Google\Ads\GoogleAds\V6\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V6\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DomainCategoryServiceClient;
+use Google\Ads\GoogleAds\V6\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ExpandedLandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ExtensionFeedItemServiceClient;
 use Google\Ads\GoogleAds\V6\Services\FeedItemServiceClient;
@@ -98,6 +102,7 @@ use Google\Ads\GoogleAds\V6\Services\KeywordPlanAdGroupServiceClient;
 use Google\Ads\GoogleAds\V6\Services\KeywordPlanCampaignKeywordServiceClient;
 use Google\Ads\GoogleAds\V6\Services\KeywordPlanCampaignServiceClient;
 use Google\Ads\GoogleAds\V6\Services\KeywordPlanServiceClient;
+use Google\Ads\GoogleAds\V6\Services\KeywordViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\LabelServiceClient;
 use Google\Ads\GoogleAds\V6\Services\LandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\LanguageConstantServiceClient;
@@ -107,6 +112,7 @@ use Google\Ads\GoogleAds\V6\Services\MediaFileServiceClient;
 use Google\Ads\GoogleAds\V6\Services\MerchantCenterLinkServiceClient;
 use Google\Ads\GoogleAds\V6\Services\MobileAppCategoryConstantServiceClient;
 use Google\Ads\GoogleAds\V6\Services\MobileDeviceConstantServiceClient;
+use Google\Ads\GoogleAds\V6\Services\OfflineUserDataJobServiceClient;
 use Google\Ads\GoogleAds\V6\Services\OperatingSystemVersionConstantServiceClient;
 use Google\Ads\GoogleAds\V6\Services\PaidOrganicSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ParentalStatusViewServiceClient;
@@ -123,6 +129,7 @@ use Google\Ads\GoogleAds\V6\Services\TopicConstantServiceClient;
 use Google\Ads\GoogleAds\V6\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V6\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\VideoServiceClient;
 use Google\ApiCore\PathTemplate;
 
@@ -133,26 +140,53 @@ final class ResourceNames
 {
 
     /**
-     * Generates resource name for an account budget.
+     * Generates a resource name of payments account type.
      *
-     * @param int $customerId the customer ID
-     * @param int $accountBudgetId the account budget ID
-     * @return string the account budget resource name
+     * @param string $customerId
+     * @param string $paymentsAccountId
+     * @return string the payments account resource name
      */
-    public static function forAccountBudget($customerId, $accountBudgetId)
-    {
-        return AccountBudgetServiceClient::accountBudgetName($customerId, $accountBudgetId);
+    public static function forPaymentsAccount(
+        $customerId,
+        $paymentsAccountId
+    ): string {
+        $pathTemplate = new PathTemplate(
+            'customers/{customer}/paymentsAccounts/{payments_account}'
+        );
+        return $pathTemplate->render([
+            'customer' => $customerId,
+            'payments_account' => $paymentsAccountId,
+        ]);
     }
 
     /**
-     * Generates resource name for an account budget proposal.
+     * Generates a resource name of account budget type.
      *
-     * @param int $customerId the customer ID
-     * @param int $accountBudgetProposalId the account budget proposal ID
+     * @param string $customerId
+     * @param string $accountBudgetId
+     * @return string the account budget resource name
+     */
+    public static function forAccountBudget(
+        $customerId,
+        $accountBudgetId
+    ): string {
+        return AccountBudgetServiceClient::accountBudgetName(
+            $customerId,
+            $accountBudgetId
+        );
+    }
+
+    /**
+     * Generates a resource name of account budget proposal type.
+     *
+     * @param string $customerId
+     * @param string $accountBudgetProposalId
      * @return string the account budget proposal resource name
      */
-    public static function forAccountBudgetProposal($customerId, $accountBudgetProposalId)
-    {
+    public static function forAccountBudgetProposal(
+        $customerId,
+        $accountBudgetProposalId
+    ): string {
         return AccountBudgetProposalServiceClient::accountBudgetProposalName(
             $customerId,
             $accountBudgetProposalId
@@ -160,65 +194,117 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an account link.
+     * Generates a resource name of account link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $accountLinkId the account link ID
+     * @param string $customerId
+     * @param string $accountLinkId
      * @return string the account link resource name
      */
-    public static function forAccountLinkName($customerId, $accountLinkId)
-    {
-        return AccountLinkServiceClient::accountLinkName($customerId, $accountLinkId);
+    public static function forAccountLink(
+        $customerId,
+        $accountLinkId
+    ): string {
+        return AccountLinkServiceClient::accountLinkName(
+            $customerId,
+            $accountLinkId
+        );
     }
 
     /**
-     * Generates resource name for an ad.
+     * Generates a resource name of ad type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adId the ad ID
+     * @param string $customerId
+     * @param string $adId
      * @return string the ad resource name
      */
-    public static function forAd($customerId, $adId)
-    {
-        return AdServiceClient::adName($customerId, $adId);
+    public static function forAd(
+        $customerId,
+        $adId
+    ): string {
+        return AdServiceClient::adName(
+            $customerId,
+            $adId
+        );
     }
 
     /**
-     * Generates resource name for an ad group.
+     * Generates a resource name of ad group type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
+     * @param string $customerId
+     * @param string $adGroupId
      * @return string the ad group resource name
      */
-    public static function forAdGroup($customerId, $adGroupId)
-    {
-        return AdGroupServiceClient::adGroupName($customerId, $adGroupId);
+    public static function forAdGroup(
+        $customerId,
+        $adGroupId
+    ): string {
+        return AdGroupServiceClient::adGroupName(
+            $customerId,
+            $adGroupId
+        );
     }
 
     /**
-     * Generates resource name for an ad group ad.
+     * Generates a resource name of ad group ad type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $adId the ad ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
      * @return string the ad group ad resource name
      */
-    public static function forAdGroupAd($customerId, $adGroupId, $adId)
-    {
-        return AdGroupAdServiceClient::adGroupAdName($customerId, $adGroupId, $adId);
+    public static function forAdGroupAd(
+        $customerId,
+        $adGroupId,
+        $adId
+    ): string {
+        return AdGroupAdServiceClient::adGroupAdName(
+            $customerId,
+            $adGroupId,
+            $adId
+        );
     }
 
     /**
-     * Generates resource name for an ad group ad label.
+     * Generates a resource name of ad group ad asset view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $adId the ad ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     * @param string $assetId
+     * @param string $fieldType
+     * @return string the ad group ad asset view resource name
+     */
+    public static function forAdGroupAdAssetView(
+        $customerId,
+        $adGroupId,
+        $adId,
+        $assetId,
+        $fieldType
+    ): string {
+        return AdGroupAdAssetViewServiceClient::adGroupAdAssetViewName(
+            $customerId,
+            $adGroupId,
+            $adId,
+            $assetId,
+            $fieldType
+        );
+    }
+
+    /**
+     * Generates a resource name of ad group ad label type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     * @param string $labelId
      * @return string the ad group ad label resource name
      */
-    public static function forAdGroupAdLabel($customerId, $adGroupId, $adId, $labelId)
-    {
+    public static function forAdGroupAdLabel(
+        $customerId,
+        $adGroupId,
+        $adId,
+        $labelId
+    ): string {
         return AdGroupAdLabelServiceClient::adGroupAdLabelName(
             $customerId,
             $adGroupId,
@@ -228,15 +314,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group audience view.
+     * Generates a resource name of ad group audience view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @return string the ad group audience resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @return string the ad group audience view resource name
      */
-    public static function forAdGroupAudienceView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdGroupAudienceView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AdGroupAudienceViewServiceClient::adGroupAudienceViewName(
             $customerId,
             $adGroupId,
@@ -245,15 +334,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group bid modifier.
+     * Generates a resource name of ad group bid modifier type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the ad group bid modifier resource name
      */
-    public static function forAdGroupBidModifier($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdGroupBidModifier(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AdGroupBidModifierServiceClient::adGroupBidModifierName(
             $customerId,
             $adGroupId,
@@ -262,15 +354,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group criterion.
+     * Generates a resource name of ad group criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the ad group criterion resource name
      */
-    public static function forAdGroupCriterion($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdGroupCriterion(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AdGroupCriterionServiceClient::adGroupCriterionName(
             $customerId,
             $adGroupId,
@@ -279,20 +374,20 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group criterion label.
+     * Generates a resource name of ad group criterion label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @param int $labelId the label ID
-     * @return string the ad group criterion resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $labelId
+     * @return string the ad group criterion label resource name
      */
     public static function forAdGroupCriterionLabel(
         $customerId,
         $adGroupId,
         $criterionId,
         $labelId
-    ) {
+    ): string {
         return AdGroupCriterionLabelServiceClient::adGroupCriterionLabelName(
             $customerId,
             $adGroupId,
@@ -302,15 +397,15 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group criterion simulation.
+     * Generates a resource name of ad group criterion simulation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @param int $type the type
-     * @param int $modificationMethod the modification method
-     * @param int $startDate the start date
-     * @param int $endDate the end date
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $type
+     * @param string $modificationMethod
+     * @param string $startDate
+     * @param string $endDate
      * @return string the ad group criterion simulation resource name
      */
     public static function forAdGroupCriterionSimulation(
@@ -321,7 +416,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return AdGroupCriterionSimulationServiceClient::adGroupCriterionSimulationName(
             $customerId,
             $adGroupId,
@@ -334,32 +429,38 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group extension setting.
+     * Generates a resource name of ad group extension setting type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $extensionType the extension type
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $extensionType
      * @return string the ad group extension setting resource name
      */
-    public static function forAdGroupExtensionSetting($customerId, $adGroupId, $extensionType)
-    {
+    public static function forAdGroupExtensionSetting(
+        $customerId,
+        $adGroupId,
+        $extensionType
+    ): string {
         return AdGroupExtensionSettingServiceClient::adGroupExtensionSettingName(
             $customerId,
             $adGroupId,
-            ExtensionType::name($extensionType)
+            $extensionType
         );
     }
 
     /**
-     * Generates resource name for an ad group feed.
+     * Generates a resource name of ad group feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $feedId the feed Id
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $feedId
      * @return string the ad group feed resource name
      */
-    public static function forAdGroupFeed($customerId, $adGroupId, $feedId)
-    {
+    public static function forAdGroupFeed(
+        $customerId,
+        $adGroupId,
+        $feedId
+    ): string {
         return AdGroupFeedServiceClient::adGroupFeedName(
             $customerId,
             $adGroupId,
@@ -368,18 +469,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group label.
+     * Generates a resource name of ad group label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $labelId
      * @return string the ad group label resource name
      */
     public static function forAdGroupLabel(
         $customerId,
         $adGroupId,
         $labelId
-    ) {
+    ): string {
         return AdGroupLabelServiceClient::adGroupLabelName(
             $customerId,
             $adGroupId,
@@ -388,14 +489,14 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group simulation.
+     * Generates a resource name of ad group simulation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $type the type
-     * @param int $modificationMethod the modification method
-     * @param int $startDate the start date
-     * @param int $endDate the end date
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $type
+     * @param string $modificationMethod
+     * @param string $startDate
+     * @param string $endDate
      * @return string the ad group simulation resource name
      */
     public static function forAdGroupSimulation(
@@ -405,7 +506,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return AdGroupSimulationServiceClient::adGroupSimulationName(
             $customerId,
             $adGroupId,
@@ -417,16 +518,20 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad parameter.
+     * Generates a resource name of ad parameter type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @param int $parameterIndex the parameter index
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $parameterIndex
      * @return string the ad parameter resource name
      */
-    public static function forAdParameter($customerId, $adGroupId, $criterionId, $parameterIndex)
-    {
+    public static function forAdParameter(
+        $customerId,
+        $adGroupId,
+        $criterionId,
+        $parameterIndex
+    ): string {
         return AdParameterServiceClient::adParameterName(
             $customerId,
             $adGroupId,
@@ -436,32 +541,38 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad schedule view.
+     * Generates a resource name of ad schedule view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the ad schedule view resource name
      */
-    public static function forAdScheduleView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdScheduleView(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return AdScheduleViewServiceClient::adScheduleViewName(
             $customerId,
-            $adGroupId,
+            $campaignId,
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for an age range view.
+     * Generates a resource name of age range view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the age range view resource name
      */
-    public static function forAgeRangeView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAgeRangeView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AgeRangeViewServiceClient::ageRangeViewName(
             $customerId,
             $adGroupId,
@@ -470,94 +581,126 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an asset.
+     * Generates a resource name of asset type.
      *
-     * @param int $customerId the customer ID
-     * @param int $assetId the asset ID
+     * @param string $customerId
+     * @param string $assetId
      * @return string the asset resource name
      */
-    public static function forAsset($customerId, $assetId)
-    {
-        return AssetServiceClient::assetName($customerId, $assetId);
-    }
-
-    /**
-     * Generates resource name for a batch job.
-     *
-     * @param int $customerId the customer ID
-     * @param int $batchJobId the batch job ID
-     * @return string the batch job resource name
-     */
-    public static function forBatchJob($customerId, $batchJobId)
-    {
-        return BatchJobServiceClient::batchJobName($customerId, $batchJobId);
-    }
-
-    /**
-     * Generates resource name for a bidding strategy.
-     *
-     * @param int $customerId the customer ID
-     * @param int $biddingStrategyId the bidding strategy ID
-     * @return string the bidding strategy resource name
-     */
-    public static function forBiddingStrategy($customerId, $biddingStrategyId)
-    {
-        return BiddingStrategyServiceClient::biddingStrategyName($customerId, $biddingStrategyId);
-    }
-
-    /**
-     * Generates resource name for a billing setup.
-     *
-     * @param int $customerId the customer ID
-     * @param int $billingSetupId the billing setup ID
-     * @return string the billing setup resource name
-     */
-    public static function forBillingSetup($customerId, $billingSetupId)
-    {
-        return BillingSetupServiceClient::billingSetupName($customerId, $billingSetupId);
-    }
-
-    /**
-     * Generates resource name for a campaign.
-     *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @return string the campaign resource name
-     */
-    public static function forCampaign($customerId, $campaignId)
-    {
-        return CampaignServiceClient::campaignName($customerId, $campaignId);
-    }
-
-    /**
-     * Generates resource name for a campaign asset.
-     *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $assetId the asset ID
-     * @param int $fieldType the field type
-     * @return string the campaign asset resource name
-     */
-    public static function forCampaignAsset($customerId, $campaignId, $assetId, $fieldType)
-    {
-        return CampaignAssetServiceClient::campaignAssetName(
+    public static function forAsset(
+        $customerId,
+        $assetId
+    ): string {
+        return AssetServiceClient::assetName(
             $customerId,
-            $campaignId,
-            $assetId,
-            AssetFieldType::name($fieldType)
+            $assetId
         );
     }
 
     /**
-     * Generates resource name for a campaign audience view.
+     * Generates a resource name of batch job type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $batchJobId
+     * @return string the batch job resource name
+     */
+    public static function forBatchJob(
+        $customerId,
+        $batchJobId
+    ): string {
+        return BatchJobServiceClient::batchJobName(
+            $customerId,
+            $batchJobId
+        );
+    }
+
+    /**
+     * Generates a resource name of bidding strategy type.
+     *
+     * @param string $customerId
+     * @param string $biddingStrategyId
+     * @return string the bidding strategy resource name
+     */
+    public static function forBiddingStrategy(
+        $customerId,
+        $biddingStrategyId
+    ): string {
+        return BiddingStrategyServiceClient::biddingStrategyName(
+            $customerId,
+            $biddingStrategyId
+        );
+    }
+
+    /**
+     * Generates a resource name of billing setup type.
+     *
+     * @param string $customerId
+     * @param string $billingSetupId
+     * @return string the billing setup resource name
+     */
+    public static function forBillingSetup(
+        $customerId,
+        $billingSetupId
+    ): string {
+        return BillingSetupServiceClient::billingSetupName(
+            $customerId,
+            $billingSetupId
+        );
+    }
+
+    /**
+     * Generates a resource name of campaign type.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @return string the campaign resource name
+     */
+    public static function forCampaign(
+        $customerId,
+        $campaignId
+    ): string {
+        return CampaignServiceClient::campaignName(
+            $customerId,
+            $campaignId
+        );
+    }
+
+    /**
+     * Generates a resource name of campaign asset type.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $assetId
+     * @param string $fieldType
+     * @return string the campaign asset resource name
+     */
+    public static function forCampaignAsset(
+        $customerId,
+        $campaignId,
+        $assetId,
+        $fieldType
+    ): string {
+        return CampaignAssetServiceClient::campaignAssetName(
+            $customerId,
+            $campaignId,
+            $assetId,
+            $fieldType
+        );
+    }
+
+    /**
+     * Generates a resource name of campaign audience view type.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the campaign audience view resource name
      */
-    public static function forCampaignAudienceView($customerId, $campaignId, $criterionId)
-    {
+    public static function forCampaignAudienceView(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return CampaignAudienceViewServiceClient::campaignAudienceViewName(
             $customerId,
             $campaignId,
@@ -566,15 +709,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign bid modifier.
+     * Generates a resource name of campaign bid modifier type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the campaign bid modifier resource name
      */
-    public static function forCampaignBidModifier($customerId, $campaignId, $criterionId)
-    {
+    public static function forCampaignBidModifier(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return CampaignBidModifierServiceClient::campaignBidModifierName(
             $customerId,
             $campaignId,
@@ -583,27 +729,35 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign budget.
+     * Generates a resource name of campaign budget type.
      *
-     * @param int $customerId the customer ID
-     * @param int $budgetId the budget ID
+     * @param string $customerId
+     * @param string $campaignBudgetId
      * @return string the campaign budget resource name
      */
-    public static function forCampaignBudget($customerId, $budgetId)
-    {
-        return CampaignBudgetServiceClient::campaignBudgetName($customerId, $budgetId);
+    public static function forCampaignBudget(
+        $customerId,
+        $campaignBudgetId
+    ): string {
+        return CampaignBudgetServiceClient::campaignBudgetName(
+            $customerId,
+            $campaignBudgetId
+        );
     }
 
     /**
-     * Generates resource name for a campaign criterion.
+     * Generates a resource name of campaign criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the campaign criterion resource name
      */
-    public static function forCampaignCriterion($customerId, $campaignId, $criterionId)
-    {
+    public static function forCampaignCriterion(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return CampaignCriterionServiceClient::campaignCriterionName(
             $customerId,
             $campaignId,
@@ -612,15 +766,15 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign criterion simulation.
+     * Generates a resource name of campaign criterion simulation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
-     * @param int $type the type
-     * @param int $modificationMethod the modification method
-     * @param int $startDate the start date
-     * @param int $endDate the end date
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
+     * @param string $type
+     * @param string $modificationMethod
+     * @param string $startDate
+     * @param string $endDate
      * @return string the campaign criterion simulation resource name
      */
     public static function forCampaignCriterionSimulation(
@@ -631,7 +785,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return CampaignCriterionSimulationServiceClient::campaignCriterionSimulationName(
             $customerId,
             $campaignId,
@@ -644,15 +798,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign draft.
+     * Generates a resource name of campaign draft type.
      *
-     * @param int $customerId the customer ID
-     * @param int $baseCampaignId the base campaign ID
-     * @param int $draftId the draft Id
+     * @param string $customerId
+     * @param string $baseCampaignId
+     * @param string $draftId
      * @return string the campaign draft resource name
      */
-    public static function forCampaignDraft($customerId, $baseCampaignId, $draftId)
-    {
+    public static function forCampaignDraft(
+        $customerId,
+        $baseCampaignId,
+        $draftId
+    ): string {
         return CampaignDraftServiceClient::campaignDraftName(
             $customerId,
             $baseCampaignId,
@@ -661,14 +818,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign experiment.
+     * Generates a resource name of campaign experiment type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignExperimentId the campaign ID
+     * @param string $customerId
+     * @param string $campaignExperimentId
      * @return string the campaign experiment resource name
      */
-    public static function forCampaignExperiment($customerId, $campaignExperimentId)
-    {
+    public static function forCampaignExperiment(
+        $customerId,
+        $campaignExperimentId
+    ): string {
         return CampaignExperimentServiceClient::campaignExperimentName(
             $customerId,
             $campaignExperimentId
@@ -676,45 +835,58 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign extension setting.
+     * Generates a resource name of campaign extension setting type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $extensionType the extension type
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $extensionType
      * @return string the campaign extension setting resource name
      */
-    public static function forCampaignExtensionSetting($customerId, $campaignId, $extensionType)
-    {
+    public static function forCampaignExtensionSetting(
+        $customerId,
+        $campaignId,
+        $extensionType
+    ): string {
         return CampaignExtensionSettingServiceClient::campaignExtensionSettingName(
             $customerId,
             $campaignId,
-            ExtensionType::name($extensionType)
+            $extensionType
         );
     }
 
     /**
-     * Generates resource name for a campaign feed.
+     * Generates a resource name of campaign feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $feedId the feed Id
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $feedId
      * @return string the campaign feed resource name
      */
-    public static function forCampaignFeed($customerId, $campaignId, $feedId)
-    {
-        return CampaignFeedServiceClient::campaignFeedName($customerId, $campaignId, $feedId);
+    public static function forCampaignFeed(
+        $customerId,
+        $campaignId,
+        $feedId
+    ): string {
+        return CampaignFeedServiceClient::campaignFeedName(
+            $customerId,
+            $campaignId,
+            $feedId
+        );
     }
 
     /**
-     * Generates resource name for a campaign label.
+     * Generates a resource name of campaign label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $labelId
      * @return string the campaign label resource name
      */
-    public static function forCampaignLabel($customerId, $campaignId, $labelId)
-    {
+    public static function forCampaignLabel(
+        $customerId,
+        $campaignId,
+        $labelId
+    ): string {
         return CampaignLabelServiceClient::campaignLabelName(
             $customerId,
             $campaignId,
@@ -723,15 +895,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign shared set.
+     * Generates a resource name of campaign shared set type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $sharedSetId the shared set Id
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $sharedSetId
      * @return string the campaign shared set resource name
      */
-    public static function forCampaignSharedSet($customerId, $campaignId, $sharedSetId)
-    {
+    public static function forCampaignSharedSet(
+        $customerId,
+        $campaignId,
+        $sharedSetId
+    ): string {
         return CampaignSharedSetServiceClient::campaignSharedSetName(
             $customerId,
             $campaignId,
@@ -740,50 +915,67 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a carrier constant.
+     * Generates a resource name of carrier constant type.
      *
-     * @param int $criterionId the criterion ID
+     * @param string $criterionId
      * @return string the carrier constant resource name
      */
-    public static function forCarrierConstant($criterionId)
-    {
-        return CarrierConstantServiceClient::carrierConstantName($criterionId);
+    public static function forCarrierConstant(
+        $criterionId
+    ): string {
+        return CarrierConstantServiceClient::carrierConstantName(
+            $criterionId
+        );
     }
 
     /**
-     * Generates resource name for a change status.
+     * Generates a resource name of change status type.
      *
-     * @param int $customerId the customer ID
-     * @param int $changeStatusId the change status ID
+     * @param string $customerId
+     * @param string $changeStatusId
      * @return string the change status resource name
      */
-    public static function forChangeStatus($customerId, $changeStatusId)
-    {
-        return ChangeStatusServiceClient::changeStatusName($customerId, $changeStatusId);
+    public static function forChangeStatus(
+        $customerId,
+        $changeStatusId
+    ): string {
+        return ChangeStatusServiceClient::changeStatusName(
+            $customerId,
+            $changeStatusId
+        );
     }
 
     /**
-     * Generates resource name for a click view.
+     * Generates a resource name of click view type.
      *
-     * @param int $customerId the customer ID
-     * @param string $date (yyyy-MM-dd) the campaign ID
-     * @param int $gclId the Google Click Id
+     * @param string $customerId
+     * @param string $date
+     * @param string $gclid
      * @return string the click view resource name
      */
-    public static function forClickView($customerId, $date, $gclId)
-    {
-        return ClickViewServiceClient::clickViewName($customerId, $date, $gclId);
+    public static function forClickView(
+        $customerId,
+        $date,
+        $gclid
+    ): string {
+        return ClickViewServiceClient::clickViewName(
+            $customerId,
+            $date,
+            $gclid
+        );
     }
 
     /**
-     * Generates resource name for a combined audience.
+     * Generates a resource name of combined audience type.
      *
-     * @param int $customerId the customer ID
-     * @param int $combinedAudienceId the combined audience ID
+     * @param string $customerId
+     * @param string $combinedAudienceId
      * @return string the combined audience resource name
      */
-    public static function forCombinedAudience($customerId, $combinedAudienceId)
-    {
+    public static function forCombinedAudience(
+        $customerId,
+        $combinedAudienceId
+    ): string {
         return CombinedAudienceServiceClient::combinedAudienceName(
             $customerId,
             $combinedAudienceId
@@ -791,14 +983,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a conversion action.
+     * Generates a resource name of conversion action type.
      *
-     * @param int $customerId the customer ID
-     * @param int $conversionActionId the conversion action ID
+     * @param string $customerId
+     * @param string $conversionActionId
      * @return string the conversion action resource name
      */
-    public static function forConversionAction($customerId, $conversionActionId)
-    {
+    public static function forConversionAction(
+        $customerId,
+        $conversionActionId
+    ): string {
         return ConversionActionServiceClient::conversionActionName(
             $customerId,
             $conversionActionId
@@ -806,49 +1000,80 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a currency constant.
+     * Generates a resource name of currency constant type.
      *
-     * @param string $currencyConstantId the currency constant ID
+     * @param string $code
      * @return string the currency constant resource name
      */
-    public static function forCurrencyConstant($currencyConstantId)
-    {
-        return CurrencyConstantServiceClient::currencyConstantName($currencyConstantId);
+    public static function forCurrencyConstant(
+        $code
+    ): string {
+        return CurrencyConstantServiceClient::currencyConstantName(
+            $code
+        );
     }
 
     /**
-     * Generates resource name for a customer.
+     * Generates a resource name of custom audience type.
      *
-     * @param int $customerId the customer ID
+     * @param string $customerId
+     * @param string $customAudienceId
+     * @return string the custom audience resource name
+     */
+    public static function forCustomAudience(
+        $customerId,
+        $customAudienceId
+    ): string {
+        return CustomAudienceServiceClient::customAudienceName(
+            $customerId,
+            $customAudienceId
+        );
+    }
+
+    /**
+     * Generates a resource name of customer type.
+     *
+     * @param string $customerId
      * @return string the customer resource name
      */
-    public static function forCustomer($customerId)
-    {
-        return CustomerServiceClient::customerName($customerId);
+    public static function forCustomer(
+        $customerId
+    ): string {
+        return CustomerServiceClient::customerName(
+            $customerId
+        );
     }
 
     /**
-     * Generates resource name for a customer client.
+     * Generates a resource name of customer client type.
      *
-     * @param int $customerId the customer ID
-     * @param int $customerClientId the customer client ID
+     * @param string $customerId
+     * @param string $clientCustomerId
      * @return string the customer client resource name
      */
-    public static function forCustomerClient($customerId, $customerClientId)
-    {
-        return CustomerClientServiceClient::customerClientName($customerId, $customerClientId);
+    public static function forCustomerClient(
+        $customerId,
+        $clientCustomerId
+    ): string {
+        return CustomerClientServiceClient::customerClientName(
+            $customerId,
+            $clientCustomerId
+        );
     }
 
     /**
-     * Generates resource name for a customer client link.
+     * Generates a resource name of customer client link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $clientCustomerId the client customer ID
-     * @param int $managerLinkId the manager customer ID
+     * @param string $customerId
+     * @param string $clientCustomerId
+     * @param string $managerLinkId
      * @return string the customer client link resource name
      */
-    public static function forCustomerClientLink($customerId, $clientCustomerId, $managerLinkId)
-    {
+    public static function forCustomerClientLink(
+        $customerId,
+        $clientCustomerId,
+        $managerLinkId
+    ): string {
         return CustomerClientLinkServiceClient::customerClientLinkName(
             $customerId,
             $clientCustomerId,
@@ -857,73 +1082,87 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a customer extension setting.
+     * Generates a resource name of customer extension setting type.
      *
-     * @param int $customerId the customer ID
-     * @param int $extensionType the extension type
+     * @param string $customerId
+     * @param string $extensionType
      * @return string the customer extension setting resource name
      */
-    public static function forCustomerExtensionSetting($customerId, $extensionType)
-    {
+    public static function forCustomerExtensionSetting(
+        $customerId,
+        $extensionType
+    ): string {
         return CustomerExtensionSettingServiceClient::customerExtensionSettingName(
             $customerId,
-            ExtensionType::name($extensionType)
+            $extensionType
         );
     }
 
     /**
-     * Generates resource name for a customer feed.
+     * Generates a resource name of customer feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
+     * @param string $customerId
+     * @param string $feedId
      * @return string the customer feed resource name
      */
-    public static function forCustomerFeed($customerId, $feedId)
-    {
-        return CustomerFeedServiceClient::customerFeedName($customerId, $feedId);
+    public static function forCustomerFeed(
+        $customerId,
+        $feedId
+    ): string {
+        return CustomerFeedServiceClient::customerFeedName(
+            $customerId,
+            $feedId
+        );
     }
 
     /**
-     * Generates resource name for a customer label.
+     * Generates a resource name of customer label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $labelId
      * @return string the customer label resource name
      */
-    public static function forCustomerLabel($customerId, $labelId)
-    {
-        return CustomerLabelServiceClient::customerLabelName($customerId, $labelId);
+    public static function forCustomerLabel(
+        $customerId,
+        $labelId
+    ): string {
+        return CustomerLabelServiceClient::customerLabelName(
+            $customerId,
+            $labelId
+        );
     }
 
     /**
-     * Generates resource name for a customer manager link.
+     * Generates a resource name of customer manager link type.
      *
-     * @param int $clientCustomerId the client customer ID
-     * @param int $managerCustomerId the manager customer ID
-     * @param int $managerLinkId the manager link ID
+     * @param string $customerId
+     * @param string $managerCustomerId
+     * @param string $managerLinkId
      * @return string the customer manager link resource name
      */
     public static function forCustomerManagerLink(
-        $clientCustomerId,
+        $customerId,
         $managerCustomerId,
         $managerLinkId
-    ) {
+    ): string {
         return CustomerManagerLinkServiceClient::customerManagerLinkName(
-            $clientCustomerId,
+            $customerId,
             $managerCustomerId,
             $managerLinkId
         );
     }
 
     /**
-     * Generates resource name for a customer negative criterion.
+     * Generates a resource name of customer negative criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $criterionId
      * @return string the customer negative criterion resource name
      */
-    public static function forCustomerNegativeCriterion($customerId, $criterionId)
-    {
+    public static function forCustomerNegativeCriterion(
+        $customerId,
+        $criterionId
+    ): string {
         return CustomerNegativeCriterionServiceClient::customerNegativeCriterionName(
             $customerId,
             $criterionId
@@ -931,26 +1170,33 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a customer user access.
+     * Generates a resource name of customer user access type.
      *
-     * @param int $customerId the customer ID
-     * @param int $userId the user ID
+     * @param string $customerId
+     * @param string $userId
      * @return string the customer user access resource name
      */
-    public static function forCustomerUserAccess($customerId, $userId)
-    {
-        return CustomerUserAccessServiceClient::customerUserAccessName($customerId, $userId);
+    public static function forCustomerUserAccess(
+        $customerId,
+        $userId
+    ): string {
+        return CustomerUserAccessServiceClient::customerUserAccessName(
+            $customerId,
+            $userId
+        );
     }
 
     /**
-     * Generates resource name for a customer user access invitation.
+     * Generates a resource name of customer user access invitation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $invitationId the invitation ID
+     * @param string $customerId
+     * @param string $invitationId
      * @return string the customer user access invitation resource name
      */
-    public static function forCustomerUserAccessInvitation($customerId, $invitationId)
-    {
+    public static function forCustomerUserAccessInvitation(
+        $customerId,
+        $invitationId
+    ): string {
         return CustomerUserAccessInvitationServiceClient::customerUserAccessInvitationName(
             $customerId,
             $invitationId
@@ -958,44 +1204,55 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a custom interest.
+     * Generates a resource name of custom interest type.
      *
-     * @param int $customerId the customer ID
-     * @param int $customInterestId the custom interest ID
+     * @param string $customerId
+     * @param string $customInterestId
      * @return string the custom interest resource name
      */
-    public static function forCustomInterest($customerId, $customInterestId)
-    {
-        return CustomInterestServiceClient::customInterestName($customerId, $customInterestId);
-    }
-
-    /**
-     * Generates resource name for a detail placement view.
-     *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param string $placement the placement
-     * @return string the detail placement view resource name
-     */
-    public static function forDetailPlacementView($customerId, $adGroupId, $placement)
-    {
-        return DetailPlacementViewServiceClient::detailPlacementViewName(
+    public static function forCustomInterest(
+        $customerId,
+        $customInterestId
+    ): string {
+        return CustomInterestServiceClient::customInterestName(
             $customerId,
-            $adGroupId,
-            $placement
+            $customInterestId
         );
     }
 
     /**
-     * Generates resource name for a display keyword view.
+     * Generates a resource name of detail placement view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $base64Placement
+     * @return string the detail placement view resource name
+     */
+    public static function forDetailPlacementView(
+        $customerId,
+        $adGroupId,
+        $base64Placement
+    ): string {
+        return DetailPlacementViewServiceClient::detailPlacementViewName(
+            $customerId,
+            $adGroupId,
+            $base64Placement
+        );
+    }
+
+    /**
+     * Generates a resource name of display keyword view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the display keyword view resource name
      */
-    public static function forDisplayKeywordView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forDisplayKeywordView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return DisplayKeywordViewServiceClient::displayKeywordViewName(
             $customerId,
             $adGroupId,
@@ -1004,33 +1261,88 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a domain category.
+     * Generates a resource name of distance view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param string $category the category
-     * @param string $languageCode the language code
+     * @param string $customerId
+     * @param string $placeholderChainId
+     * @param string $distanceBucket
+     * @return string the distance view resource name
+     */
+    public static function forDistanceView(
+        $customerId,
+        $placeholderChainId,
+        $distanceBucket
+    ): string {
+        return DistanceViewServiceClient::distanceViewName(
+            $customerId,
+            $placeholderChainId,
+            $distanceBucket
+        );
+    }
+
+    /**
+     * Generates a resource name of domain category type.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $base64Category
+     * @param string $languageCode
      * @return string the domain category resource name
      */
-    public static function forDomainCategory($customerId, $campaignId, $category, $languageCode)
-    {
+    public static function forDomainCategory(
+        $customerId,
+        $campaignId,
+        $base64Category,
+        $languageCode
+    ): string {
         return DomainCategoryServiceClient::domainCategoryName(
             $customerId,
             $campaignId,
-            $category,
+            $base64Category,
             $languageCode
         );
     }
 
     /**
-     * Generates resource name for an expanded langing page view.
+     * Generates a resource name of dynamic search ads search term view type.
      *
-     * @param int $customerId the customer ID
-     * @param string $expandedFinalUrlFingerprint the expanded final URL fingerprint
-     * @return string the expanded langing page view resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $searchTermFingerprint
+     * @param string $headlineFingerprint
+     * @param string $landingPageFingerprint
+     * @param string $pageUrlFingerprint
+     * @return string the dynamic search ads search term view resource name
      */
-    public static function forExpandedLandingPageView($customerId, $expandedFinalUrlFingerprint)
-    {
+    public static function forDynamicSearchAdsSearchTermView(
+        $customerId,
+        $adGroupId,
+        $searchTermFingerprint,
+        $headlineFingerprint,
+        $landingPageFingerprint,
+        $pageUrlFingerprint
+    ): string {
+        return DynamicSearchAdsSearchTermViewServiceClient::dynamicSearchAdsSearchTermViewName(
+            $customerId,
+            $adGroupId,
+            $searchTermFingerprint,
+            $headlineFingerprint,
+            $landingPageFingerprint,
+            $pageUrlFingerprint
+        );
+    }
+
+    /**
+     * Generates a resource name of expanded landing page view type.
+     *
+     * @param string $customerId
+     * @param string $expandedFinalUrlFingerprint
+     * @return string the expanded landing page view resource name
+     */
+    public static function forExpandedLandingPageView(
+        $customerId,
+        $expandedFinalUrlFingerprint
+    ): string {
         return ExpandedLandingPageViewServiceClient::expandedLandingPageViewName(
             $customerId,
             $expandedFinalUrlFingerprint
@@ -1038,39 +1350,52 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an extension feed item.
+     * Generates a resource name of extension feed item type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedItemId the feed item ID
+     * @param string $customerId
+     * @param string $feedItemId
      * @return string the extension feed item resource name
      */
-    public static function forExtensionFeedItem($customerId, $feedItemId)
-    {
-        return ExtensionFeedItemServiceClient::extensionFeedItemName($customerId, $feedItemId);
+    public static function forExtensionFeedItem(
+        $customerId,
+        $feedItemId
+    ): string {
+        return ExtensionFeedItemServiceClient::extensionFeedItemName(
+            $customerId,
+            $feedItemId
+        );
     }
 
     /**
-     * Generates resource name for a feed.
+     * Generates a resource name of feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
+     * @param string $customerId
+     * @param string $feedId
      * @return string the feed resource name
      */
-    public static function forFeed($customerId, $feedId)
-    {
-        return FeedServiceClient::feedName($customerId, $feedId);
+    public static function forFeed(
+        $customerId,
+        $feedId
+    ): string {
+        return FeedServiceClient::feedName(
+            $customerId,
+            $feedId
+        );
     }
 
     /**
-     * Generates resource name for a feed item.
+     * Generates a resource name of feed item type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemId the feed item ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
      * @return string the feed item resource name
      */
-    public static function forFeedItem($customerId, $feedId, $feedItemId)
-    {
+    public static function forFeedItem(
+        $customerId,
+        $feedId,
+        $feedItemId
+    ): string {
         return FeedItemServiceClient::feedItemName(
             $customerId,
             $feedId,
@@ -1079,15 +1404,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed item set.
+     * Generates a resource name of feed item set type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemSetId the feed item set ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
      * @return string the feed item set resource name
      */
-    public static function forFeedItemSet($customerId, $feedId, $feedItemSetId)
-    {
+    public static function forFeedItemSet(
+        $customerId,
+        $feedId,
+        $feedItemSetId
+    ): string {
         return FeedItemSetServiceClient::feedItemSetName(
             $customerId,
             $feedId,
@@ -1096,16 +1424,20 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed item set link.
+     * Generates a resource name of feed item set link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemSetId the feed item set ID
-     * @param int $feedItemId the feed item ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
+     * @param string $feedItemId
      * @return string the feed item set link resource name
      */
-    public static function forFeedItemSetLink($customerId, $feedId, $feedItemSetId, $feedItemId)
-    {
+    public static function forFeedItemSetLink(
+        $customerId,
+        $feedId,
+        $feedItemSetId,
+        $feedItemId
+    ): string {
         return FeedItemSetLinkServiceClient::feedItemSetLinkName(
             $customerId,
             $feedId,
@@ -1115,13 +1447,13 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed item target.
+     * Generates a resource name of feed item target type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemId the feed item ID
-     * @param int $feedItemTargetType the feed item target type
-     * @param int $feedItemTargetId the feed item target ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     * @param string $feedItemTargetType
+     * @param string $feedItemTargetId
      * @return string the feed item target resource name
      */
     public static function forFeedItemTarget(
@@ -1130,7 +1462,7 @@ final class ResourceNames
         $feedItemId,
         $feedItemTargetType,
         $feedItemTargetId
-    ) {
+    ): string {
         return FeedItemTargetServiceClient::feedItemTargetName(
             $customerId,
             $feedId,
@@ -1141,15 +1473,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed mapping.
+     * Generates a resource name of feed mapping type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedMappingId the feed mapping ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedMappingId
      * @return string the feed mapping resource name
      */
-    public static function forFeedMapping($customerId, $feedId, $feedMappingId)
-    {
+    public static function forFeedMapping(
+        $customerId,
+        $feedId,
+        $feedMappingId
+    ): string {
         return FeedMappingServiceClient::feedMappingName(
             $customerId,
             $feedId,
@@ -1158,14 +1493,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed placeholder view.
+     * Generates a resource name of feed placeholder view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $placeholderType the placeholder type
+     * @param string $customerId
+     * @param string $placeholderType
      * @return string the feed placeholder view resource name
      */
-    public static function forFeedPlaceholderView($customerId, $placeholderType)
-    {
+    public static function forFeedPlaceholderView(
+        $customerId,
+        $placeholderType
+    ): string {
         return FeedPlaceholderViewServiceClient::feedPlaceholderViewName(
             $customerId,
             $placeholderType
@@ -1173,15 +1510,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a gender view.
+     * Generates a resource name of gender view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the gender view resource name
      */
-    public static function forGenderView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forGenderView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return GenderViewServiceClient::genderViewName(
             $customerId,
             $adGroupId,
@@ -1190,15 +1530,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a geographic view.
+     * Generates a resource name of geographic view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $countryCriterionId the country criterion ID
-     * @param int $locationType the location type
+     * @param string $customerId
+     * @param string $countryCriterionId
+     * @param string $locationType
      * @return string the geographic view resource name
      */
-    public static function forGeographicView($customerId, $countryCriterionId, $locationType)
-    {
+    public static function forGeographicView(
+        $customerId,
+        $countryCriterionId,
+        $locationType
+    ): string {
         return GeographicViewServiceClient::geographicViewName(
             $customerId,
             $countryCriterionId,
@@ -1207,54 +1550,66 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a geo target constant.
+     * Generates a resource name of geo target constant type.
      *
-     * @param int $geoTargetConstantId the geo target constant ID
+     * @param string $criterionId
      * @return string the geo target constant resource name
      */
-    public static function forGeoTargetConstant($geoTargetConstantId)
-    {
-        return GeoTargetConstantServiceClient::geoTargetConstantName($geoTargetConstantId);
-    }
-
-    /**
-     * Generates resource name for a Google Ads field.
-     *
-     * @param string $name the name
-     * @return string the Google Ads field resource name
-     */
-    public static function forGoogleAdsField($name)
-    {
-        return GoogleAdsFieldServiceClient::googleAdsFieldName($name);
-    }
-
-    /**
-     * Generates resource name for a group placement view.
-     *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param string $placement the placement
-     * @return string the group placement view resource name
-     */
-    public static function forGroupPlacementView($customerId, $adGroupId, $placement)
-    {
-        return GroupPlacementViewServiceClient::groupPlacementViewName(
-            $customerId,
-            $adGroupId,
-            $placement
+    public static function forGeoTargetConstant(
+        $criterionId
+    ): string {
+        return GeoTargetConstantServiceClient::geoTargetConstantName(
+            $criterionId
         );
     }
 
     /**
-     * Generates resource name for a hotel group view.
+     * Generates a resource name of google ads field type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param string $criterionId the criterion ID
+     * @param string $googleAdsField
+     * @return string the google ads field resource name
+     */
+    public static function forGoogleAdsField(
+        $googleAdsField
+    ): string {
+        return GoogleAdsFieldServiceClient::googleAdsFieldName(
+            $googleAdsField
+        );
+    }
+
+    /**
+     * Generates a resource name of group placement view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $base64Placement
+     * @return string the group placement view resource name
+     */
+    public static function forGroupPlacementView(
+        $customerId,
+        $adGroupId,
+        $base64Placement
+    ): string {
+        return GroupPlacementViewServiceClient::groupPlacementViewName(
+            $customerId,
+            $adGroupId,
+            $base64Placement
+        );
+    }
+
+    /**
+     * Generates a resource name of hotel group view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the hotel group view resource name
      */
-    public static function forHotelGroupView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forHotelGroupView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return HotelGroupViewServiceClient::hotelGroupViewName(
             $customerId,
             $adGroupId,
@@ -1263,26 +1618,32 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a hotel performance view.
+     * Generates a resource name of hotel performance view type.
      *
-     * @param int $customerId the customer ID
+     * @param string $customerId
      * @return string the hotel performance view resource name
      */
-    public static function forHotelPerformanceView($customerId)
-    {
-        return HotelPerformanceViewServiceClient::hotelPerformanceViewName($customerId);
+    public static function forHotelPerformanceView(
+        $customerId
+    ): string {
+        return HotelPerformanceViewServiceClient::hotelPerformanceViewName(
+            $customerId
+        );
     }
 
     /**
-     * Generates resource name for a income range view.
+     * Generates a resource name of income range view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the income range view resource name
      */
-    public static function forIncomeRangeView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forIncomeRangeView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return IncomeRangeViewServiceClient::incomeRangeViewName(
             $customerId,
             $adGroupId,
@@ -1291,26 +1652,33 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan.
+     * Generates a resource name of keyword plan type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanId the keyword plan ID
+     * @param string $customerId
+     * @param string $keywordPlanId
      * @return string the keyword plan resource name
      */
-    public static function forKeywordPlan($customerId, $keywordPlanId)
-    {
-        return KeywordPlanServiceClient::keywordPlanName($customerId, $keywordPlanId);
+    public static function forKeywordPlan(
+        $customerId,
+        $keywordPlanId
+    ): string {
+        return KeywordPlanServiceClient::keywordPlanName(
+            $customerId,
+            $keywordPlanId
+        );
     }
 
     /**
-     * Generates resource name for a keyword plan ad group.
+     * Generates a resource name of keyword plan ad group type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanAdGroupId the keyword plan ad group ID
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupId
      * @return string the keyword plan ad group resource name
      */
-    public static function forKeywordPlanAdGroup($customerId, $keywordPlanAdGroupId)
-    {
+    public static function forKeywordPlanAdGroup(
+        $customerId,
+        $keywordPlanAdGroupId
+    ): string {
         return KeywordPlanAdGroupServiceClient::keywordPlanAdGroupName(
             $customerId,
             $keywordPlanAdGroupId
@@ -1318,14 +1686,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan ad group keyword.
+     * Generates a resource name of keyword plan ad group keyword type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanAdGroupKeywordId the keyword plan ad group keyword ID
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupKeywordId
      * @return string the keyword plan ad group keyword resource name
      */
-    public static function forKeywordPlanAdGroupKeyword($customerId, $keywordPlanAdGroupKeywordId)
-    {
+    public static function forKeywordPlanAdGroupKeyword(
+        $customerId,
+        $keywordPlanAdGroupKeywordId
+    ): string {
         return KeywordPlanAdGroupKeywordServiceClient::keywordPlanAdGroupKeywordName(
             $customerId,
             $keywordPlanAdGroupKeywordId
@@ -1333,14 +1703,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan campaign.
+     * Generates a resource name of keyword plan campaign type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanCampaignId the keyword plan campaign ID
+     * @param string $customerId
+     * @param string $keywordPlanCampaignId
      * @return string the keyword plan campaign resource name
      */
-    public static function forKeywordPlanCampaign($customerId, $keywordPlanCampaignId)
-    {
+    public static function forKeywordPlanCampaign(
+        $customerId,
+        $keywordPlanCampaignId
+    ): string {
         return KeywordPlanCampaignServiceClient::keywordPlanCampaignName(
             $customerId,
             $keywordPlanCampaignId
@@ -1348,14 +1720,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan campaign keyword.
+     * Generates a resource name of keyword plan campaign keyword type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanCampaignKeywordId the keyword plan campaign keyword ID
+     * @param string $customerId
+     * @param string $keywordPlanCampaignKeywordId
      * @return string the keyword plan campaign keyword resource name
      */
-    public static function forKeywordPlanCampaignKeyword($customerId, $keywordPlanCampaignKeywordId)
-    {
+    public static function forKeywordPlanCampaignKeyword(
+        $customerId,
+        $keywordPlanCampaignKeywordId
+    ): string {
         return KeywordPlanCampaignKeywordServiceClient::keywordPlanCampaignKeywordName(
             $customerId,
             $keywordPlanCampaignKeywordId
@@ -1363,28 +1737,53 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a label.
+     * Generates a resource name of keyword view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $labelId the label ID
-     * @return string the label resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @return string the keyword view resource name
      */
-    public static function forLabel($customerId, $labelId)
-    {
-        return LabelServiceClient::labelName($customerId, $labelId);
+    public static function forKeywordView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
+        return KeywordViewServiceClient::keywordViewName(
+            $customerId,
+            $adGroupId,
+            $criterionId
+        );
     }
 
     /**
-     * Generates resource name for a landing page view.
+     * Generates a resource name of label type.
      *
-     * @param int $customerId the customer ID
-     * @param string $unexpandedFinalUrlFingerprint the unexpanded final URL fingerprint
+     * @param string $customerId
+     * @param string $labelId
+     * @return string the label resource name
+     */
+    public static function forLabel(
+        $customerId,
+        $labelId
+    ): string {
+        return LabelServiceClient::labelName(
+            $customerId,
+            $labelId
+        );
+    }
+
+    /**
+     * Generates a resource name of landing page view type.
+     *
+     * @param string $customerId
+     * @param string $unexpandedFinalUrlFingerprint
      * @return string the landing page view resource name
      */
     public static function forLandingPageView(
         $customerId,
         $unexpandedFinalUrlFingerprint
-    ) {
+    ): string {
         return LandingPageViewServiceClient::landingPageViewName(
             $customerId,
             $unexpandedFinalUrlFingerprint
@@ -1392,43 +1791,52 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a language constant.
+     * Generates a resource name of language constant type.
      *
-     * @param int $languageConstantId the language constant ID
+     * @param string $criterionId
      * @return string the language constant resource name
      */
-    public static function forLanguageConstant($languageConstantId)
-    {
-        return LanguageConstantServiceClient::languageConstantName($languageConstantId);
-    }
-
-    /**
-     * Generates resource name for a location view.
-     *
-     * @param int $customerId the customer ID
-     * @param int $campaingId the campaign ID
-     * @param int $criterionId the criterion ID
-     * @return string the location view resource name
-     */
-    public static function forLocationView($customerId, $campaingId, $criterionId)
-    {
-        return LocationViewServiceClient::locationViewName(
-            $customerId,
-            $campaingId,
+    public static function forLanguageConstant(
+        $criterionId
+    ): string {
+        return LanguageConstantServiceClient::languageConstantName(
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for a managed placement view.
+     * Generates a resource name of location view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
+     * @return string the location view resource name
+     */
+    public static function forLocationView(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
+        return LocationViewServiceClient::locationViewName(
+            $customerId,
+            $campaignId,
+            $criterionId
+        );
+    }
+
+    /**
+     * Generates a resource name of managed placement view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the managed placement view resource name
      */
-    public static function forManagedPlacementView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forManagedPlacementView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return ManagedPlacementViewServiceClient::managedPlacementViewName(
             $customerId,
             $adGroupId,
@@ -1437,26 +1845,33 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a media file.
+     * Generates a resource name of media file type.
      *
-     * @param int $customerId the customer ID
-     * @param int $mediaFileId the media file ID
+     * @param string $customerId
+     * @param string $mediaFileId
      * @return string the media file resource name
      */
-    public static function forMediaFile($customerId, $mediaFileId)
-    {
-        return MediaFileServiceClient::mediaFileName($customerId, $mediaFileId);
+    public static function forMediaFile(
+        $customerId,
+        $mediaFileId
+    ): string {
+        return MediaFileServiceClient::mediaFileName(
+            $customerId,
+            $mediaFileId
+        );
     }
 
     /**
-     * Generates resource name for a merchant center link.
+     * Generates a resource name of merchant center link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $merchantCenterId the merchant center ID
+     * @param string $customerId
+     * @param string $merchantCenterId
      * @return string the merchant center link resource name
      */
-    public static function forMerchantCenterLink($customerId, $merchantCenterId)
-    {
+    public static function forMerchantCenterLink(
+        $customerId,
+        $merchantCenterId
+    ): string {
         return MerchantCenterLinkServiceClient::merchantCenterLinkName(
             $customerId,
             $merchantCenterId
@@ -1464,75 +1879,100 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a mobile app category constant.
+     * Generates a resource name of mobile app category constant type.
      *
-     * @param int $mobileAppCategoryId the mobile app category ID
+     * @param string $mobileAppCategoryId
      * @return string the mobile app category constant resource name
      */
-    public static function forMobileAppCategoryConstant($mobileAppCategoryId)
-    {
+    public static function forMobileAppCategoryConstant(
+        $mobileAppCategoryId
+    ): string {
         return MobileAppCategoryConstantServiceClient::mobileAppCategoryConstantName(
             $mobileAppCategoryId
         );
     }
 
     /**
-     * Generates resource name for a mobile device constant.
+     * Generates a resource name of mobile device constant type.
      *
-     * @param int $criterionId the criterion ID
+     * @param string $criterionId
      * @return string the mobile device constant resource name
      */
-    public static function forMobileDeviceConstant($criterionId)
-    {
-        return MobileDeviceConstantServiceClient::mobileDeviceConstantName($criterionId);
+    public static function forMobileDeviceConstant(
+        $criterionId
+    ): string {
+        return MobileDeviceConstantServiceClient::mobileDeviceConstantName(
+            $criterionId
+        );
     }
 
     /**
-     * Generates resource name for a operating system version constant.
+     * Generates a resource name of offline user data job type.
      *
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $offlineUserDataUpdateId
+     * @return string the offline user data job resource name
+     */
+    public static function forOfflineUserDataJob(
+        $customerId,
+        $offlineUserDataUpdateId
+    ): string {
+        return OfflineUserDataJobServiceClient::offlineUserDataJobName(
+            $customerId,
+            $offlineUserDataUpdateId
+        );
+    }
+
+    /**
+     * Generates a resource name of operating system version constant type.
+     *
+     * @param string $criterionId
      * @return string the operating system version constant resource name
      */
-    public static function forOperatingSystemVersionConstant($criterionId)
-    {
+    public static function forOperatingSystemVersionConstant(
+        $criterionId
+    ): string {
         return OperatingSystemVersionConstantServiceClient::operatingSystemVersionConstantName(
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for a paid organic search term view.
+     * Generates a resource name of paid organic search term view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $adGroupId the ad group ID
-     * @param string $searchTerm the search term
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $adGroupId
+     * @param string $base64SearchTerm
      * @return string the paid organic search term view resource name
      */
     public static function forPaidOrganicSearchTermView(
         $customerId,
         $campaignId,
         $adGroupId,
-        $searchTerm
-    ) {
+        $base64SearchTerm
+    ): string {
         return PaidOrganicSearchTermViewServiceClient::paidOrganicSearchTermViewName(
             $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $base64SearchTerm
         );
     }
 
     /**
-     * Generates resource name for a parental status view.
+     * Generates a resource name of parental status view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the parental status view resource name
      */
-    public static function forParentalStatusView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forParentalStatusView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return ParentalStatusViewServiceClient::parentalStatusViewName(
             $customerId,
             $adGroupId,
@@ -1541,38 +1981,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a payments account.
+     * Generates a resource name of product bidding category constant type.
      *
-     * @param int $customerId the customer ID
-     * @param int $paymentsAccountId the payments account ID
-     * @return string the payments account resource name
-     */
-    public static function forPaymentsAccount($customerId, $paymentsAccountId)
-    {
-        $pathTemplate = new PathTemplate(
-            'customers/{customer}/paymentsAccounts/{payments_account}'
-        );
-        return $pathTemplate->render(
-            [
-                'customer' => $customerId,
-                'payments_account' => $paymentsAccountId,
-            ]
-        );
-    }
-
-    /**
-     * Generates resource name for a product bidding category constant.
-     *
-     * @param string $countryCode the country code
-     * @param int $level the level
-     * @param int $id ID of the product bidding category
+     * @param string $countryCode
+     * @param string $level
+     * @param string $id
      * @return string the product bidding category constant resource name
      */
     public static function forProductBiddingCategoryConstant(
         $countryCode,
         $level,
         $id
-    ) {
+    ): string {
         return ProductBiddingCategoryConstantServiceClient::productBiddingCategoryConstantName(
             $countryCode,
             $level,
@@ -1581,43 +2001,53 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a product group view.
+     * Generates a resource name of product group view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adgroupId
+     * @param string $criterionId
      * @return string the product group view resource name
      */
-    public static function forProductGroupView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forProductGroupView(
+        $customerId,
+        $adgroupId,
+        $criterionId
+    ): string {
         return ProductGroupViewServiceClient::productGroupViewName(
             $customerId,
-            $adGroupId,
+            $adgroupId,
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for a recommendation.
+     * Generates a resource name of recommendation type.
      *
-     * @param int $customerId the customer ID
-     * @param string $recommendationId the recommendation ID
+     * @param string $customerId
+     * @param string $recommendationId
      * @return string the recommendation resource name
      */
-    public static function forRecommendation($customerId, $recommendationId)
-    {
-        return RecommendationServiceClient::recommendationName($customerId, $recommendationId);
+    public static function forRecommendation(
+        $customerId,
+        $recommendationId
+    ): string {
+        return RecommendationServiceClient::recommendationName(
+            $customerId,
+            $recommendationId
+        );
     }
 
     /**
-     * Generates resource name for a remarketing action.
+     * Generates a resource name of remarketing action type.
      *
-     * @param int $customerId the customer ID
-     * @param int $remarketingActionId the remarketing action ID
+     * @param string $customerId
+     * @param string $remarketingActionId
      * @return string the remarketing action resource name
      */
-    public static function forRemarketingAction($customerId, $remarketingActionId)
-    {
+    public static function forRemarketingAction(
+        $customerId,
+        $remarketingActionId
+    ): string {
         return RemarketingActionServiceClient::remarketingActionName(
             $customerId,
             $remarketingActionId
@@ -1625,38 +2055,41 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a search term view.
+     * Generates a resource name of search term view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $adGroupId the ad group ID
-     * @param string $searchTerm the search term
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $adGroupId
+     * @param string $query
      * @return string the search term view resource name
      */
     public static function forSearchTermView(
         $customerId,
         $campaignId,
         $adGroupId,
-        $searchTerm
-    ) {
+        $query
+    ): string {
         return SearchTermViewServiceClient::searchTermViewName(
             $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $query
         );
     }
 
     /**
-     * Generates resource name for a shared criterion.
+     * Generates a resource name of shared criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $sharedSetId the shared set ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $sharedSetId
+     * @param string $criterionId
      * @return string the shared criterion resource name
      */
-    public static function forSharedCriterion($customerId, $sharedSetId, $criterionId)
-    {
+    public static function forSharedCriterion(
+        $customerId,
+        $sharedSetId,
+        $criterionId
+    ): string {
         return SharedCriterionServiceClient::sharedCriterionName(
             $customerId,
             $sharedSetId,
@@ -1665,66 +2098,80 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a shared set.
+     * Generates a resource name of shared set type.
      *
-     * @param int $customerId the customer ID
-     * @param int $sharedSetId the shared set ID
+     * @param string $customerId
+     * @param string $sharedSetId
      * @return string the shared set resource name
      */
-    public static function forSharedSet($customerId, $sharedSetId)
-    {
-        return SharedSetServiceClient::sharedSetName($customerId, $sharedSetId);
-    }
-
-    /**
-     * Generates resource name for a shopping performance view.
-     *
-     * @param int $customerId the customer ID
-     * @return string the shopping performance view resource name
-     */
-    public static function forShoppingPerformanceView($customerId)
-    {
-        return ShoppingPerformanceViewServiceClient::shoppingPerformanceViewName($customerId);
-    }
-
-    /**
-     * Generates resource name for a third party app analytics link.
-     *
-     * @param int $customerId the customer ID
-     * @param int $thirdPartyAppAnalyticsLinkId the third party app analytics link ID
-     * @return string the third party app analytics link resource name
-     */
-    public static function forThirdPartyAppAnalyticsLinkName(
+    public static function forSharedSet(
         $customerId,
-        $thirdPartyAppAnalyticsLinkId
-    ) {
-        return ThirdPartyAppAnalyticsLinkServiceClient::thirdPartyAppAnalyticsLinkName(
+        $sharedSetId
+    ): string {
+        return SharedSetServiceClient::sharedSetName(
             $customerId,
-            $thirdPartyAppAnalyticsLinkId
+            $sharedSetId
         );
     }
 
     /**
-     * Generates resource name for a topic constant.
+     * Generates a resource name of shopping performance view type.
      *
-     * @param int $topicId the topic ID
-     * @return string the topic constant resource name
+     * @param string $customerId
+     * @return string the shopping performance view resource name
      */
-    public static function forTopicConstant($topicId)
-    {
-        return TopicConstantServiceClient::topicConstantName($topicId);
+    public static function forShoppingPerformanceView(
+        $customerId
+    ): string {
+        return ShoppingPerformanceViewServiceClient::shoppingPerformanceViewName(
+            $customerId
+        );
     }
 
     /**
-     * Generates resource name for a topic view.
+     * Generates a resource name of third party app analytics link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $customerLinkId
+     * @return string the third party app analytics link resource name
+     */
+    public static function forThirdPartyAppAnalyticsLink(
+        $customerId,
+        $customerLinkId
+    ): string {
+        return ThirdPartyAppAnalyticsLinkServiceClient::thirdPartyAppAnalyticsLinkName(
+            $customerId,
+            $customerLinkId
+        );
+    }
+
+    /**
+     * Generates a resource name of topic constant type.
+     *
+     * @param string $topicId
+     * @return string the topic constant resource name
+     */
+    public static function forTopicConstant(
+        $topicId
+    ): string {
+        return TopicConstantServiceClient::topicConstantName(
+            $topicId
+        );
+    }
+
+    /**
+     * Generates a resource name of topic view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the topic view resource name
      */
-    public static function forTopicView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forTopicView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return TopicViewServiceClient::topicViewName(
             $customerId,
             $adGroupId,
@@ -1733,38 +2180,73 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a user interest.
+     * Generates a resource name of user interest type.
      *
-     * @param int $customerId the customer ID
-     * @param int $userInterestId the user interest ID
+     * @param string $customerId
+     * @param string $userInterestId
      * @return string the user interest resource name
      */
-    public static function forUserInterest($customerId, $userInterestId)
-    {
-        return UserInterestServiceClient::userInterestName($customerId, $userInterestId);
+    public static function forUserInterest(
+        $customerId,
+        $userInterestId
+    ): string {
+        return UserInterestServiceClient::userInterestName(
+            $customerId,
+            $userInterestId
+        );
     }
 
     /**
-     * Generates resource name for a user list.
+     * Generates a resource name of user list type.
      *
-     * @param int $customerId the customer ID
-     * @param int $userListId the user list ID
+     * @param string $customerId
+     * @param string $userListId
      * @return string the user list resource name
      */
-    public static function forUserList($customerId, $userListId)
-    {
-        return UserListServiceClient::userListName($customerId, $userListId);
+    public static function forUserList(
+        $customerId,
+        $userListId
+    ): string {
+        return UserListServiceClient::userListName(
+            $customerId,
+            $userListId
+        );
     }
 
     /**
-     * Generates resource name for a video.
+     * Generates a resource name of user location view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $videoId the video ID
+     * @param string $customerId
+     * @param string $countryCriterionId
+     * @param string $isTargetingLocation
+     * @return string the user location view resource name
+     */
+    public static function forUserLocationView(
+        $customerId,
+        $countryCriterionId,
+        $isTargetingLocation
+    ): string {
+        return UserLocationViewServiceClient::userLocationViewName(
+            $customerId,
+            $countryCriterionId,
+            $isTargetingLocation
+        );
+    }
+
+    /**
+     * Generates a resource name of video type.
+     *
+     * @param string $customerId
+     * @param string $videoId
      * @return string the video resource name
      */
-    public static function forVideo($customerId, $videoId)
-    {
-        return VideoServiceClient::videoName($customerId, $videoId);
+    public static function forVideo(
+        $customerId,
+        $videoId
+    ): string {
+        return VideoServiceClient::videoName(
+            $customerId,
+            $videoId
+        );
     }
 }

--- a/src/Google/Ads/GoogleAds/Util/V7/ResourceNames.php
+++ b/src/Google/Ads/GoogleAds/Util/V7/ResourceNames.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Util\V7;
 
-use Google\Ads\GoogleAds\V7\Enums\AssetFieldTypeEnum\AssetFieldType;
-use Google\Ads\GoogleAds\V7\Enums\ExtensionTypeEnum\ExtensionType;
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V7\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAssetServiceClient;
@@ -66,6 +67,7 @@ use Google\Ads\GoogleAds\V7\Services\CombinedAudienceServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ConversionCustomVariableServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CurrencyConstantServiceClient;
+use Google\Ads\GoogleAds\V7\Services\CustomAudienceServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomerAssetServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomerClientLinkServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomerClientServiceClient;
@@ -80,7 +82,9 @@ use Google\Ads\GoogleAds\V7\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V7\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DomainCategoryServiceClient;
+use Google\Ads\GoogleAds\V7\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ExpandedLandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ExtensionFeedItemServiceClient;
 use Google\Ads\GoogleAds\V7\Services\FeedItemServiceClient;
@@ -103,6 +107,7 @@ use Google\Ads\GoogleAds\V7\Services\KeywordPlanAdGroupServiceClient;
 use Google\Ads\GoogleAds\V7\Services\KeywordPlanCampaignKeywordServiceClient;
 use Google\Ads\GoogleAds\V7\Services\KeywordPlanCampaignServiceClient;
 use Google\Ads\GoogleAds\V7\Services\KeywordPlanServiceClient;
+use Google\Ads\GoogleAds\V7\Services\KeywordViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\LabelServiceClient;
 use Google\Ads\GoogleAds\V7\Services\LandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\LanguageConstantServiceClient;
@@ -113,6 +118,7 @@ use Google\Ads\GoogleAds\V7\Services\MediaFileServiceClient;
 use Google\Ads\GoogleAds\V7\Services\MerchantCenterLinkServiceClient;
 use Google\Ads\GoogleAds\V7\Services\MobileAppCategoryConstantServiceClient;
 use Google\Ads\GoogleAds\V7\Services\MobileDeviceConstantServiceClient;
+use Google\Ads\GoogleAds\V7\Services\OfflineUserDataJobServiceClient;
 use Google\Ads\GoogleAds\V7\Services\OperatingSystemVersionConstantServiceClient;
 use Google\Ads\GoogleAds\V7\Services\PaidOrganicSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ParentalStatusViewServiceClient;
@@ -129,6 +135,7 @@ use Google\Ads\GoogleAds\V7\Services\TopicConstantServiceClient;
 use Google\Ads\GoogleAds\V7\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V7\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\VideoServiceClient;
 use Google\Ads\GoogleAds\V7\Services\WebpageViewServiceClient;
 use Google\ApiCore\PathTemplate;
@@ -140,26 +147,53 @@ final class ResourceNames
 {
 
     /**
-     * Generates resource name for an account budget.
+     * Generates a resource name of payments account type.
      *
-     * @param int $customerId the customer ID
-     * @param int $accountBudgetId the account budget ID
-     * @return string the account budget resource name
+     * @param string $customerId
+     * @param string $paymentsAccountId
+     * @return string the payments account resource name
      */
-    public static function forAccountBudget($customerId, $accountBudgetId)
-    {
-        return AccountBudgetServiceClient::accountBudgetName($customerId, $accountBudgetId);
+    public static function forPaymentsAccount(
+        $customerId,
+        $paymentsAccountId
+    ): string {
+        $pathTemplate = new PathTemplate(
+            'customers/{customer}/paymentsAccounts/{payments_account}'
+        );
+        return $pathTemplate->render([
+            'customer' => $customerId,
+            'payments_account' => $paymentsAccountId,
+        ]);
     }
 
     /**
-     * Generates resource name for an account budget proposal.
+     * Generates a resource name of account budget type.
      *
-     * @param int $customerId the customer ID
-     * @param int $accountBudgetProposalId the account budget proposal ID
+     * @param string $customerId
+     * @param string $accountBudgetId
+     * @return string the account budget resource name
+     */
+    public static function forAccountBudget(
+        $customerId,
+        $accountBudgetId
+    ): string {
+        return AccountBudgetServiceClient::accountBudgetName(
+            $customerId,
+            $accountBudgetId
+        );
+    }
+
+    /**
+     * Generates a resource name of account budget proposal type.
+     *
+     * @param string $customerId
+     * @param string $accountBudgetProposalId
      * @return string the account budget proposal resource name
      */
-    public static function forAccountBudgetProposal($customerId, $accountBudgetProposalId)
-    {
+    public static function forAccountBudgetProposal(
+        $customerId,
+        $accountBudgetProposalId
+    ): string {
         return AccountBudgetProposalServiceClient::accountBudgetProposalName(
             $customerId,
             $accountBudgetProposalId
@@ -167,65 +201,117 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an account link.
+     * Generates a resource name of account link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $accountLinkId the account link ID
+     * @param string $customerId
+     * @param string $accountLinkId
      * @return string the account link resource name
      */
-    public static function forAccountLinkName($customerId, $accountLinkId)
-    {
-        return AccountLinkServiceClient::accountLinkName($customerId, $accountLinkId);
+    public static function forAccountLink(
+        $customerId,
+        $accountLinkId
+    ): string {
+        return AccountLinkServiceClient::accountLinkName(
+            $customerId,
+            $accountLinkId
+        );
     }
 
     /**
-     * Generates resource name for an ad.
+     * Generates a resource name of ad type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adId the ad ID
+     * @param string $customerId
+     * @param string $adId
      * @return string the ad resource name
      */
-    public static function forAd($customerId, $adId)
-    {
-        return AdServiceClient::adName($customerId, $adId);
+    public static function forAd(
+        $customerId,
+        $adId
+    ): string {
+        return AdServiceClient::adName(
+            $customerId,
+            $adId
+        );
     }
 
     /**
-     * Generates resource name for an ad group.
+     * Generates a resource name of ad group type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
+     * @param string $customerId
+     * @param string $adGroupId
      * @return string the ad group resource name
      */
-    public static function forAdGroup($customerId, $adGroupId)
-    {
-        return AdGroupServiceClient::adGroupName($customerId, $adGroupId);
+    public static function forAdGroup(
+        $customerId,
+        $adGroupId
+    ): string {
+        return AdGroupServiceClient::adGroupName(
+            $customerId,
+            $adGroupId
+        );
     }
 
     /**
-     * Generates resource name for an ad group ad.
+     * Generates a resource name of ad group ad type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $adId the ad ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
      * @return string the ad group ad resource name
      */
-    public static function forAdGroupAd($customerId, $adGroupId, $adId)
-    {
-        return AdGroupAdServiceClient::adGroupAdName($customerId, $adGroupId, $adId);
+    public static function forAdGroupAd(
+        $customerId,
+        $adGroupId,
+        $adId
+    ): string {
+        return AdGroupAdServiceClient::adGroupAdName(
+            $customerId,
+            $adGroupId,
+            $adId
+        );
     }
 
     /**
-     * Generates resource name for an ad group ad label.
+     * Generates a resource name of ad group ad asset view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $adId the ad ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     * @param string $assetId
+     * @param string $fieldType
+     * @return string the ad group ad asset view resource name
+     */
+    public static function forAdGroupAdAssetView(
+        $customerId,
+        $adGroupId,
+        $adId,
+        $assetId,
+        $fieldType
+    ): string {
+        return AdGroupAdAssetViewServiceClient::adGroupAdAssetViewName(
+            $customerId,
+            $adGroupId,
+            $adId,
+            $assetId,
+            $fieldType
+        );
+    }
+
+    /**
+     * Generates a resource name of ad group ad label type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     * @param string $labelId
      * @return string the ad group ad label resource name
      */
-    public static function forAdGroupAdLabel($customerId, $adGroupId, $adId, $labelId)
-    {
+    public static function forAdGroupAdLabel(
+        $customerId,
+        $adGroupId,
+        $adId,
+        $labelId
+    ): string {
         return AdGroupAdLabelServiceClient::adGroupAdLabelName(
             $customerId,
             $adGroupId,
@@ -235,7 +321,7 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a ad group asset.
+     * Generates a resource name of ad group asset type.
      *
      * @param string $customerId
      * @param string $adGroupId
@@ -248,7 +334,7 @@ final class ResourceNames
         $adGroupId,
         $assetId,
         $fieldType
-    ) {
+    ): string {
         return AdGroupAssetServiceClient::adGroupAssetName(
             $customerId,
             $adGroupId,
@@ -258,15 +344,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group audience view.
+     * Generates a resource name of ad group audience view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @return string the ad group audience resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @return string the ad group audience view resource name
      */
-    public static function forAdGroupAudienceView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdGroupAudienceView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AdGroupAudienceViewServiceClient::adGroupAudienceViewName(
             $customerId,
             $adGroupId,
@@ -275,15 +364,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group bid modifier.
+     * Generates a resource name of ad group bid modifier type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the ad group bid modifier resource name
      */
-    public static function forAdGroupBidModifier($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdGroupBidModifier(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AdGroupBidModifierServiceClient::adGroupBidModifierName(
             $customerId,
             $adGroupId,
@@ -292,15 +384,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group criterion.
+     * Generates a resource name of ad group criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the ad group criterion resource name
      */
-    public static function forAdGroupCriterion($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdGroupCriterion(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AdGroupCriterionServiceClient::adGroupCriterionName(
             $customerId,
             $adGroupId,
@@ -309,20 +404,20 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group criterion label.
+     * Generates a resource name of ad group criterion label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @param int $labelId the label ID
-     * @return string the ad group criterion resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $labelId
+     * @return string the ad group criterion label resource name
      */
     public static function forAdGroupCriterionLabel(
         $customerId,
         $adGroupId,
         $criterionId,
         $labelId
-    ) {
+    ): string {
         return AdGroupCriterionLabelServiceClient::adGroupCriterionLabelName(
             $customerId,
             $adGroupId,
@@ -332,15 +427,15 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group criterion simulation.
+     * Generates a resource name of ad group criterion simulation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @param int $type the type
-     * @param int $modificationMethod the modification method
-     * @param int $startDate the start date
-     * @param int $endDate the end date
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $type
+     * @param string $modificationMethod
+     * @param string $startDate
+     * @param string $endDate
      * @return string the ad group criterion simulation resource name
      */
     public static function forAdGroupCriterionSimulation(
@@ -351,7 +446,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return AdGroupCriterionSimulationServiceClient::adGroupCriterionSimulationName(
             $customerId,
             $adGroupId,
@@ -364,32 +459,38 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group extension setting.
+     * Generates a resource name of ad group extension setting type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $extensionType the extension type
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $extensionType
      * @return string the ad group extension setting resource name
      */
-    public static function forAdGroupExtensionSetting($customerId, $adGroupId, $extensionType)
-    {
+    public static function forAdGroupExtensionSetting(
+        $customerId,
+        $adGroupId,
+        $extensionType
+    ): string {
         return AdGroupExtensionSettingServiceClient::adGroupExtensionSettingName(
             $customerId,
             $adGroupId,
-            ExtensionType::name($extensionType)
+            $extensionType
         );
     }
 
     /**
-     * Generates resource name for an ad group feed.
+     * Generates a resource name of ad group feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $feedId the feed Id
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $feedId
      * @return string the ad group feed resource name
      */
-    public static function forAdGroupFeed($customerId, $adGroupId, $feedId)
-    {
+    public static function forAdGroupFeed(
+        $customerId,
+        $adGroupId,
+        $feedId
+    ): string {
         return AdGroupFeedServiceClient::adGroupFeedName(
             $customerId,
             $adGroupId,
@@ -398,18 +499,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group label.
+     * Generates a resource name of ad group label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $labelId
      * @return string the ad group label resource name
      */
     public static function forAdGroupLabel(
         $customerId,
         $adGroupId,
         $labelId
-    ) {
+    ): string {
         return AdGroupLabelServiceClient::adGroupLabelName(
             $customerId,
             $adGroupId,
@@ -418,14 +519,14 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad group simulation.
+     * Generates a resource name of ad group simulation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $type the type
-     * @param int $modificationMethod the modification method
-     * @param int $startDate the start date
-     * @param int $endDate the end date
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $type
+     * @param string $modificationMethod
+     * @param string $startDate
+     * @param string $endDate
      * @return string the ad group simulation resource name
      */
     public static function forAdGroupSimulation(
@@ -435,7 +536,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return AdGroupSimulationServiceClient::adGroupSimulationName(
             $customerId,
             $adGroupId,
@@ -447,16 +548,20 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad parameter.
+     * Generates a resource name of ad parameter type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
-     * @param int $parameterIndex the parameter index
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $parameterIndex
      * @return string the ad parameter resource name
      */
-    public static function forAdParameter($customerId, $adGroupId, $criterionId, $parameterIndex)
-    {
+    public static function forAdParameter(
+        $customerId,
+        $adGroupId,
+        $criterionId,
+        $parameterIndex
+    ): string {
         return AdParameterServiceClient::adParameterName(
             $customerId,
             $adGroupId,
@@ -466,32 +571,38 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an ad schedule view.
+     * Generates a resource name of ad schedule view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the ad schedule view resource name
      */
-    public static function forAdScheduleView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAdScheduleView(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return AdScheduleViewServiceClient::adScheduleViewName(
             $customerId,
-            $adGroupId,
+            $campaignId,
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for an age range view.
+     * Generates a resource name of age range view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the age range view resource name
      */
-    public static function forAgeRangeView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forAgeRangeView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return AgeRangeViewServiceClient::ageRangeViewName(
             $customerId,
             $adGroupId,
@@ -500,43 +611,58 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an asset.
+     * Generates a resource name of asset type.
      *
-     * @param int $customerId the customer ID
-     * @param int $assetId the asset ID
+     * @param string $customerId
+     * @param string $assetId
      * @return string the asset resource name
      */
-    public static function forAsset($customerId, $assetId)
-    {
-        return AssetServiceClient::assetName($customerId, $assetId);
+    public static function forAsset(
+        $customerId,
+        $assetId
+    ): string {
+        return AssetServiceClient::assetName(
+            $customerId,
+            $assetId
+        );
     }
 
     /**
-     * Generates resource name for a batch job.
+     * Generates a resource name of batch job type.
      *
-     * @param int $customerId the customer ID
-     * @param int $batchJobId the batch job ID
+     * @param string $customerId
+     * @param string $batchJobId
      * @return string the batch job resource name
      */
-    public static function forBatchJob($customerId, $batchJobId)
-    {
-        return BatchJobServiceClient::batchJobName($customerId, $batchJobId);
+    public static function forBatchJob(
+        $customerId,
+        $batchJobId
+    ): string {
+        return BatchJobServiceClient::batchJobName(
+            $customerId,
+            $batchJobId
+        );
     }
 
     /**
-     * Generates resource name for a bidding strategy.
+     * Generates a resource name of bidding strategy type.
      *
-     * @param int $customerId the customer ID
-     * @param int $biddingStrategyId the bidding strategy ID
+     * @param string $customerId
+     * @param string $biddingStrategyId
      * @return string the bidding strategy resource name
      */
-    public static function forBiddingStrategy($customerId, $biddingStrategyId)
-    {
-        return BiddingStrategyServiceClient::biddingStrategyName($customerId, $biddingStrategyId);
+    public static function forBiddingStrategy(
+        $customerId,
+        $biddingStrategyId
+    ): string {
+        return BiddingStrategyServiceClient::biddingStrategyName(
+            $customerId,
+            $biddingStrategyId
+        );
     }
 
     /**
-     * Generates resource name for a bidding strategy simulation.
+     * Generates a resource name of bidding strategy simulation type.
      *
      * @param string $customerId
      * @param string $biddingStrategyId
@@ -553,7 +679,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return BiddingStrategySimulationServiceClient::biddingStrategySimulationName(
             $customerId,
             $biddingStrategyId,
@@ -565,58 +691,75 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a billing setup.
+     * Generates a resource name of billing setup type.
      *
-     * @param int $customerId the customer ID
-     * @param int $billingSetupId the billing setup ID
+     * @param string $customerId
+     * @param string $billingSetupId
      * @return string the billing setup resource name
      */
-    public static function forBillingSetup($customerId, $billingSetupId)
-    {
-        return BillingSetupServiceClient::billingSetupName($customerId, $billingSetupId);
-    }
-
-    /**
-     * Generates resource name for a campaign.
-     *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @return string the campaign resource name
-     */
-    public static function forCampaign($customerId, $campaignId)
-    {
-        return CampaignServiceClient::campaignName($customerId, $campaignId);
-    }
-
-    /**
-     * Generates resource name for a campaign asset.
-     *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $assetId the asset ID
-     * @param int $fieldType the field type
-     * @return string the campaign asset resource name
-     */
-    public static function forCampaignAsset($customerId, $campaignId, $assetId, $fieldType)
-    {
-        return CampaignAssetServiceClient::campaignAssetName(
+    public static function forBillingSetup(
+        $customerId,
+        $billingSetupId
+    ): string {
+        return BillingSetupServiceClient::billingSetupName(
             $customerId,
-            $campaignId,
-            $assetId,
-            AssetFieldType::name($fieldType)
+            $billingSetupId
         );
     }
 
     /**
-     * Generates resource name for a campaign audience view.
+     * Generates a resource name of campaign type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @return string the campaign resource name
+     */
+    public static function forCampaign(
+        $customerId,
+        $campaignId
+    ): string {
+        return CampaignServiceClient::campaignName(
+            $customerId,
+            $campaignId
+        );
+    }
+
+    /**
+     * Generates a resource name of campaign asset type.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $assetId
+     * @param string $fieldType
+     * @return string the campaign asset resource name
+     */
+    public static function forCampaignAsset(
+        $customerId,
+        $campaignId,
+        $assetId,
+        $fieldType
+    ): string {
+        return CampaignAssetServiceClient::campaignAssetName(
+            $customerId,
+            $campaignId,
+            $assetId,
+            $fieldType
+        );
+    }
+
+    /**
+     * Generates a resource name of campaign audience view type.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the campaign audience view resource name
      */
-    public static function forCampaignAudienceView($customerId, $campaignId, $criterionId)
-    {
+    public static function forCampaignAudienceView(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return CampaignAudienceViewServiceClient::campaignAudienceViewName(
             $customerId,
             $campaignId,
@@ -625,15 +768,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign bid modifier.
+     * Generates a resource name of campaign bid modifier type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the campaign bid modifier resource name
      */
-    public static function forCampaignBidModifier($customerId, $campaignId, $criterionId)
-    {
+    public static function forCampaignBidModifier(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return CampaignBidModifierServiceClient::campaignBidModifierName(
             $customerId,
             $campaignId,
@@ -642,27 +788,35 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign budget.
+     * Generates a resource name of campaign budget type.
      *
-     * @param int $customerId the customer ID
-     * @param int $budgetId the budget ID
+     * @param string $customerId
+     * @param string $campaignBudgetId
      * @return string the campaign budget resource name
      */
-    public static function forCampaignBudget($customerId, $budgetId)
-    {
-        return CampaignBudgetServiceClient::campaignBudgetName($customerId, $budgetId);
+    public static function forCampaignBudget(
+        $customerId,
+        $campaignBudgetId
+    ): string {
+        return CampaignBudgetServiceClient::campaignBudgetName(
+            $customerId,
+            $campaignBudgetId
+        );
     }
 
     /**
-     * Generates resource name for a campaign criterion.
+     * Generates a resource name of campaign criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the campaign criterion resource name
      */
-    public static function forCampaignCriterion($customerId, $campaignId, $criterionId)
-    {
+    public static function forCampaignCriterion(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return CampaignCriterionServiceClient::campaignCriterionName(
             $customerId,
             $campaignId,
@@ -671,15 +825,15 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign criterion simulation.
+     * Generates a resource name of campaign criterion simulation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $criterionId the criterion ID
-     * @param int $type the type
-     * @param int $modificationMethod the modification method
-     * @param int $startDate the start date
-     * @param int $endDate the end date
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
+     * @param string $type
+     * @param string $modificationMethod
+     * @param string $startDate
+     * @param string $endDate
      * @return string the campaign criterion simulation resource name
      */
     public static function forCampaignCriterionSimulation(
@@ -690,7 +844,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return CampaignCriterionSimulationServiceClient::campaignCriterionSimulationName(
             $customerId,
             $campaignId,
@@ -703,15 +857,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign draft.
+     * Generates a resource name of campaign draft type.
      *
-     * @param int $customerId the customer ID
-     * @param int $baseCampaignId the base campaign ID
-     * @param int $draftId the draft Id
+     * @param string $customerId
+     * @param string $baseCampaignId
+     * @param string $draftId
      * @return string the campaign draft resource name
      */
-    public static function forCampaignDraft($customerId, $baseCampaignId, $draftId)
-    {
+    public static function forCampaignDraft(
+        $customerId,
+        $baseCampaignId,
+        $draftId
+    ): string {
         return CampaignDraftServiceClient::campaignDraftName(
             $customerId,
             $baseCampaignId,
@@ -720,14 +877,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign experiment.
+     * Generates a resource name of campaign experiment type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignExperimentId the campaign ID
+     * @param string $customerId
+     * @param string $campaignExperimentId
      * @return string the campaign experiment resource name
      */
-    public static function forCampaignExperiment($customerId, $campaignExperimentId)
-    {
+    public static function forCampaignExperiment(
+        $customerId,
+        $campaignExperimentId
+    ): string {
         return CampaignExperimentServiceClient::campaignExperimentName(
             $customerId,
             $campaignExperimentId
@@ -735,45 +894,58 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign extension setting.
+     * Generates a resource name of campaign extension setting type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $extensionType the extension type
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $extensionType
      * @return string the campaign extension setting resource name
      */
-    public static function forCampaignExtensionSetting($customerId, $campaignId, $extensionType)
-    {
+    public static function forCampaignExtensionSetting(
+        $customerId,
+        $campaignId,
+        $extensionType
+    ): string {
         return CampaignExtensionSettingServiceClient::campaignExtensionSettingName(
             $customerId,
             $campaignId,
-            ExtensionType::name($extensionType)
+            $extensionType
         );
     }
 
     /**
-     * Generates resource name for a campaign feed.
+     * Generates a resource name of campaign feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $feedId the feed Id
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $feedId
      * @return string the campaign feed resource name
      */
-    public static function forCampaignFeed($customerId, $campaignId, $feedId)
-    {
-        return CampaignFeedServiceClient::campaignFeedName($customerId, $campaignId, $feedId);
+    public static function forCampaignFeed(
+        $customerId,
+        $campaignId,
+        $feedId
+    ): string {
+        return CampaignFeedServiceClient::campaignFeedName(
+            $customerId,
+            $campaignId,
+            $feedId
+        );
     }
 
     /**
-     * Generates resource name for a campaign label.
+     * Generates a resource name of campaign label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $labelId
      * @return string the campaign label resource name
      */
-    public static function forCampaignLabel($customerId, $campaignId, $labelId)
-    {
+    public static function forCampaignLabel(
+        $customerId,
+        $campaignId,
+        $labelId
+    ): string {
         return CampaignLabelServiceClient::campaignLabelName(
             $customerId,
             $campaignId,
@@ -782,15 +954,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign shared set.
+     * Generates a resource name of campaign shared set type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $sharedSetId the shared set Id
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $sharedSetId
      * @return string the campaign shared set resource name
      */
-    public static function forCampaignSharedSet($customerId, $campaignId, $sharedSetId)
-    {
+    public static function forCampaignSharedSet(
+        $customerId,
+        $campaignId,
+        $sharedSetId
+    ): string {
         return CampaignSharedSetServiceClient::campaignSharedSetName(
             $customerId,
             $campaignId,
@@ -799,7 +974,7 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a campaign simulation.
+     * Generates a resource name of campaign simulation type.
      *
      * @param string $customerId
      * @param string $campaignId
@@ -816,7 +991,7 @@ final class ResourceNames
         $modificationMethod,
         $startDate,
         $endDate
-    ) {
+    ): string {
         return CampaignSimulationServiceClient::campaignSimulationName(
             $customerId,
             $campaignId,
@@ -828,50 +1003,67 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a carrier constant.
+     * Generates a resource name of carrier constant type.
      *
-     * @param int $criterionId the criterion ID
+     * @param string $criterionId
      * @return string the carrier constant resource name
      */
-    public static function forCarrierConstant($criterionId)
-    {
-        return CarrierConstantServiceClient::carrierConstantName($criterionId);
+    public static function forCarrierConstant(
+        $criterionId
+    ): string {
+        return CarrierConstantServiceClient::carrierConstantName(
+            $criterionId
+        );
     }
 
     /**
-     * Generates resource name for a change status.
+     * Generates a resource name of change status type.
      *
-     * @param int $customerId the customer ID
-     * @param int $changeStatusId the change status ID
+     * @param string $customerId
+     * @param string $changeStatusId
      * @return string the change status resource name
      */
-    public static function forChangeStatus($customerId, $changeStatusId)
-    {
-        return ChangeStatusServiceClient::changeStatusName($customerId, $changeStatusId);
+    public static function forChangeStatus(
+        $customerId,
+        $changeStatusId
+    ): string {
+        return ChangeStatusServiceClient::changeStatusName(
+            $customerId,
+            $changeStatusId
+        );
     }
 
     /**
-     * Generates resource name for a click view.
+     * Generates a resource name of click view type.
      *
-     * @param int $customerId the customer ID
-     * @param string $date (yyyy-MM-dd) the campaign ID
-     * @param int $gclId the Google Click Id
+     * @param string $customerId
+     * @param string $date
+     * @param string $gclid
      * @return string the click view resource name
      */
-    public static function forClickView($customerId, $date, $gclId)
-    {
-        return ClickViewServiceClient::clickViewName($customerId, $date, $gclId);
+    public static function forClickView(
+        $customerId,
+        $date,
+        $gclid
+    ): string {
+        return ClickViewServiceClient::clickViewName(
+            $customerId,
+            $date,
+            $gclid
+        );
     }
 
     /**
-     * Generates resource name for a combined audience.
+     * Generates a resource name of combined audience type.
      *
-     * @param int $customerId the customer ID
-     * @param int $combinedAudienceId the combined audience ID
+     * @param string $customerId
+     * @param string $combinedAudienceId
      * @return string the combined audience resource name
      */
-    public static function forCombinedAudience($customerId, $combinedAudienceId)
-    {
+    public static function forCombinedAudience(
+        $customerId,
+        $combinedAudienceId
+    ): string {
         return CombinedAudienceServiceClient::combinedAudienceName(
             $customerId,
             $combinedAudienceId
@@ -879,14 +1071,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a conversion action.
+     * Generates a resource name of conversion action type.
      *
-     * @param int $customerId the customer ID
-     * @param int $conversionActionId the conversion action ID
+     * @param string $customerId
+     * @param string $conversionActionId
      * @return string the conversion action resource name
      */
-    public static function forConversionAction($customerId, $conversionActionId)
-    {
+    public static function forConversionAction(
+        $customerId,
+        $conversionActionId
+    ): string {
         return ConversionActionServiceClient::conversionActionName(
             $customerId,
             $conversionActionId
@@ -894,7 +1088,7 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a conversion custom variable.
+     * Generates a resource name of conversion custom variable type.
      *
      * @param string $customerId
      * @param string $conversionCustomVariableId
@@ -903,7 +1097,7 @@ final class ResourceNames
     public static function forConversionCustomVariable(
         $customerId,
         $conversionCustomVariableId
-    ) {
+    ): string {
         return ConversionCustomVariableServiceClient::conversionCustomVariableName(
             $customerId,
             $conversionCustomVariableId
@@ -911,29 +1105,52 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a currency constant.
+     * Generates a resource name of currency constant type.
      *
-     * @param string $currencyConstantId the currency constant ID
+     * @param string $code
      * @return string the currency constant resource name
      */
-    public static function forCurrencyConstant($currencyConstantId)
-    {
-        return CurrencyConstantServiceClient::currencyConstantName($currencyConstantId);
+    public static function forCurrencyConstant(
+        $code
+    ): string {
+        return CurrencyConstantServiceClient::currencyConstantName(
+            $code
+        );
     }
 
     /**
-     * Generates resource name for a customer.
+     * Generates a resource name of custom audience type.
      *
-     * @param int $customerId the customer ID
+     * @param string $customerId
+     * @param string $customAudienceId
+     * @return string the custom audience resource name
+     */
+    public static function forCustomAudience(
+        $customerId,
+        $customAudienceId
+    ): string {
+        return CustomAudienceServiceClient::customAudienceName(
+            $customerId,
+            $customAudienceId
+        );
+    }
+
+    /**
+     * Generates a resource name of customer type.
+     *
+     * @param string $customerId
      * @return string the customer resource name
      */
-    public static function forCustomer($customerId)
-    {
-        return CustomerServiceClient::customerName($customerId);
+    public static function forCustomer(
+        $customerId
+    ): string {
+        return CustomerServiceClient::customerName(
+            $customerId
+        );
     }
 
     /**
-     * Generates resource name for a customer asset.
+     * Generates a resource name of customer asset type.
      *
      * @param string $customerId
      * @param string $assetId
@@ -944,7 +1161,7 @@ final class ResourceNames
         $customerId,
         $assetId,
         $fieldType
-    ) {
+    ): string {
         return CustomerAssetServiceClient::customerAssetName(
             $customerId,
             $assetId,
@@ -953,27 +1170,35 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a customer client.
+     * Generates a resource name of customer client type.
      *
-     * @param int $customerId the customer ID
-     * @param int $customerClientId the customer client ID
+     * @param string $customerId
+     * @param string $clientCustomerId
      * @return string the customer client resource name
      */
-    public static function forCustomerClient($customerId, $customerClientId)
-    {
-        return CustomerClientServiceClient::customerClientName($customerId, $customerClientId);
+    public static function forCustomerClient(
+        $customerId,
+        $clientCustomerId
+    ): string {
+        return CustomerClientServiceClient::customerClientName(
+            $customerId,
+            $clientCustomerId
+        );
     }
 
     /**
-     * Generates resource name for a customer client link.
+     * Generates a resource name of customer client link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $clientCustomerId the client customer ID
-     * @param int $managerLinkId the manager customer ID
+     * @param string $customerId
+     * @param string $clientCustomerId
+     * @param string $managerLinkId
      * @return string the customer client link resource name
      */
-    public static function forCustomerClientLink($customerId, $clientCustomerId, $managerLinkId)
-    {
+    public static function forCustomerClientLink(
+        $customerId,
+        $clientCustomerId,
+        $managerLinkId
+    ): string {
         return CustomerClientLinkServiceClient::customerClientLinkName(
             $customerId,
             $clientCustomerId,
@@ -982,73 +1207,87 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a customer extension setting.
+     * Generates a resource name of customer extension setting type.
      *
-     * @param int $customerId the customer ID
-     * @param int $extensionType the extension type
+     * @param string $customerId
+     * @param string $extensionType
      * @return string the customer extension setting resource name
      */
-    public static function forCustomerExtensionSetting($customerId, $extensionType)
-    {
+    public static function forCustomerExtensionSetting(
+        $customerId,
+        $extensionType
+    ): string {
         return CustomerExtensionSettingServiceClient::customerExtensionSettingName(
             $customerId,
-            ExtensionType::name($extensionType)
+            $extensionType
         );
     }
 
     /**
-     * Generates resource name for a customer feed.
+     * Generates a resource name of customer feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
+     * @param string $customerId
+     * @param string $feedId
      * @return string the customer feed resource name
      */
-    public static function forCustomerFeed($customerId, $feedId)
-    {
-        return CustomerFeedServiceClient::customerFeedName($customerId, $feedId);
+    public static function forCustomerFeed(
+        $customerId,
+        $feedId
+    ): string {
+        return CustomerFeedServiceClient::customerFeedName(
+            $customerId,
+            $feedId
+        );
     }
 
     /**
-     * Generates resource name for a customer label.
+     * Generates a resource name of customer label type.
      *
-     * @param int $customerId the customer ID
-     * @param int $labelId the label ID
+     * @param string $customerId
+     * @param string $labelId
      * @return string the customer label resource name
      */
-    public static function forCustomerLabel($customerId, $labelId)
-    {
-        return CustomerLabelServiceClient::customerLabelName($customerId, $labelId);
+    public static function forCustomerLabel(
+        $customerId,
+        $labelId
+    ): string {
+        return CustomerLabelServiceClient::customerLabelName(
+            $customerId,
+            $labelId
+        );
     }
 
     /**
-     * Generates resource name for a customer manager link.
+     * Generates a resource name of customer manager link type.
      *
-     * @param int $clientCustomerId the client customer ID
-     * @param int $managerCustomerId the manager customer ID
-     * @param int $managerLinkId the manager link ID
+     * @param string $customerId
+     * @param string $managerCustomerId
+     * @param string $managerLinkId
      * @return string the customer manager link resource name
      */
     public static function forCustomerManagerLink(
-        $clientCustomerId,
+        $customerId,
         $managerCustomerId,
         $managerLinkId
-    ) {
+    ): string {
         return CustomerManagerLinkServiceClient::customerManagerLinkName(
-            $clientCustomerId,
+            $customerId,
             $managerCustomerId,
             $managerLinkId
         );
     }
 
     /**
-     * Generates resource name for a customer negative criterion.
+     * Generates a resource name of customer negative criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $criterionId
      * @return string the customer negative criterion resource name
      */
-    public static function forCustomerNegativeCriterion($customerId, $criterionId)
-    {
+    public static function forCustomerNegativeCriterion(
+        $customerId,
+        $criterionId
+    ): string {
         return CustomerNegativeCriterionServiceClient::customerNegativeCriterionName(
             $customerId,
             $criterionId
@@ -1056,26 +1295,33 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a customer user access.
+     * Generates a resource name of customer user access type.
      *
-     * @param int $customerId the customer ID
-     * @param int $userId the user ID
+     * @param string $customerId
+     * @param string $userId
      * @return string the customer user access resource name
      */
-    public static function forCustomerUserAccess($customerId, $userId)
-    {
-        return CustomerUserAccessServiceClient::customerUserAccessName($customerId, $userId);
+    public static function forCustomerUserAccess(
+        $customerId,
+        $userId
+    ): string {
+        return CustomerUserAccessServiceClient::customerUserAccessName(
+            $customerId,
+            $userId
+        );
     }
 
     /**
-     * Generates resource name for a customer user access invitation.
+     * Generates a resource name of customer user access invitation type.
      *
-     * @param int $customerId the customer ID
-     * @param int $invitationId the invitation ID
+     * @param string $customerId
+     * @param string $invitationId
      * @return string the customer user access invitation resource name
      */
-    public static function forCustomerUserAccessInvitation($customerId, $invitationId)
-    {
+    public static function forCustomerUserAccessInvitation(
+        $customerId,
+        $invitationId
+    ): string {
         return CustomerUserAccessInvitationServiceClient::customerUserAccessInvitationName(
             $customerId,
             $invitationId
@@ -1083,44 +1329,55 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a custom interest.
+     * Generates a resource name of custom interest type.
      *
-     * @param int $customerId the customer ID
-     * @param int $customInterestId the custom interest ID
+     * @param string $customerId
+     * @param string $customInterestId
      * @return string the custom interest resource name
      */
-    public static function forCustomInterest($customerId, $customInterestId)
-    {
-        return CustomInterestServiceClient::customInterestName($customerId, $customInterestId);
-    }
-
-    /**
-     * Generates resource name for a detail placement view.
-     *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param string $placement the placement
-     * @return string the detail placement view resource name
-     */
-    public static function forDetailPlacementView($customerId, $adGroupId, $placement)
-    {
-        return DetailPlacementViewServiceClient::detailPlacementViewName(
+    public static function forCustomInterest(
+        $customerId,
+        $customInterestId
+    ): string {
+        return CustomInterestServiceClient::customInterestName(
             $customerId,
-            $adGroupId,
-            $placement
+            $customInterestId
         );
     }
 
     /**
-     * Generates resource name for a display keyword view.
+     * Generates a resource name of detail placement view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $base64Placement
+     * @return string the detail placement view resource name
+     */
+    public static function forDetailPlacementView(
+        $customerId,
+        $adGroupId,
+        $base64Placement
+    ): string {
+        return DetailPlacementViewServiceClient::detailPlacementViewName(
+            $customerId,
+            $adGroupId,
+            $base64Placement
+        );
+    }
+
+    /**
+     * Generates a resource name of display keyword view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the display keyword view resource name
      */
-    public static function forDisplayKeywordView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forDisplayKeywordView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return DisplayKeywordViewServiceClient::displayKeywordViewName(
             $customerId,
             $adGroupId,
@@ -1129,33 +1386,88 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a domain category.
+     * Generates a resource name of distance view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param string $category the category
-     * @param string $languageCode the language code
+     * @param string $customerId
+     * @param string $placeholderChainId
+     * @param string $distanceBucket
+     * @return string the distance view resource name
+     */
+    public static function forDistanceView(
+        $customerId,
+        $placeholderChainId,
+        $distanceBucket
+    ): string {
+        return DistanceViewServiceClient::distanceViewName(
+            $customerId,
+            $placeholderChainId,
+            $distanceBucket
+        );
+    }
+
+    /**
+     * Generates a resource name of domain category type.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $base64Category
+     * @param string $languageCode
      * @return string the domain category resource name
      */
-    public static function forDomainCategory($customerId, $campaignId, $category, $languageCode)
-    {
+    public static function forDomainCategory(
+        $customerId,
+        $campaignId,
+        $base64Category,
+        $languageCode
+    ): string {
         return DomainCategoryServiceClient::domainCategoryName(
             $customerId,
             $campaignId,
-            $category,
+            $base64Category,
             $languageCode
         );
     }
 
     /**
-     * Generates resource name for an expanded langing page view.
+     * Generates a resource name of dynamic search ads search term view type.
      *
-     * @param int $customerId the customer ID
-     * @param string $expandedFinalUrlFingerprint the expanded final URL fingerprint
-     * @return string the expanded langing page view resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $searchTermFingerprint
+     * @param string $headlineFingerprint
+     * @param string $landingPageFingerprint
+     * @param string $pageUrlFingerprint
+     * @return string the dynamic search ads search term view resource name
      */
-    public static function forExpandedLandingPageView($customerId, $expandedFinalUrlFingerprint)
-    {
+    public static function forDynamicSearchAdsSearchTermView(
+        $customerId,
+        $adGroupId,
+        $searchTermFingerprint,
+        $headlineFingerprint,
+        $landingPageFingerprint,
+        $pageUrlFingerprint
+    ): string {
+        return DynamicSearchAdsSearchTermViewServiceClient::dynamicSearchAdsSearchTermViewName(
+            $customerId,
+            $adGroupId,
+            $searchTermFingerprint,
+            $headlineFingerprint,
+            $landingPageFingerprint,
+            $pageUrlFingerprint
+        );
+    }
+
+    /**
+     * Generates a resource name of expanded landing page view type.
+     *
+     * @param string $customerId
+     * @param string $expandedFinalUrlFingerprint
+     * @return string the expanded landing page view resource name
+     */
+    public static function forExpandedLandingPageView(
+        $customerId,
+        $expandedFinalUrlFingerprint
+    ): string {
         return ExpandedLandingPageViewServiceClient::expandedLandingPageViewName(
             $customerId,
             $expandedFinalUrlFingerprint
@@ -1163,39 +1475,52 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for an extension feed item.
+     * Generates a resource name of extension feed item type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedItemId the feed item ID
+     * @param string $customerId
+     * @param string $feedItemId
      * @return string the extension feed item resource name
      */
-    public static function forExtensionFeedItem($customerId, $feedItemId)
-    {
-        return ExtensionFeedItemServiceClient::extensionFeedItemName($customerId, $feedItemId);
+    public static function forExtensionFeedItem(
+        $customerId,
+        $feedItemId
+    ): string {
+        return ExtensionFeedItemServiceClient::extensionFeedItemName(
+            $customerId,
+            $feedItemId
+        );
     }
 
     /**
-     * Generates resource name for a feed.
+     * Generates a resource name of feed type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
+     * @param string $customerId
+     * @param string $feedId
      * @return string the feed resource name
      */
-    public static function forFeed($customerId, $feedId)
-    {
-        return FeedServiceClient::feedName($customerId, $feedId);
+    public static function forFeed(
+        $customerId,
+        $feedId
+    ): string {
+        return FeedServiceClient::feedName(
+            $customerId,
+            $feedId
+        );
     }
 
     /**
-     * Generates resource name for a feed item.
+     * Generates a resource name of feed item type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemId the feed item ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
      * @return string the feed item resource name
      */
-    public static function forFeedItem($customerId, $feedId, $feedItemId)
-    {
+    public static function forFeedItem(
+        $customerId,
+        $feedId,
+        $feedItemId
+    ): string {
         return FeedItemServiceClient::feedItemName(
             $customerId,
             $feedId,
@@ -1204,15 +1529,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed item set.
+     * Generates a resource name of feed item set type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemSetId the feed item set ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
      * @return string the feed item set resource name
      */
-    public static function forFeedItemSet($customerId, $feedId, $feedItemSetId)
-    {
+    public static function forFeedItemSet(
+        $customerId,
+        $feedId,
+        $feedItemSetId
+    ): string {
         return FeedItemSetServiceClient::feedItemSetName(
             $customerId,
             $feedId,
@@ -1221,16 +1549,20 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed item set link.
+     * Generates a resource name of feed item set link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemSetId the feed item set ID
-     * @param int $feedItemId the feed item ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
+     * @param string $feedItemId
      * @return string the feed item set link resource name
      */
-    public static function forFeedItemSetLink($customerId, $feedId, $feedItemSetId, $feedItemId)
-    {
+    public static function forFeedItemSetLink(
+        $customerId,
+        $feedId,
+        $feedItemSetId,
+        $feedItemId
+    ): string {
         return FeedItemSetLinkServiceClient::feedItemSetLinkName(
             $customerId,
             $feedId,
@@ -1240,13 +1572,13 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed item target.
+     * Generates a resource name of feed item target type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedItemId the feed item ID
-     * @param int $feedItemTargetType the feed item target type
-     * @param int $feedItemTargetId the feed item target ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     * @param string $feedItemTargetType
+     * @param string $feedItemTargetId
      * @return string the feed item target resource name
      */
     public static function forFeedItemTarget(
@@ -1255,7 +1587,7 @@ final class ResourceNames
         $feedItemId,
         $feedItemTargetType,
         $feedItemTargetId
-    ) {
+    ): string {
         return FeedItemTargetServiceClient::feedItemTargetName(
             $customerId,
             $feedId,
@@ -1266,15 +1598,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed mapping.
+     * Generates a resource name of feed mapping type.
      *
-     * @param int $customerId the customer ID
-     * @param int $feedId the feed ID
-     * @param int $feedMappingId the feed mapping ID
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedMappingId
      * @return string the feed mapping resource name
      */
-    public static function forFeedMapping($customerId, $feedId, $feedMappingId)
-    {
+    public static function forFeedMapping(
+        $customerId,
+        $feedId,
+        $feedMappingId
+    ): string {
         return FeedMappingServiceClient::feedMappingName(
             $customerId,
             $feedId,
@@ -1283,14 +1618,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a feed placeholder view.
+     * Generates a resource name of feed placeholder view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $placeholderType the placeholder type
+     * @param string $customerId
+     * @param string $placeholderType
      * @return string the feed placeholder view resource name
      */
-    public static function forFeedPlaceholderView($customerId, $placeholderType)
-    {
+    public static function forFeedPlaceholderView(
+        $customerId,
+        $placeholderType
+    ): string {
         return FeedPlaceholderViewServiceClient::feedPlaceholderViewName(
             $customerId,
             $placeholderType
@@ -1298,15 +1635,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a gender view.
+     * Generates a resource name of gender view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the gender view resource name
      */
-    public static function forGenderView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forGenderView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return GenderViewServiceClient::genderViewName(
             $customerId,
             $adGroupId,
@@ -1315,15 +1655,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a geographic view.
+     * Generates a resource name of geographic view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $countryCriterionId the country criterion ID
-     * @param int $locationType the location type
+     * @param string $customerId
+     * @param string $countryCriterionId
+     * @param string $locationType
      * @return string the geographic view resource name
      */
-    public static function forGeographicView($customerId, $countryCriterionId, $locationType)
-    {
+    public static function forGeographicView(
+        $customerId,
+        $countryCriterionId,
+        $locationType
+    ): string {
         return GeographicViewServiceClient::geographicViewName(
             $customerId,
             $countryCriterionId,
@@ -1332,54 +1675,66 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a geo target constant.
+     * Generates a resource name of geo target constant type.
      *
-     * @param int $geoTargetConstantId the geo target constant ID
+     * @param string $criterionId
      * @return string the geo target constant resource name
      */
-    public static function forGeoTargetConstant($geoTargetConstantId)
-    {
-        return GeoTargetConstantServiceClient::geoTargetConstantName($geoTargetConstantId);
-    }
-
-    /**
-     * Generates resource name for a Google Ads field.
-     *
-     * @param string $name the name
-     * @return string the Google Ads field resource name
-     */
-    public static function forGoogleAdsField($name)
-    {
-        return GoogleAdsFieldServiceClient::googleAdsFieldName($name);
-    }
-
-    /**
-     * Generates resource name for a group placement view.
-     *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param string $placement the placement
-     * @return string the group placement view resource name
-     */
-    public static function forGroupPlacementView($customerId, $adGroupId, $placement)
-    {
-        return GroupPlacementViewServiceClient::groupPlacementViewName(
-            $customerId,
-            $adGroupId,
-            $placement
+    public static function forGeoTargetConstant(
+        $criterionId
+    ): string {
+        return GeoTargetConstantServiceClient::geoTargetConstantName(
+            $criterionId
         );
     }
 
     /**
-     * Generates resource name for a hotel group view.
+     * Generates a resource name of google ads field type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param string $criterionId the criterion ID
+     * @param string $googleAdsField
+     * @return string the google ads field resource name
+     */
+    public static function forGoogleAdsField(
+        $googleAdsField
+    ): string {
+        return GoogleAdsFieldServiceClient::googleAdsFieldName(
+            $googleAdsField
+        );
+    }
+
+    /**
+     * Generates a resource name of group placement view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $base64Placement
+     * @return string the group placement view resource name
+     */
+    public static function forGroupPlacementView(
+        $customerId,
+        $adGroupId,
+        $base64Placement
+    ): string {
+        return GroupPlacementViewServiceClient::groupPlacementViewName(
+            $customerId,
+            $adGroupId,
+            $base64Placement
+        );
+    }
+
+    /**
+     * Generates a resource name of hotel group view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the hotel group view resource name
      */
-    public static function forHotelGroupView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forHotelGroupView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return HotelGroupViewServiceClient::hotelGroupViewName(
             $customerId,
             $adGroupId,
@@ -1388,26 +1743,32 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a hotel performance view.
+     * Generates a resource name of hotel performance view type.
      *
-     * @param int $customerId the customer ID
+     * @param string $customerId
      * @return string the hotel performance view resource name
      */
-    public static function forHotelPerformanceView($customerId)
-    {
-        return HotelPerformanceViewServiceClient::hotelPerformanceViewName($customerId);
+    public static function forHotelPerformanceView(
+        $customerId
+    ): string {
+        return HotelPerformanceViewServiceClient::hotelPerformanceViewName(
+            $customerId
+        );
     }
 
     /**
-     * Generates resource name for a income range view.
+     * Generates a resource name of income range view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the income range view resource name
      */
-    public static function forIncomeRangeView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forIncomeRangeView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return IncomeRangeViewServiceClient::incomeRangeViewName(
             $customerId,
             $adGroupId,
@@ -1416,26 +1777,33 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan.
+     * Generates a resource name of keyword plan type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanId the keyword plan ID
+     * @param string $customerId
+     * @param string $keywordPlanId
      * @return string the keyword plan resource name
      */
-    public static function forKeywordPlan($customerId, $keywordPlanId)
-    {
-        return KeywordPlanServiceClient::keywordPlanName($customerId, $keywordPlanId);
+    public static function forKeywordPlan(
+        $customerId,
+        $keywordPlanId
+    ): string {
+        return KeywordPlanServiceClient::keywordPlanName(
+            $customerId,
+            $keywordPlanId
+        );
     }
 
     /**
-     * Generates resource name for a keyword plan ad group.
+     * Generates a resource name of keyword plan ad group type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanAdGroupId the keyword plan ad group ID
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupId
      * @return string the keyword plan ad group resource name
      */
-    public static function forKeywordPlanAdGroup($customerId, $keywordPlanAdGroupId)
-    {
+    public static function forKeywordPlanAdGroup(
+        $customerId,
+        $keywordPlanAdGroupId
+    ): string {
         return KeywordPlanAdGroupServiceClient::keywordPlanAdGroupName(
             $customerId,
             $keywordPlanAdGroupId
@@ -1443,14 +1811,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan ad group keyword.
+     * Generates a resource name of keyword plan ad group keyword type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanAdGroupKeywordId the keyword plan ad group keyword ID
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupKeywordId
      * @return string the keyword plan ad group keyword resource name
      */
-    public static function forKeywordPlanAdGroupKeyword($customerId, $keywordPlanAdGroupKeywordId)
-    {
+    public static function forKeywordPlanAdGroupKeyword(
+        $customerId,
+        $keywordPlanAdGroupKeywordId
+    ): string {
         return KeywordPlanAdGroupKeywordServiceClient::keywordPlanAdGroupKeywordName(
             $customerId,
             $keywordPlanAdGroupKeywordId
@@ -1458,14 +1828,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan campaign.
+     * Generates a resource name of keyword plan campaign type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanCampaignId the keyword plan campaign ID
+     * @param string $customerId
+     * @param string $keywordPlanCampaignId
      * @return string the keyword plan campaign resource name
      */
-    public static function forKeywordPlanCampaign($customerId, $keywordPlanCampaignId)
-    {
+    public static function forKeywordPlanCampaign(
+        $customerId,
+        $keywordPlanCampaignId
+    ): string {
         return KeywordPlanCampaignServiceClient::keywordPlanCampaignName(
             $customerId,
             $keywordPlanCampaignId
@@ -1473,14 +1845,16 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a keyword plan campaign keyword.
+     * Generates a resource name of keyword plan campaign keyword type.
      *
-     * @param int $customerId the customer ID
-     * @param int $keywordPlanCampaignKeywordId the keyword plan campaign keyword ID
+     * @param string $customerId
+     * @param string $keywordPlanCampaignKeywordId
      * @return string the keyword plan campaign keyword resource name
      */
-    public static function forKeywordPlanCampaignKeyword($customerId, $keywordPlanCampaignKeywordId)
-    {
+    public static function forKeywordPlanCampaignKeyword(
+        $customerId,
+        $keywordPlanCampaignKeywordId
+    ): string {
         return KeywordPlanCampaignKeywordServiceClient::keywordPlanCampaignKeywordName(
             $customerId,
             $keywordPlanCampaignKeywordId
@@ -1488,28 +1862,53 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a label.
+     * Generates a resource name of keyword view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $labelId the label ID
-     * @return string the label resource name
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @return string the keyword view resource name
      */
-    public static function forLabel($customerId, $labelId)
-    {
-        return LabelServiceClient::labelName($customerId, $labelId);
+    public static function forKeywordView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
+        return KeywordViewServiceClient::keywordViewName(
+            $customerId,
+            $adGroupId,
+            $criterionId
+        );
     }
 
     /**
-     * Generates resource name for a landing page view.
+     * Generates a resource name of label type.
      *
-     * @param int $customerId the customer ID
-     * @param string $unexpandedFinalUrlFingerprint the unexpanded final URL fingerprint
+     * @param string $customerId
+     * @param string $labelId
+     * @return string the label resource name
+     */
+    public static function forLabel(
+        $customerId,
+        $labelId
+    ): string {
+        return LabelServiceClient::labelName(
+            $customerId,
+            $labelId
+        );
+    }
+
+    /**
+     * Generates a resource name of landing page view type.
+     *
+     * @param string $customerId
+     * @param string $unexpandedFinalUrlFingerprint
      * @return string the landing page view resource name
      */
     public static function forLandingPageView(
         $customerId,
         $unexpandedFinalUrlFingerprint
-    ) {
+    ): string {
         return LandingPageViewServiceClient::landingPageViewName(
             $customerId,
             $unexpandedFinalUrlFingerprint
@@ -1517,18 +1916,21 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a language constant.
+     * Generates a resource name of language constant type.
      *
-     * @param int $languageConstantId the language constant ID
+     * @param string $criterionId
      * @return string the language constant resource name
      */
-    public static function forLanguageConstant($languageConstantId)
-    {
-        return LanguageConstantServiceClient::languageConstantName($languageConstantId);
+    public static function forLanguageConstant(
+        $criterionId
+    ): string {
+        return LanguageConstantServiceClient::languageConstantName(
+            $criterionId
+        );
     }
 
     /**
-     * Generates resource name for a life event.
+     * Generates a resource name of life event type.
      *
      * @param string $customerId
      * @param string $lifeEventId
@@ -1537,7 +1939,7 @@ final class ResourceNames
     public static function forLifeEvent(
         $customerId,
         $lifeEventId
-    ) {
+    ): string {
         return LifeEventServiceClient::lifeEventName(
             $customerId,
             $lifeEventId
@@ -1545,32 +1947,38 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a location view.
+     * Generates a resource name of location view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaingId the campaign ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
      * @return string the location view resource name
      */
-    public static function forLocationView($customerId, $campaingId, $criterionId)
-    {
+    public static function forLocationView(
+        $customerId,
+        $campaignId,
+        $criterionId
+    ): string {
         return LocationViewServiceClient::locationViewName(
             $customerId,
-            $campaingId,
+            $campaignId,
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for a managed placement view.
+     * Generates a resource name of managed placement view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the managed placement view resource name
      */
-    public static function forManagedPlacementView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forManagedPlacementView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return ManagedPlacementViewServiceClient::managedPlacementViewName(
             $customerId,
             $adGroupId,
@@ -1579,26 +1987,33 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a media file.
+     * Generates a resource name of media file type.
      *
-     * @param int $customerId the customer ID
-     * @param int $mediaFileId the media file ID
+     * @param string $customerId
+     * @param string $mediaFileId
      * @return string the media file resource name
      */
-    public static function forMediaFile($customerId, $mediaFileId)
-    {
-        return MediaFileServiceClient::mediaFileName($customerId, $mediaFileId);
+    public static function forMediaFile(
+        $customerId,
+        $mediaFileId
+    ): string {
+        return MediaFileServiceClient::mediaFileName(
+            $customerId,
+            $mediaFileId
+        );
     }
 
     /**
-     * Generates resource name for a merchant center link.
+     * Generates a resource name of merchant center link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $merchantCenterId the merchant center ID
+     * @param string $customerId
+     * @param string $merchantCenterId
      * @return string the merchant center link resource name
      */
-    public static function forMerchantCenterLink($customerId, $merchantCenterId)
-    {
+    public static function forMerchantCenterLink(
+        $customerId,
+        $merchantCenterId
+    ): string {
         return MerchantCenterLinkServiceClient::merchantCenterLinkName(
             $customerId,
             $merchantCenterId
@@ -1606,75 +2021,100 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a mobile app category constant.
+     * Generates a resource name of mobile app category constant type.
      *
-     * @param int $mobileAppCategoryId the mobile app category ID
+     * @param string $mobileAppCategoryId
      * @return string the mobile app category constant resource name
      */
-    public static function forMobileAppCategoryConstant($mobileAppCategoryId)
-    {
+    public static function forMobileAppCategoryConstant(
+        $mobileAppCategoryId
+    ): string {
         return MobileAppCategoryConstantServiceClient::mobileAppCategoryConstantName(
             $mobileAppCategoryId
         );
     }
 
     /**
-     * Generates resource name for a mobile device constant.
+     * Generates a resource name of mobile device constant type.
      *
-     * @param int $criterionId the criterion ID
+     * @param string $criterionId
      * @return string the mobile device constant resource name
      */
-    public static function forMobileDeviceConstant($criterionId)
-    {
-        return MobileDeviceConstantServiceClient::mobileDeviceConstantName($criterionId);
+    public static function forMobileDeviceConstant(
+        $criterionId
+    ): string {
+        return MobileDeviceConstantServiceClient::mobileDeviceConstantName(
+            $criterionId
+        );
     }
 
     /**
-     * Generates resource name for a operating system version constant.
+     * Generates a resource name of offline user data job type.
      *
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $offlineUserDataUpdateId
+     * @return string the offline user data job resource name
+     */
+    public static function forOfflineUserDataJob(
+        $customerId,
+        $offlineUserDataUpdateId
+    ): string {
+        return OfflineUserDataJobServiceClient::offlineUserDataJobName(
+            $customerId,
+            $offlineUserDataUpdateId
+        );
+    }
+
+    /**
+     * Generates a resource name of operating system version constant type.
+     *
+     * @param string $criterionId
      * @return string the operating system version constant resource name
      */
-    public static function forOperatingSystemVersionConstant($criterionId)
-    {
+    public static function forOperatingSystemVersionConstant(
+        $criterionId
+    ): string {
         return OperatingSystemVersionConstantServiceClient::operatingSystemVersionConstantName(
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for a paid organic search term view.
+     * Generates a resource name of paid organic search term view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $adGroupId the ad group ID
-     * @param string $searchTerm the search term
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $adGroupId
+     * @param string $base64SearchTerm
      * @return string the paid organic search term view resource name
      */
     public static function forPaidOrganicSearchTermView(
         $customerId,
         $campaignId,
         $adGroupId,
-        $searchTerm
-    ) {
+        $base64SearchTerm
+    ): string {
         return PaidOrganicSearchTermViewServiceClient::paidOrganicSearchTermViewName(
             $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $base64SearchTerm
         );
     }
 
     /**
-     * Generates resource name for a parental status view.
+     * Generates a resource name of parental status view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the parental status view resource name
      */
-    public static function forParentalStatusView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forParentalStatusView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return ParentalStatusViewServiceClient::parentalStatusViewName(
             $customerId,
             $adGroupId,
@@ -1683,38 +2123,18 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a payments account.
+     * Generates a resource name of product bidding category constant type.
      *
-     * @param int $customerId the customer ID
-     * @param int $paymentsAccountId the payments account ID
-     * @return string the payments account resource name
-     */
-    public static function forPaymentsAccount($customerId, $paymentsAccountId)
-    {
-        $pathTemplate = new PathTemplate(
-            'customers/{customer}/paymentsAccounts/{payments_account}'
-        );
-        return $pathTemplate->render(
-            [
-                'customer' => $customerId,
-                'payments_account' => $paymentsAccountId,
-            ]
-        );
-    }
-
-    /**
-     * Generates resource name for a product bidding category constant.
-     *
-     * @param string $countryCode the country code
-     * @param int $level the level
-     * @param int $id ID of the product bidding category
+     * @param string $countryCode
+     * @param string $level
+     * @param string $id
      * @return string the product bidding category constant resource name
      */
     public static function forProductBiddingCategoryConstant(
         $countryCode,
         $level,
         $id
-    ) {
+    ): string {
         return ProductBiddingCategoryConstantServiceClient::productBiddingCategoryConstantName(
             $countryCode,
             $level,
@@ -1723,43 +2143,53 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a product group view.
+     * Generates a resource name of product group view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $adgroupId
+     * @param string $criterionId
      * @return string the product group view resource name
      */
-    public static function forProductGroupView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forProductGroupView(
+        $customerId,
+        $adgroupId,
+        $criterionId
+    ): string {
         return ProductGroupViewServiceClient::productGroupViewName(
             $customerId,
-            $adGroupId,
+            $adgroupId,
             $criterionId
         );
     }
 
     /**
-     * Generates resource name for a recommendation.
+     * Generates a resource name of recommendation type.
      *
-     * @param int $customerId the customer ID
-     * @param string $recommendationId the recommendation ID
+     * @param string $customerId
+     * @param string $recommendationId
      * @return string the recommendation resource name
      */
-    public static function forRecommendation($customerId, $recommendationId)
-    {
-        return RecommendationServiceClient::recommendationName($customerId, $recommendationId);
+    public static function forRecommendation(
+        $customerId,
+        $recommendationId
+    ): string {
+        return RecommendationServiceClient::recommendationName(
+            $customerId,
+            $recommendationId
+        );
     }
 
     /**
-     * Generates resource name for a remarketing action.
+     * Generates a resource name of remarketing action type.
      *
-     * @param int $customerId the customer ID
-     * @param int $remarketingActionId the remarketing action ID
+     * @param string $customerId
+     * @param string $remarketingActionId
      * @return string the remarketing action resource name
      */
-    public static function forRemarketingAction($customerId, $remarketingActionId)
-    {
+    public static function forRemarketingAction(
+        $customerId,
+        $remarketingActionId
+    ): string {
         return RemarketingActionServiceClient::remarketingActionName(
             $customerId,
             $remarketingActionId
@@ -1767,38 +2197,41 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a search term view.
+     * Generates a resource name of search term view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $campaignId the campaign ID
-     * @param int $adGroupId the ad group ID
-     * @param string $searchTerm the search term
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $adGroupId
+     * @param string $query
      * @return string the search term view resource name
      */
     public static function forSearchTermView(
         $customerId,
         $campaignId,
         $adGroupId,
-        $searchTerm
-    ) {
+        $query
+    ): string {
         return SearchTermViewServiceClient::searchTermViewName(
             $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $query
         );
     }
 
     /**
-     * Generates resource name for a shared criterion.
+     * Generates a resource name of shared criterion type.
      *
-     * @param int $customerId the customer ID
-     * @param int $sharedSetId the shared set ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $sharedSetId
+     * @param string $criterionId
      * @return string the shared criterion resource name
      */
-    public static function forSharedCriterion($customerId, $sharedSetId, $criterionId)
-    {
+    public static function forSharedCriterion(
+        $customerId,
+        $sharedSetId,
+        $criterionId
+    ): string {
         return SharedCriterionServiceClient::sharedCriterionName(
             $customerId,
             $sharedSetId,
@@ -1807,66 +2240,80 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a shared set.
+     * Generates a resource name of shared set type.
      *
-     * @param int $customerId the customer ID
-     * @param int $sharedSetId the shared set ID
+     * @param string $customerId
+     * @param string $sharedSetId
      * @return string the shared set resource name
      */
-    public static function forSharedSet($customerId, $sharedSetId)
-    {
-        return SharedSetServiceClient::sharedSetName($customerId, $sharedSetId);
-    }
-
-    /**
-     * Generates resource name for a shopping performance view.
-     *
-     * @param int $customerId the customer ID
-     * @return string the shopping performance view resource name
-     */
-    public static function forShoppingPerformanceView($customerId)
-    {
-        return ShoppingPerformanceViewServiceClient::shoppingPerformanceViewName($customerId);
-    }
-
-    /**
-     * Generates resource name for a third party app analytics link.
-     *
-     * @param int $customerId the customer ID
-     * @param int $thirdPartyAppAnalyticsLinkId the third party app analytics link ID
-     * @return string the third party app analytics link resource name
-     */
-    public static function forThirdPartyAppAnalyticsLinkName(
+    public static function forSharedSet(
         $customerId,
-        $thirdPartyAppAnalyticsLinkId
-    ) {
-        return ThirdPartyAppAnalyticsLinkServiceClient::thirdPartyAppAnalyticsLinkName(
+        $sharedSetId
+    ): string {
+        return SharedSetServiceClient::sharedSetName(
             $customerId,
-            $thirdPartyAppAnalyticsLinkId
+            $sharedSetId
         );
     }
 
     /**
-     * Generates resource name for a topic constant.
+     * Generates a resource name of shopping performance view type.
      *
-     * @param int $topicId the topic ID
-     * @return string the topic constant resource name
+     * @param string $customerId
+     * @return string the shopping performance view resource name
      */
-    public static function forTopicConstant($topicId)
-    {
-        return TopicConstantServiceClient::topicConstantName($topicId);
+    public static function forShoppingPerformanceView(
+        $customerId
+    ): string {
+        return ShoppingPerformanceViewServiceClient::shoppingPerformanceViewName(
+            $customerId
+        );
     }
 
     /**
-     * Generates resource name for a topic view.
+     * Generates a resource name of third party app analytics link type.
      *
-     * @param int $customerId the customer ID
-     * @param int $adGroupId the ad group ID
-     * @param int $criterionId the criterion ID
+     * @param string $customerId
+     * @param string $customerLinkId
+     * @return string the third party app analytics link resource name
+     */
+    public static function forThirdPartyAppAnalyticsLink(
+        $customerId,
+        $customerLinkId
+    ): string {
+        return ThirdPartyAppAnalyticsLinkServiceClient::thirdPartyAppAnalyticsLinkName(
+            $customerId,
+            $customerLinkId
+        );
+    }
+
+    /**
+     * Generates a resource name of topic constant type.
+     *
+     * @param string $topicId
+     * @return string the topic constant resource name
+     */
+    public static function forTopicConstant(
+        $topicId
+    ): string {
+        return TopicConstantServiceClient::topicConstantName(
+            $topicId
+        );
+    }
+
+    /**
+     * Generates a resource name of topic view type.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
      * @return string the topic view resource name
      */
-    public static function forTopicView($customerId, $adGroupId, $criterionId)
-    {
+    public static function forTopicView(
+        $customerId,
+        $adGroupId,
+        $criterionId
+    ): string {
         return TopicViewServiceClient::topicViewName(
             $customerId,
             $adGroupId,
@@ -1875,43 +2322,78 @@ final class ResourceNames
     }
 
     /**
-     * Generates resource name for a user interest.
+     * Generates a resource name of user interest type.
      *
-     * @param int $customerId the customer ID
-     * @param int $userInterestId the user interest ID
+     * @param string $customerId
+     * @param string $userInterestId
      * @return string the user interest resource name
      */
-    public static function forUserInterest($customerId, $userInterestId)
-    {
-        return UserInterestServiceClient::userInterestName($customerId, $userInterestId);
+    public static function forUserInterest(
+        $customerId,
+        $userInterestId
+    ): string {
+        return UserInterestServiceClient::userInterestName(
+            $customerId,
+            $userInterestId
+        );
     }
 
     /**
-     * Generates resource name for a user list.
+     * Generates a resource name of user list type.
      *
-     * @param int $customerId the customer ID
-     * @param int $userListId the user list ID
+     * @param string $customerId
+     * @param string $userListId
      * @return string the user list resource name
      */
-    public static function forUserList($customerId, $userListId)
-    {
-        return UserListServiceClient::userListName($customerId, $userListId);
+    public static function forUserList(
+        $customerId,
+        $userListId
+    ): string {
+        return UserListServiceClient::userListName(
+            $customerId,
+            $userListId
+        );
     }
 
     /**
-     * Generates resource name for a video.
+     * Generates a resource name of user location view type.
      *
-     * @param int $customerId the customer ID
-     * @param int $videoId the video ID
+     * @param string $customerId
+     * @param string $countryCriterionId
+     * @param string $isTargetingLocation
+     * @return string the user location view resource name
+     */
+    public static function forUserLocationView(
+        $customerId,
+        $countryCriterionId,
+        $isTargetingLocation
+    ): string {
+        return UserLocationViewServiceClient::userLocationViewName(
+            $customerId,
+            $countryCriterionId,
+            $isTargetingLocation
+        );
+    }
+
+    /**
+     * Generates a resource name of video type.
+     *
+     * @param string $customerId
+     * @param string $videoId
      * @return string the video resource name
      */
-    public static function forVideo($customerId, $videoId)
-    {
-        return VideoServiceClient::videoName($customerId, $videoId);
+    public static function forVideo(
+        $customerId,
+        $videoId
+    ): string {
+        return VideoServiceClient::videoName(
+            $customerId,
+            $videoId
+        );
     }
 
     /**
-     * Generates resource name for a webpage view.
+     * Generates a resource name of webpage view type.
      *
      * @param string $customerId
      * @param string $adGroupId
@@ -1922,7 +2404,7 @@ final class ResourceNames
         $customerId,
         $adGroupId,
         $criterionId
-    ) {
+    ): string {
         return WebpageViewServiceClient::webpageViewName(
             $customerId,
             $adGroupId,

--- a/tests/Google/Ads/GoogleAds/Util/V6/ResourceNamesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V6/ResourceNamesTest.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2020 Google LLC
+/**
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Util\V6;
 
-use Google\Ads\GoogleAds\V6\Enums\AssetFieldTypeEnum\AssetFieldType;
-use Google\Ads\GoogleAds\V6\Enums\ExtensionTypeEnum\ExtensionType;
-use Google\Ads\GoogleAds\V6\Enums\PlaceholderTypeEnum\PlaceholderType;
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V6\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V6\Services\AdGroupAudienceViewServiceClient;
@@ -63,6 +63,7 @@ use Google\Ads\GoogleAds\V6\Services\ClickViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CombinedAudienceServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CurrencyConstantServiceClient;
+use Google\Ads\GoogleAds\V6\Services\CustomAudienceServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomerClientLinkServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomerClientServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomerExtensionSettingServiceClient;
@@ -76,7 +77,9 @@ use Google\Ads\GoogleAds\V6\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V6\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V6\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\DomainCategoryServiceClient;
+use Google\Ads\GoogleAds\V6\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ExpandedLandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ExtensionFeedItemServiceClient;
 use Google\Ads\GoogleAds\V6\Services\FeedItemServiceClient;
@@ -99,6 +102,7 @@ use Google\Ads\GoogleAds\V6\Services\KeywordPlanAdGroupServiceClient;
 use Google\Ads\GoogleAds\V6\Services\KeywordPlanCampaignKeywordServiceClient;
 use Google\Ads\GoogleAds\V6\Services\KeywordPlanCampaignServiceClient;
 use Google\Ads\GoogleAds\V6\Services\KeywordPlanServiceClient;
+use Google\Ads\GoogleAds\V6\Services\KeywordViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\LabelServiceClient;
 use Google\Ads\GoogleAds\V6\Services\LandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\LanguageConstantServiceClient;
@@ -108,6 +112,7 @@ use Google\Ads\GoogleAds\V6\Services\MediaFileServiceClient;
 use Google\Ads\GoogleAds\V6\Services\MerchantCenterLinkServiceClient;
 use Google\Ads\GoogleAds\V6\Services\MobileAppCategoryConstantServiceClient;
 use Google\Ads\GoogleAds\V6\Services\MobileDeviceConstantServiceClient;
+use Google\Ads\GoogleAds\V6\Services\OfflineUserDataJobServiceClient;
 use Google\Ads\GoogleAds\V6\Services\OperatingSystemVersionConstantServiceClient;
 use Google\Ads\GoogleAds\V6\Services\PaidOrganicSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\ParentalStatusViewServiceClient;
@@ -124,6 +129,7 @@ use Google\Ads\GoogleAds\V6\Services\TopicConstantServiceClient;
 use Google\Ads\GoogleAds\V6\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V6\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V6\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V6\Services\VideoServiceClient;
 use PHPUnit\Framework\TestCase;
 
@@ -136,23 +142,49 @@ use PHPUnit\Framework\TestCase;
 class ResourceNamesTest extends TestCase
 {
 
-    private const CUSTOMER_ID = 1234567890;
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forPaymentsAccount()
+     */
+    public function testGetNameForPaymentsAccount()
+    {
+        $customerId = '111111';
+        $paymentsAccountId = '1111-2222-3333-4444';
+        $expectedResourceName = sprintf(
+            'customers/%s/paymentsAccounts/%s',
+            $customerId,
+            $paymentsAccountId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forPaymentsAccount(
+                $customerId,
+                $paymentsAccountId
+            )
+        );
+    }
 
     /**
      * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forAccountBudget()
      */
     public function testGetNameForAccountBudget()
     {
-        $accountBudgetId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/accountBudgets/%s', self::CUSTOMER_ID, $accountBudgetId);
+        $customerId = '111111';
+        $accountBudgetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/accountBudgets/%s",
+            $customerId,
+            $accountBudgetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAccountBudget(self::CUSTOMER_ID, $accountBudgetId)
+            ResourceNames::forAccountBudget(
+                $customerId,
+                $accountBudgetId
+            )
         );
 
         $names = AccountBudgetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($accountBudgetId, $names['account_budget_id']);
     }
 
@@ -161,37 +193,48 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAccountBudgetProposal()
     {
-        $accountBudgetProposalId = 111111;
+        $customerId = '111111';
+        $accountBudgetProposalId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/accountBudgetProposals/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/accountBudgetProposals/%s",
+            $customerId,
             $accountBudgetProposalId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAccountBudgetProposal(self::CUSTOMER_ID, $accountBudgetProposalId)
+            ResourceNames::forAccountBudgetProposal(
+                $customerId,
+                $accountBudgetProposalId
+            )
         );
 
         $names = AccountBudgetProposalServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($accountBudgetProposalId, $names['account_budget_proposal_id']);
     }
 
     /**
-     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forAccountLinkName()
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forAccountLink()
      */
-    public function testGetNameForAccountLinkName()
+    public function testGetNameForAccountLink()
     {
-        $accountLinkId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/accountLinks/%s', self::CUSTOMER_ID, $accountLinkId);
+        $customerId = '111111';
+        $accountLinkId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/accountLinks/%s",
+            $customerId,
+            $accountLinkId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAccountLinkName(self::CUSTOMER_ID, $accountLinkId)
+            ResourceNames::forAccountLink(
+                $customerId,
+                $accountLinkId
+            )
         );
 
         $names = AccountLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($accountLinkId, $names['account_link_id']);
     }
 
@@ -200,16 +243,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAd()
     {
-        $adId = 22222;
-        $expectedResourceName =
-            sprintf('customers/%s/ads/%s', self::CUSTOMER_ID, $adId);
+        $customerId = '111111';
+        $adId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/ads/%s",
+            $customerId,
+            $adId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAd(self::CUSTOMER_ID, $adId)
+            ResourceNames::forAd(
+                $customerId,
+                $adId
+            )
         );
 
         $names = AdServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adId, $names['ad_id']);
     }
 
@@ -218,15 +268,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroup()
     {
-        $adGroupId = 111111;
-        $expectedResourceName = sprintf('customers/%s/adGroups/%s', self::CUSTOMER_ID, $adGroupId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroups/%s",
+            $customerId,
+            $adGroupId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroup(self::CUSTOMER_ID, $adGroupId)
+            ResourceNames::forAdGroup(
+                $customerId,
+                $adGroupId
+            )
         );
 
         $names = AdGroupServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
     }
 
@@ -235,19 +293,65 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupAd()
     {
-        $adGroupId = 111111;
-        $adId = 22222;
-        $expectedResourceName =
-            sprintf('customers/%s/adGroupAds/%s~%s', self::CUSTOMER_ID, $adGroupId, $adId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $adId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupAds/%s~%s",
+            $customerId,
+            $adGroupId,
+            $adId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupAd(self::CUSTOMER_ID, $adGroupId, $adId)
+            ResourceNames::forAdGroupAd(
+                $customerId,
+                $adGroupId,
+                $adId
+            )
         );
 
         $names = AdGroupAdServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($adId, $names['ad_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forAdGroupAdAssetView()
+     */
+    public function testGetNameForAdGroupAdAssetView()
+    {
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $adId = '333333';
+        $assetId = '444444';
+        $fieldType = '555555';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupAdAssetViews/%s~%s~%s~%s",
+            $customerId,
+            $adGroupId,
+            $adId,
+            $assetId,
+            $fieldType
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forAdGroupAdAssetView(
+                $customerId,
+                $adGroupId,
+                $adId,
+                $assetId,
+                $fieldType
+            )
+        );
+
+        $names = AdGroupAdAssetViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adGroupId, $names['ad_group_id']);
+        $this->assertEquals($adId, $names['ad_id']);
+        $this->assertEquals($assetId, $names['asset_id']);
+        $this->assertEquals($fieldType, $names['field_type']);
     }
 
     /**
@@ -255,23 +359,29 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupAdLabel()
     {
-        $adGroupId = 111111;
-        $adId = 222222;
-        $labelId = 333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $adId = '333333';
+        $labelId = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupAdLabels/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupAdLabels/%s~%s~%s",
+            $customerId,
             $adGroupId,
             $adId,
             $labelId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupAdLabel(self::CUSTOMER_ID, $adGroupId, $adId, $labelId)
+            ResourceNames::forAdGroupAdLabel(
+                $customerId,
+                $adGroupId,
+                $adId,
+                $labelId
+            )
         );
 
         $names = AdGroupAdLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($adId, $names['ad_id']);
         $this->assertEquals($labelId, $names['label_id']);
@@ -282,25 +392,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupAudienceView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupAudienceViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupAudienceViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupAudienceView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId
             )
         );
 
         $names = AdGroupAudienceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -310,21 +421,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupBidModifier()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupBidModifiers/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupBidModifiers/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupBidModifier(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forAdGroupBidModifier(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = AdGroupBidModifierServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -334,21 +450,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupCriterion()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupCriteria/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupCriteria/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupCriterion(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forAdGroupCriterion(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = AdGroupCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -358,12 +479,13 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupCriterionLabel()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
-        $labelId = 4444444;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $labelId = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupCriterionLabels/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupCriterionLabels/%s~%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId,
             $labelId
@@ -371,7 +493,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupCriterionLabel(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId,
                 $labelId
@@ -379,7 +501,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdGroupCriterionLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($labelId, $names['label_id']);
@@ -390,15 +512,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupCriterionSimulation()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
-        $type = 4444444;
-        $modificationMethod = 5555555;
-        $startDate = 66666666;
-        $endDate = 7777777;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $type = '444444';
+        $modificationMethod = '555555';
+        $startDate = '666666';
+        $endDate = '777777';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupCriterionSimulations/%s~%s~%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupCriterionSimulations/%s~%s~%s~%s~%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId,
             $type,
@@ -409,7 +532,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupCriterionSimulation(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId,
                 $type,
@@ -420,7 +543,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdGroupCriterionSimulationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($type, $names['type']);
@@ -434,27 +557,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupExtensionSetting()
     {
-        $adGroupId = 111111;
-        $extensionType = ExtensionType::SITELINK;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $extensionType = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupExtensionSettings/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupExtensionSettings/%s~%s",
+            $customerId,
             $adGroupId,
-            'SITELINK'
+            $extensionType
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupExtensionSetting(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $extensionType
             )
         );
 
         $names = AdGroupExtensionSettingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals(ExtensionType::name($extensionType), $names['extension_type']);
+        $this->assertEquals($extensionType, $names['extension_type']);
     }
 
     /**
@@ -462,17 +586,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupFeed()
     {
-        $adGroupId = 111111;
-        $feedId = 3333333;
-        $expectedResourceName =
-            sprintf('customers/%s/adGroupFeeds/%s~%s', self::CUSTOMER_ID, $adGroupId, $feedId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $feedId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupFeeds/%s~%s",
+            $customerId,
+            $adGroupId,
+            $feedId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupFeed(self::CUSTOMER_ID, $adGroupId, $feedId)
+            ResourceNames::forAdGroupFeed(
+                $customerId,
+                $adGroupId,
+                $feedId
+            )
         );
 
         $names = AdGroupFeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
@@ -482,17 +615,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupLabel()
     {
-        $adGroupId = 111111;
-        $labelId = 3333333;
-        $expectedResourceName =
-            sprintf('customers/%s/adGroupLabels/%s~%s', self::CUSTOMER_ID, $adGroupId, $labelId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $labelId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupLabels/%s~%s",
+            $customerId,
+            $adGroupId,
+            $labelId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupLabel(self::CUSTOMER_ID, $adGroupId, $labelId)
+            ResourceNames::forAdGroupLabel(
+                $customerId,
+                $adGroupId,
+                $labelId
+            )
         );
 
         $names = AdGroupLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
@@ -502,14 +644,15 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupSimulation()
     {
-        $adGroupId = 111111;
-        $type = 4444444;
-        $modificationMethod = 5555555;
-        $startDate = 66666666;
-        $endDate = 7777777;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $type = '333333';
+        $modificationMethod = '444444';
+        $startDate = '555555';
+        $endDate = '666666';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupSimulations/%s~%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupSimulations/%s~%s~%s~%s~%s",
+            $customerId,
             $adGroupId,
             $type,
             $modificationMethod,
@@ -519,7 +662,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupSimulation(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $type,
                 $modificationMethod,
@@ -529,7 +672,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdGroupSimulationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($type, $names['type']);
         $this->assertEquals($modificationMethod, $names['modification_method']);
@@ -542,12 +685,13 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdParameter()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
-        $parameterIndex = 4444444;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $parameterIndex = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/adParameters/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adParameters/%s~%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId,
             $parameterIndex
@@ -555,7 +699,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdParameter(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId,
                 $parameterIndex
@@ -563,7 +707,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdParameterServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($parameterIndex, $names['parameter_index']);
@@ -574,21 +718,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdScheduleView()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adScheduleViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adScheduleViews/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdScheduleView(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forAdScheduleView(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = AdScheduleViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -598,21 +747,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAgeRangeView()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/ageRangeViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/ageRangeViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAgeRangeView(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forAgeRangeView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = AgeRangeViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -622,15 +776,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAsset()
     {
-        $assetId = 111111;
-        $expectedResourceName = sprintf('customers/%s/assets/%s', self::CUSTOMER_ID, $assetId);
+        $customerId = '111111';
+        $assetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/assets/%s",
+            $customerId,
+            $assetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAsset(self::CUSTOMER_ID, $assetId)
+            ResourceNames::forAsset(
+                $customerId,
+                $assetId
+            )
         );
 
         $names = AssetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($assetId, $names['asset_id']);
     }
 
@@ -639,16 +801,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForBatchJob()
     {
-        $batchJobId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/batchJobs/%s', self::CUSTOMER_ID, $batchJobId);
+        $customerId = '111111';
+        $batchJobId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/batchJobs/%s",
+            $customerId,
+            $batchJobId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forBatchJob(self::CUSTOMER_ID, $batchJobId)
+            ResourceNames::forBatchJob(
+                $customerId,
+                $batchJobId
+            )
         );
 
         $names = BatchJobServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($batchJobId, $names['batch_job_id']);
     }
 
@@ -657,16 +826,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForBiddingStrategy()
     {
-        $biddingStrategyId = 4444444;
-        $expectedResourceName =
-            sprintf('customers/%s/biddingStrategies/%s', self::CUSTOMER_ID, $biddingStrategyId);
+        $customerId = '111111';
+        $biddingStrategyId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/biddingStrategies/%s",
+            $customerId,
+            $biddingStrategyId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forBiddingStrategy(self::CUSTOMER_ID, $biddingStrategyId)
+            ResourceNames::forBiddingStrategy(
+                $customerId,
+                $biddingStrategyId
+            )
         );
 
         $names = BiddingStrategyServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($biddingStrategyId, $names['bidding_strategy_id']);
     }
 
@@ -675,16 +851,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForBillingSetup()
     {
-        $billingSetupId = 4444444;
-        $expectedResourceName =
-            sprintf('customers/%s/billingSetups/%s', self::CUSTOMER_ID, $billingSetupId);
+        $customerId = '111111';
+        $billingSetupId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/billingSetups/%s",
+            $customerId,
+            $billingSetupId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forBillingSetup(self::CUSTOMER_ID, $billingSetupId)
+            ResourceNames::forBillingSetup(
+                $customerId,
+                $billingSetupId
+            )
         );
 
         $names = BillingSetupServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($billingSetupId, $names['billing_setup_id']);
     }
 
@@ -693,16 +876,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaign()
     {
-        $campaignId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/campaigns/%s', self::CUSTOMER_ID, $campaignId);
+        $customerId = '111111';
+        $campaignId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/campaigns/%s",
+            $customerId,
+            $campaignId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaign(self::CUSTOMER_ID, $campaignId)
+            ResourceNames::forCampaign(
+                $customerId,
+                $campaignId
+            )
         );
 
         $names = CampaignServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
     }
 
@@ -711,26 +901,32 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignAsset()
     {
-        $campaignId = 111111;
-        $assetId = 3333333;
-        $fieldType = 3;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $assetId = '333333';
+        $fieldType = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignAssets/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignAssets/%s~%s~%s",
+            $customerId,
             $campaignId,
             $assetId,
-            AssetFieldType::name($fieldType)
+            $fieldType
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignAsset(self::CUSTOMER_ID, $campaignId, $assetId, $fieldType)
+            ResourceNames::forCampaignAsset(
+                $customerId,
+                $campaignId,
+                $assetId,
+                $fieldType
+            )
         );
 
         $names = CampaignAssetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($assetId, $names['asset_id']);
-        $this->assertEquals(AssetFieldType::name($fieldType), $names['field_type']);
+        $this->assertEquals($fieldType, $names['field_type']);
     }
 
     /**
@@ -738,21 +934,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignAudienceView()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignAudienceViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignAudienceViews/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignAudienceView(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forCampaignAudienceView(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = CampaignAudienceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -762,21 +963,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignBidModifier()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignBidModifiers/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignBidModifiers/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignBidModifier(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forCampaignBidModifier(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = CampaignBidModifierServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -786,17 +992,24 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignBudget()
     {
-        $budgetId = 555555;
-        $expectedResourceName =
-            sprintf('customers/%s/campaignBudgets/%s', self::CUSTOMER_ID, $budgetId);
+        $customerId = '111111';
+        $campaignBudgetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/campaignBudgets/%s",
+            $customerId,
+            $campaignBudgetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignBudget(self::CUSTOMER_ID, $budgetId)
+            ResourceNames::forCampaignBudget(
+                $customerId,
+                $campaignBudgetId
+            )
         );
 
         $names = CampaignBudgetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals($budgetId, $names['campaign_budget_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($campaignBudgetId, $names['campaign_budget_id']);
     }
 
     /**
@@ -804,21 +1017,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignCriterion()
     {
-        $campaignId = 66666666;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignCriteria/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignCriteria/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignCriterion(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forCampaignCriterion(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = CampaignCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -828,15 +1046,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignCriterionSimulation()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
-        $type = 4444444;
-        $modificationMethod = 5555555;
-        $startDate = 66666666;
-        $endDate = 7777777;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
+        $type = '444444';
+        $modificationMethod = '555555';
+        $startDate = '666666';
+        $endDate = '777777';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignCriterionSimulations/%s~%s~%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignCriterionSimulations/%s~%s~%s~%s~%s~%s",
+            $customerId,
             $campaignId,
             $criterionId,
             $type,
@@ -847,7 +1066,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignCriterionSimulation(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $criterionId,
                 $type,
@@ -858,7 +1077,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = CampaignCriterionSimulationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($type, $names['type']);
@@ -872,21 +1091,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignDraft()
     {
-        $baseCampaignId = 111111;
-        $draftId = 3333333;
+        $customerId = '111111';
+        $baseCampaignId = '222222';
+        $draftId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignDrafts/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignDrafts/%s~%s",
+            $customerId,
             $baseCampaignId,
             $draftId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignDraft(self::CUSTOMER_ID, $baseCampaignId, $draftId)
+            ResourceNames::forCampaignDraft(
+                $customerId,
+                $baseCampaignId,
+                $draftId
+            )
         );
 
         $names = CampaignDraftServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($baseCampaignId, $names['base_campaign_id']);
         $this->assertEquals($draftId, $names['draft_id']);
     }
@@ -896,19 +1120,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignExperiment()
     {
-        $campaignExperimentId = 66666666;
+        $customerId = '111111';
+        $campaignExperimentId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignExperiments/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignExperiments/%s",
+            $customerId,
             $campaignExperimentId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignExperiment(self::CUSTOMER_ID, $campaignExperimentId)
+            ResourceNames::forCampaignExperiment(
+                $customerId,
+                $campaignExperimentId
+            )
         );
 
         $names = CampaignExperimentServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignExperimentId, $names['campaign_experiment_id']);
     }
 
@@ -917,27 +1145,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignExtensionSetting()
     {
-        $campaignId = 111111;
-        $extensionType = ExtensionType::SITELINK;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $extensionType = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignExtensionSettings/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignExtensionSettings/%s~%s",
+            $customerId,
             $campaignId,
-            'SITELINK'
+            $extensionType
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignExtensionSetting(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $extensionType
             )
         );
 
         $names = CampaignExtensionSettingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
-        $this->assertEquals(ExtensionType::name($extensionType), $names['extension_type']);
+        $this->assertEquals($extensionType, $names['extension_type']);
     }
 
     /**
@@ -945,25 +1174,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignFeed()
     {
-        $campaignId = 111111;
-        $feedId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $feedId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignFeeds/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignFeeds/%s~%s",
+            $customerId,
             $campaignId,
             $feedId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignFeed(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $feedId
             )
         );
 
         $names = CampaignFeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
@@ -973,25 +1203,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignLabel()
     {
-        $campaignId = 111111;
-        $labelId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $labelId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignLabels/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignLabels/%s~%s",
+            $customerId,
             $campaignId,
             $labelId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignLabel(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $labelId
             )
         );
 
         $names = CampaignLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
@@ -1001,25 +1232,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignSharedSet()
     {
-        $campaignId = 111111;
-        $sharedSetId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $sharedSetId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignSharedSets/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignSharedSets/%s~%s",
+            $customerId,
             $campaignId,
             $sharedSetId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignSharedSet(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $sharedSetId
             )
         );
 
         $names = CampaignSharedSetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($sharedSetId, $names['shared_set_id']);
     }
@@ -1029,11 +1261,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCarrierConstant()
     {
-        $criterionId = 3333333;
-        $expectedResourceName = sprintf('carrierConstants/%s', $criterionId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "carrierConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCarrierConstant($criterionId)
+            ResourceNames::forCarrierConstant(
+                $criterionId
+            )
         );
 
         $names = CarrierConstantServiceClient::parseName($expectedResourceName);
@@ -1045,16 +1282,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForChangeStatus()
     {
-        $changeStatusId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/changeStatus/%s', self::CUSTOMER_ID, $changeStatusId);
+        $customerId = '111111';
+        $changeStatusId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/changeStatus/%s",
+            $customerId,
+            $changeStatusId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forChangeStatus(self::CUSTOMER_ID, $changeStatusId)
+            ResourceNames::forChangeStatus(
+                $customerId,
+                $changeStatusId
+            )
         );
 
         $names = ChangeStatusServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($changeStatusId, $names['change_status_id']);
     }
 
@@ -1063,19 +1307,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForClickView()
     {
-        $date = '2019-05-29';
-        $gclId = 3333333;
-        $expectedResourceName =
-            sprintf('customers/%s/clickViews/%s~%s', self::CUSTOMER_ID, $date, $gclId);
+        $customerId = '111111';
+        $date = '222222';
+        $gclid = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/clickViews/%s~%s",
+            $customerId,
+            $date,
+            $gclid
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forClickView(self::CUSTOMER_ID, $date, $gclId)
+            ResourceNames::forClickView(
+                $customerId,
+                $date,
+                $gclid
+            )
         );
 
         $names = ClickViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($date, $names['date']);
-        $this->assertEquals($gclId, $names['gclid']);
+        $this->assertEquals($gclid, $names['gclid']);
     }
 
     /**
@@ -1083,16 +1336,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCombinedAudience()
     {
-        $combinedAudienceId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/combinedAudiences/%s', self::CUSTOMER_ID, $combinedAudienceId);
+        $customerId = '111111';
+        $combinedAudienceId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/combinedAudiences/%s",
+            $customerId,
+            $combinedAudienceId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCombinedAudience(self::CUSTOMER_ID, $combinedAudienceId)
+            ResourceNames::forCombinedAudience(
+                $customerId,
+                $combinedAudienceId
+            )
         );
 
         $names = CombinedAudienceServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($combinedAudienceId, $names['combined_audience_id']);
     }
 
@@ -1101,16 +1361,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForConversionAction()
     {
-        $conversionActionId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/conversionActions/%s', self::CUSTOMER_ID, $conversionActionId);
+        $customerId = '111111';
+        $conversionActionId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/conversionActions/%s",
+            $customerId,
+            $conversionActionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forConversionAction(self::CUSTOMER_ID, $conversionActionId)
+            ResourceNames::forConversionAction(
+                $customerId,
+                $conversionActionId
+            )
         );
 
         $names = ConversionActionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($conversionActionId, $names['conversion_action_id']);
     }
 
@@ -1119,15 +1386,45 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCurrencyConstant()
     {
-        $usdCurrencyConstantId = 'USD';
-        $expectedResourceName = sprintf('currencyConstants/%s', $usdCurrencyConstantId);
+        $code = '111111';
+        $expectedResourceName = sprintf(
+            "currencyConstants/%s",
+            $code
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCurrencyConstant($usdCurrencyConstantId)
+            ResourceNames::forCurrencyConstant(
+                $code
+            )
         );
 
         $names = CurrencyConstantServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($usdCurrencyConstantId, $names['code']);
+        $this->assertEquals($code, $names['code']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forCustomAudience()
+     */
+    public function testGetNameForCustomAudience()
+    {
+        $customerId = '111111';
+        $customAudienceId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customAudiences/%s",
+            $customerId,
+            $customAudienceId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forCustomAudience(
+                $customerId,
+                $customAudienceId
+            )
+        );
+
+        $names = CustomAudienceServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($customAudienceId, $names['custom_audience_id']);
     }
 
     /**
@@ -1135,14 +1432,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomer()
     {
-        $expectedResourceName = sprintf('customers/%s', self::CUSTOMER_ID);
+        $customerId = '111111';
+        $expectedResourceName = sprintf(
+            "customers/%s",
+            $customerId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomer(self::CUSTOMER_ID)
+            ResourceNames::forCustomer(
+                $customerId
+            )
         );
 
         $names = CustomerServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
     }
 
     /**
@@ -1150,16 +1453,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerClient()
     {
-        $clientCustomerId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerClients/%s', self::CUSTOMER_ID, $clientCustomerId);
+        $customerId = '111111';
+        $clientCustomerId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerClients/%s",
+            $customerId,
+            $clientCustomerId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerClient(self::CUSTOMER_ID, $clientCustomerId)
+            ResourceNames::forCustomerClient(
+                $customerId,
+                $clientCustomerId
+            )
         );
 
         $names = CustomerClientServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($clientCustomerId, $names['client_customer_id']);
     }
 
@@ -1168,25 +1478,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerClientLink()
     {
-        $clientCustomerId = 111111;
-        $managerLinkId = 3333333;
+        $customerId = '111111';
+        $clientCustomerId = '222222';
+        $managerLinkId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/customerClientLinks/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/customerClientLinks/%s~%s",
+            $customerId,
             $clientCustomerId,
             $managerLinkId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCustomerClientLink(
-                self::CUSTOMER_ID,
+                $customerId,
                 $clientCustomerId,
                 $managerLinkId
             )
         );
 
         $names = CustomerClientLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($clientCustomerId, $names['client_customer_id']);
         $this->assertEquals($managerLinkId, $names['manager_link_id']);
     }
@@ -1196,20 +1507,24 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerExtensionSetting()
     {
-        $extensionType = ExtensionType::SITELINK;
+        $customerId = '111111';
+        $extensionType = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/customerExtensionSettings/%s',
-            self::CUSTOMER_ID,
-            'SITELINK'
+            "customers/%s/customerExtensionSettings/%s",
+            $customerId,
+            $extensionType
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerExtensionSetting(self::CUSTOMER_ID, $extensionType)
+            ResourceNames::forCustomerExtensionSetting(
+                $customerId,
+                $extensionType
+            )
         );
 
         $names = CustomerExtensionSettingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals(ExtensionType::name($extensionType), $names['extension_type']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($extensionType, $names['extension_type']);
     }
 
     /**
@@ -1217,16 +1532,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerFeed()
     {
-        $feedId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerFeeds/%s', self::CUSTOMER_ID, $feedId);
+        $customerId = '111111';
+        $feedId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerFeeds/%s",
+            $customerId,
+            $feedId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerFeed(self::CUSTOMER_ID, $feedId)
+            ResourceNames::forCustomerFeed(
+                $customerId,
+                $feedId
+            )
         );
 
         $names = CustomerFeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
 
@@ -1235,16 +1557,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerLabel()
     {
-        $labelId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerLabels/%s', self::CUSTOMER_ID, $labelId);
+        $customerId = '111111';
+        $labelId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerLabels/%s",
+            $customerId,
+            $labelId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerLabel(self::CUSTOMER_ID, $labelId)
+            ResourceNames::forCustomerLabel(
+                $customerId,
+                $labelId
+            )
         );
 
         $names = CustomerLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
 
@@ -1253,22 +1582,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerManagerLink()
     {
-        $managerCustomerId = 111111;
-        $managerLinkId = 222222;
+        $customerId = '111111';
+        $managerCustomerId = '222222';
+        $managerLinkId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/customerManagerLinks/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/customerManagerLinks/%s~%s",
+            $customerId,
             $managerCustomerId,
             $managerLinkId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forCustomerManagerLink(
-            self::CUSTOMER_ID,
-            $managerCustomerId,
-            $managerLinkId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forCustomerManagerLink(
+                $customerId,
+                $managerCustomerId,
+                $managerLinkId
+            )
+        );
 
         $names = CustomerManagerLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($managerCustomerId, $names['manager_customer_id']);
         $this->assertEquals($managerLinkId, $names['manager_link_id']);
     }
@@ -1278,16 +1611,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerNegativeCriterion()
     {
-        $criterionId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerNegativeCriteria/%s', self::CUSTOMER_ID, $criterionId);
+        $customerId = '111111';
+        $criterionId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerNegativeCriteria/%s",
+            $customerId,
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerNegativeCriterion(self::CUSTOMER_ID, $criterionId)
+            ResourceNames::forCustomerNegativeCriterion(
+                $customerId,
+                $criterionId
+            )
         );
 
         $names = CustomerNegativeCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
@@ -1296,16 +1636,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerUserAccess()
     {
-        $userId = 1111111;
-        $expectedResourceName =
-            sprintf('customers/%s/customerUserAccesses/%s', self::CUSTOMER_ID, $userId);
+        $customerId = '111111';
+        $userId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerUserAccesses/%s",
+            $customerId,
+            $userId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerUserAccess(self::CUSTOMER_ID, $userId)
+            ResourceNames::forCustomerUserAccess(
+                $customerId,
+                $userId
+            )
         );
 
         $names = CustomerUserAccessServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($userId, $names['user_id']);
     }
 
@@ -1314,19 +1661,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerUserAccessInvitation()
     {
-        $invitationId = 1111111;
+        $customerId = '111111';
+        $invitationId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/customerUserAccessInvitations/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/customerUserAccessInvitations/%s",
+            $customerId,
             $invitationId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerUserAccessInvitation(self::CUSTOMER_ID, $invitationId)
+            ResourceNames::forCustomerUserAccessInvitation(
+                $customerId,
+                $invitationId
+            )
         );
 
         $names = CustomerUserAccessInvitationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($invitationId, $names['invitation_id']);
     }
 
@@ -1335,16 +1686,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomInterest()
     {
-        $customInterestId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customInterests/%s', self::CUSTOMER_ID, $customInterestId);
+        $customerId = '111111';
+        $customInterestId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customInterests/%s",
+            $customerId,
+            $customInterestId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomInterest(self::CUSTOMER_ID, $customInterestId)
+            ResourceNames::forCustomInterest(
+                $customerId,
+                $customInterestId
+            )
         );
 
         $names = CustomInterestServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($customInterestId, $names['custom_interest_id']);
     }
 
@@ -1353,24 +1711,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForDetailPlacementView()
     {
-        $adGroupId = 111111;
-        $placement = 'base64';
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $base64Placement = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/detailPlacementViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/detailPlacementViews/%s~%s",
+            $customerId,
             $adGroupId,
-            $placement
+            $base64Placement
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forDetailPlacementView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $placement
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDetailPlacementView(
+                $customerId,
+                $adGroupId,
+                $base64Placement
+            )
+        );
 
         $names = DetailPlacementViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($placement, $names['base64_placement']);
+        $this->assertEquals($base64Placement, $names['base64_placement']);
     }
 
     /**
@@ -1378,24 +1740,57 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForDisplayKeywordView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/displayKeywordViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/displayKeywordViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forDisplayKeywordView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDisplayKeywordView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = DisplayKeywordViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forDistanceView()
+     */
+    public function testGetNameForDistanceView()
+    {
+        $customerId = '111111';
+        $placeholderChainId = '222222';
+        $distanceBucket = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/distanceViews/%s~%s",
+            $customerId,
+            $placeholderChainId,
+            $distanceBucket
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDistanceView(
+                $customerId,
+                $placeholderChainId,
+                $distanceBucket
+            )
+        );
+
+        $names = DistanceViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($placeholderChainId, $names['placeholder_chain_id']);
+        $this->assertEquals($distanceBucket, $names['distance_bucket']);
     }
 
     /**
@@ -1403,31 +1798,73 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForDomainCategory()
     {
-        $campaignId = 111111;
-        $category = 'category';
-        $languageCode = 'en';
+        $customerId = '111111';
+        $campaignId = '222222';
+        $base64Category = '333333';
+        $languageCode = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/domainCategories/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/domainCategories/%s~%s~%s",
+            $customerId,
             $campaignId,
-            $category,
+            $base64Category,
             $languageCode
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forDomainCategory(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
-                $category,
+                $base64Category,
                 $languageCode
             )
         );
 
         $names = DomainCategoryServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
-        $this->assertEquals($category, $names['base64_category']);
+        $this->assertEquals($base64Category, $names['base64_category']);
         $this->assertEquals($languageCode, $names['language_code']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forDynamicSearchAdsSearchTermView()
+     */
+    public function testGetNameForDynamicSearchAdsSearchTermView()
+    {
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $searchTermFingerprint = '333333';
+        $headlineFingerprint = '444444';
+        $landingPageFingerprint = '555555';
+        $pageUrlFingerprint = '666666';
+        $expectedResourceName = sprintf(
+            "customers/%s/dynamicSearchAdsSearchTermViews/%s~%s~%s~%s~%s",
+            $customerId,
+            $adGroupId,
+            $searchTermFingerprint,
+            $headlineFingerprint,
+            $landingPageFingerprint,
+            $pageUrlFingerprint
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDynamicSearchAdsSearchTermView(
+                $customerId,
+                $adGroupId,
+                $searchTermFingerprint,
+                $headlineFingerprint,
+                $landingPageFingerprint,
+                $pageUrlFingerprint
+            )
+        );
+
+        $names = DynamicSearchAdsSearchTermViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adGroupId, $names['ad_group_id']);
+        $this->assertEquals($searchTermFingerprint, $names['search_term_fingerprint']);
+        $this->assertEquals($headlineFingerprint, $names['headline_fingerprint']);
+        $this->assertEquals($landingPageFingerprint, $names['landing_page_fingerprint']);
+        $this->assertEquals($pageUrlFingerprint, $names['page_url_fingerprint']);
     }
 
     /**
@@ -1435,22 +1872,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForExpandedLandingPageView()
     {
-        $expandedFinalUrlFingerprint = 'url';
+        $customerId = '111111';
+        $expandedFinalUrlFingerprint = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/expandedLandingPageViews/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/expandedLandingPageViews/%s",
+            $customerId,
             $expandedFinalUrlFingerprint
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forExpandedLandingPageView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $expandedFinalUrlFingerprint
             )
         );
 
         $names = ExpandedLandingPageViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($expandedFinalUrlFingerprint, $names['expanded_final_url_fingerprint']);
     }
 
@@ -1459,16 +1897,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForExtensionFeedItem()
     {
-        $feedItemId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/extensionFeedItems/%s', self::CUSTOMER_ID, $feedItemId);
+        $customerId = '111111';
+        $feedItemId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/extensionFeedItems/%s",
+            $customerId,
+            $feedItemId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forExtensionFeedItem(self::CUSTOMER_ID, $feedItemId)
+            ResourceNames::forExtensionFeedItem(
+                $customerId,
+                $feedItemId
+            )
         );
 
         $names = ExtensionFeedItemServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
     }
 
@@ -1477,15 +1922,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeed()
     {
-        $feedId = 66666666;
-        $expectedResourceName = sprintf('customers/%s/feeds/%s', self::CUSTOMER_ID, $feedId);
+        $customerId = '111111';
+        $feedId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/feeds/%s",
+            $customerId,
+            $feedId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forFeed(self::CUSTOMER_ID, $feedId)
+            ResourceNames::forFeed(
+                $customerId,
+                $feedId
+            )
         );
 
         $names = FeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
 
@@ -1494,22 +1947,27 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItem()
     {
-        $feedId = 111111;
-        $feedItemId = 222222;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItems/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItems/%s~%s",
+            $customerId,
             $feedId,
             $feedItemId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedItem(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedItemId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedItem(
+                $customerId,
+                $feedId,
+                $feedItemId
+            )
+        );
 
         $names = FeedItemServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
     }
 
@@ -1518,22 +1976,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItemSet()
     {
-        $feedId = 111111;
-        $feedItemSetId = 222222;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemSetId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItemSets/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItemSets/%s~%s",
+            $customerId,
             $feedId,
             $feedItemSetId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedItemSet(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedItemSetId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedItemSet(
+                $customerId,
+                $feedId,
+                $feedItemSetId
+            )
+        );
 
         $names = FeedItemSetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemSetId, $names['feed_item_set_id']);
     }
@@ -1543,25 +2005,29 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItemSetLink()
     {
-        $feedId = 111111;
-        $feedItemId = 222222;
-        $feedItemSetId = 333333;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemSetId = '333333';
+        $feedItemId = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItemSetLinks/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItemSetLinks/%s~%s~%s",
+            $customerId,
             $feedId,
             $feedItemSetId,
             $feedItemId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedItemSetLink(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedItemSetId,
-            $feedItemId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedItemSetLink(
+                $customerId,
+                $feedId,
+                $feedItemSetId,
+                $feedItemId
+            )
+        );
 
         $names = FeedItemSetLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemSetId, $names['feed_item_set_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
@@ -1572,13 +2038,14 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItemTarget()
     {
-        $feedId = 3333333;
-        $feedItemId = 4444444;
-        $feedItemTargetType = 5555555;
-        $feedItemTargetId = 66666666;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemId = '333333';
+        $feedItemTargetType = '444444';
+        $feedItemTargetId = '555555';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItemTargets/%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItemTargets/%s~%s~%s~%s",
+            $customerId,
             $feedId,
             $feedItemId,
             $feedItemTargetType,
@@ -1587,7 +2054,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forFeedItemTarget(
-                self::CUSTOMER_ID,
+                $customerId,
                 $feedId,
                 $feedItemId,
                 $feedItemTargetType,
@@ -1596,7 +2063,8 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = FeedItemTargetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
         $this->assertEquals($feedItemTargetType, $names['feed_item_target_type']);
         $this->assertEquals($feedItemTargetId, $names['feed_item_target_id']);
@@ -1607,22 +2075,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedMapping()
     {
-        $feedId = 111111;
-        $feedMappingId = 222222;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedMappingId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/feedMappings/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedMappings/%s~%s",
+            $customerId,
             $feedId,
             $feedMappingId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedMapping(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedMappingId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedMapping(
+                $customerId,
+                $feedId,
+                $feedMappingId
+            )
+        );
 
         $names = FeedMappingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedMappingId, $names['feed_mapping_id']);
     }
@@ -1632,19 +2104,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedPlaceholderView()
     {
-        $placeholderType = PlaceholderType::AD_CUSTOMIZER;
+        $customerId = '111111';
+        $placeholderType = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/feedPlaceholderViews/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedPlaceholderViews/%s",
+            $customerId,
             $placeholderType
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedPlaceholderView(
-            self::CUSTOMER_ID,
-            $placeholderType
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedPlaceholderView(
+                $customerId,
+                $placeholderType
+            )
+        );
 
         $names = FeedPlaceholderViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($placeholderType, $names['placeholder_type']);
     }
 
@@ -1653,22 +2129,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGenderView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/genderViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/genderViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forGenderView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forGenderView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = GenderViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -1678,22 +2158,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGeographicView()
     {
-        $countryCriterionId = 111111;
-        $locationType = 222222;
+        $customerId = '111111';
+        $countryCriterionId = '222222';
+        $locationType = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/geographicViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/geographicViews/%s~%s",
+            $customerId,
             $countryCriterionId,
             $locationType
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forGeographicView(
-            self::CUSTOMER_ID,
-            $countryCriterionId,
-            $locationType
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forGeographicView(
+                $customerId,
+                $countryCriterionId,
+                $locationType
+            )
+        );
 
         $names = GeographicViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($countryCriterionId, $names['country_criterion_id']);
         $this->assertEquals($locationType, $names['location_type']);
     }
@@ -1703,15 +2187,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGeoTargetConstant()
     {
-        $japanTargetConstantId = 2392;
-        $expectedResourceName = sprintf('geoTargetConstants/%s', $japanTargetConstantId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "geoTargetConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forGeoTargetConstant($japanTargetConstantId)
+            ResourceNames::forGeoTargetConstant(
+                $criterionId
+            )
         );
 
         $names = GeoTargetConstantServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($japanTargetConstantId, $names['criterion_id']);
+        $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
     /**
@@ -1719,15 +2208,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGoogleAdsField()
     {
-        $field = 'field';
-        $expectedResourceName = sprintf('googleAdsFields/%s', $field);
+        $googleAdsField = '111111';
+        $expectedResourceName = sprintf(
+            "googleAdsFields/%s",
+            $googleAdsField
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forGoogleAdsField($field)
+            ResourceNames::forGoogleAdsField(
+                $googleAdsField
+            )
         );
 
         $names = GoogleAdsFieldServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($field, $names['google_ads_field']);
+        $this->assertEquals($googleAdsField, $names['google_ads_field']);
     }
 
     /**
@@ -1735,24 +2229,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGroupPlacementView()
     {
-        $adGroupId = 111111;
-        $placement = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $base64Placement = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/groupPlacementViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/groupPlacementViews/%s~%s",
+            $customerId,
             $adGroupId,
-            $placement
+            $base64Placement
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forGroupPlacementView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $placement
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forGroupPlacementView(
+                $customerId,
+                $adGroupId,
+                $base64Placement
+            )
+        );
 
         $names = GroupPlacementViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($placement, $names['base64_placement']);
+        $this->assertEquals($base64Placement, $names['base64_placement']);
     }
 
     /**
@@ -1760,22 +2258,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForHotelGroupView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/hotelGroupViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/hotelGroupViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forHotelGroupView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forHotelGroupView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = HotelGroupViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -1785,16 +2287,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForHotelPerformanceView()
     {
+        $customerId = '111111';
         $expectedResourceName = sprintf(
-            'customers/%s/hotelPerformanceView',
-            self::CUSTOMER_ID
+            "customers/%s/hotelPerformanceView",
+            $customerId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forHotelPerformanceView(
-            self::CUSTOMER_ID
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forHotelPerformanceView(
+                $customerId
+            )
+        );
 
         $names = HotelPerformanceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
     }
 
     /**
@@ -1802,21 +2308,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForIncomeRangeView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/incomeRangeViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/incomeRangeViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forIncomeRangeView(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forIncomeRangeView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = IncomeRangeViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -1826,20 +2337,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlan()
     {
-        $keywordPlanId = 222222;
+        $customerId = '111111';
+        $keywordPlanId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlans/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlans/%s",
+            $customerId,
             $keywordPlanId
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forKeywordPlan(self::CUSTOMER_ID, $keywordPlanId)
+            ResourceNames::forKeywordPlan(
+                $customerId,
+                $keywordPlanId
+            )
         );
 
         $names = KeywordPlanServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanId, $names['keyword_plan_id']);
     }
 
@@ -1848,20 +2362,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanAdGroup()
     {
-        $keywordPlanAdGroupId = 222222;
+        $customerId = '111111';
+        $keywordPlanAdGroupId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanAdGroups/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanAdGroups/%s",
+            $customerId,
             $keywordPlanAdGroupId
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forKeywordPlanAdGroup(self::CUSTOMER_ID, $keywordPlanAdGroupId)
+            ResourceNames::forKeywordPlanAdGroup(
+                $customerId,
+                $keywordPlanAdGroupId
+            )
         );
 
         $names = KeywordPlanAdGroupServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanAdGroupId, $names['keyword_plan_ad_group_id']);
     }
 
@@ -1870,23 +2387,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanAdGroupKeyword()
     {
-        $keywordPlanAdGroupKeywordId = 222222;
+        $customerId = '111111';
+        $keywordPlanAdGroupKeywordId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanAdGroupKeywords/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanAdGroupKeywords/%s",
+            $customerId,
             $keywordPlanAdGroupKeywordId
         );
-
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forKeywordPlanAdGroupKeyword(
-                self::CUSTOMER_ID,
+                $customerId,
                 $keywordPlanAdGroupKeywordId
             )
         );
 
         $names = KeywordPlanAdGroupKeywordServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanAdGroupKeywordId, $names['keyword_plan_ad_group_keyword_id']);
     }
 
@@ -1895,20 +2412,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanCampaign()
     {
-        $keywordPlanCampaignId = 222222;
+        $customerId = '111111';
+        $keywordPlanCampaignId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanCampaigns/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanCampaigns/%s",
+            $customerId,
             $keywordPlanCampaignId
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forKeywordPlanCampaign(self::CUSTOMER_ID, $keywordPlanCampaignId)
+            ResourceNames::forKeywordPlanCampaign(
+                $customerId,
+                $keywordPlanCampaignId
+            )
         );
 
         $names = KeywordPlanCampaignServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanCampaignId, $names['keyword_plan_campaign_id']);
     }
 
@@ -1917,24 +2437,53 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanCampaignKeyword()
     {
-        $keywordPlanCampaignKeywordId = 222222;
+        $customerId = '111111';
+        $keywordPlanCampaignKeywordId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanCampaignKeywords/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanCampaignKeywords/%s",
+            $customerId,
             $keywordPlanCampaignKeywordId
         );
-
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forKeywordPlanCampaignKeyword(
-                self::CUSTOMER_ID,
+                $customerId,
                 $keywordPlanCampaignKeywordId
             )
         );
 
         $names = KeywordPlanCampaignKeywordServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanCampaignKeywordId, $names['keyword_plan_campaign_keyword_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forKeywordView()
+     */
+    public function testGetNameForKeywordView()
+    {
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/keywordViews/%s~%s",
+            $customerId,
+            $adGroupId,
+            $criterionId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forKeywordView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
+
+        $names = KeywordViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adGroupId, $names['ad_group_id']);
+        $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
     /**
@@ -1942,15 +2491,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLabel()
     {
-        $labelId = 938;
-        $expectedResourceName = sprintf('customers/%s/labels/%s', self::CUSTOMER_ID, $labelId);
+        $customerId = '111111';
+        $labelId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/labels/%s",
+            $customerId,
+            $labelId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLabel(self::CUSTOMER_ID, $labelId)
+            ResourceNames::forLabel(
+                $customerId,
+                $labelId
+            )
         );
 
         $names = LabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
 
@@ -1959,24 +2516,24 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLandingPageView()
     {
-        $unexpandedFinalUrlFingerprint = 'url';
+        $customerId = '111111';
+        $unexpandedFinalUrlFingerprint = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/landingPageViews/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/landingPageViews/%s",
+            $customerId,
             $unexpandedFinalUrlFingerprint
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLandingPageView(self::CUSTOMER_ID, $unexpandedFinalUrlFingerprint)
+            ResourceNames::forLandingPageView(
+                $customerId,
+                $unexpandedFinalUrlFingerprint
+            )
         );
 
         $names = LandingPageViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals(
-            $unexpandedFinalUrlFingerprint,
-            $names['unexpanded_final_url_fingerprint']
-        );
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($unexpandedFinalUrlFingerprint, $names['unexpanded_final_url_fingerprint']);
     }
 
     /**
@@ -1984,15 +2541,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLanguageConstant()
     {
-        $englishLanguageId = 1000;
-        $expectedResourceName = sprintf('languageConstants/%s', $englishLanguageId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "languageConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLanguageConstant($englishLanguageId)
+            ResourceNames::forLanguageConstant(
+                $criterionId
+            )
         );
 
         $names = LanguageConstantServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($englishLanguageId, $names['criterion_id']);
+        $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
     /**
@@ -2000,21 +2562,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLocationView()
     {
-        $campaignId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/locationViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/locationViews/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLocationView(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forLocationView(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = LocationViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2024,22 +2591,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForManagedPlacementView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/managedPlacementViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/managedPlacementViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forManagedPlacementView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forManagedPlacementView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = ManagedPlacementViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2049,16 +2620,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMediaFile()
     {
-        $mediaFileId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/mediaFiles/%s', self::CUSTOMER_ID, $mediaFileId);
+        $customerId = '111111';
+        $mediaFileId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/mediaFiles/%s",
+            $customerId,
+            $mediaFileId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMediaFile(self::CUSTOMER_ID, $mediaFileId)
+            ResourceNames::forMediaFile(
+                $customerId,
+                $mediaFileId
+            )
         );
 
         $names = MediaFileServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($mediaFileId, $names['media_file_id']);
     }
 
@@ -2067,16 +2645,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMerchantCenterLink()
     {
-        $merchantCenterId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/merchantCenterLinks/%s', self::CUSTOMER_ID, $merchantCenterId);
+        $customerId = '111111';
+        $merchantCenterId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/merchantCenterLinks/%s",
+            $customerId,
+            $merchantCenterId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMerchantCenterLink(self::CUSTOMER_ID, $merchantCenterId)
+            ResourceNames::forMerchantCenterLink(
+                $customerId,
+                $merchantCenterId
+            )
         );
 
         $names = MerchantCenterLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($merchantCenterId, $names['merchant_center_id']);
     }
 
@@ -2085,11 +2670,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMobileAppCategoryConstant()
     {
-        $mobileAppCategoryId = 1000;
-        $expectedResourceName = sprintf('mobileAppCategoryConstants/%s', $mobileAppCategoryId);
+        $mobileAppCategoryId = '111111';
+        $expectedResourceName = sprintf(
+            "mobileAppCategoryConstants/%s",
+            $mobileAppCategoryId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMobileAppCategoryConstant($mobileAppCategoryId)
+            ResourceNames::forMobileAppCategoryConstant(
+                $mobileAppCategoryId
+            )
         );
 
         $names = MobileAppCategoryConstantServiceClient::parseName($expectedResourceName);
@@ -2101,11 +2691,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMobileDeviceConstant()
     {
-        $criterionId = 1000;
-        $expectedResourceName = sprintf('mobileDeviceConstants/%s', $criterionId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "mobileDeviceConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMobileDeviceConstant($criterionId)
+            ResourceNames::forMobileDeviceConstant(
+                $criterionId
+            )
         );
 
         $names = MobileDeviceConstantServiceClient::parseName($expectedResourceName);
@@ -2113,15 +2708,45 @@ class ResourceNamesTest extends TestCase
     }
 
     /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forOfflineUserDataJob()
+     */
+    public function testGetNameForOfflineUserDataJob()
+    {
+        $customerId = '111111';
+        $offlineUserDataUpdateId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/offlineUserDataJobs/%s",
+            $customerId,
+            $offlineUserDataUpdateId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forOfflineUserDataJob(
+                $customerId,
+                $offlineUserDataUpdateId
+            )
+        );
+
+        $names = OfflineUserDataJobServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($offlineUserDataUpdateId, $names['offline_user_data_update_id']);
+    }
+
+    /**
      * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forOperatingSystemVersionConstant()
      */
     public function testGetNameForOperatingSystemVersionConstant()
     {
-        $criterionId = 1000;
-        $expectedResourceName = sprintf('operatingSystemVersionConstants/%s', $criterionId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "operatingSystemVersionConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forOperatingSystemVersionConstant($criterionId)
+            ResourceNames::forOperatingSystemVersionConstant(
+                $criterionId
+            )
         );
 
         $names = OperatingSystemVersionConstantServiceClient::parseName($expectedResourceName);
@@ -2133,31 +2758,32 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForPaidOrganicSearchTermView()
     {
-        $campaignId = 111111;
-        $adGroupId = 222222;
-        $searchTerm = 'base64';
+        $customerId = '111111';
+        $campaignId = '222222';
+        $adGroupId = '333333';
+        $base64SearchTerm = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/paidOrganicSearchTermViews/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/paidOrganicSearchTermViews/%s~%s~%s",
+            $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $base64SearchTerm
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forPaidOrganicSearchTermView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $adGroupId,
-                $searchTerm
+                $base64SearchTerm
             )
         );
 
         $names = PaidOrganicSearchTermViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($searchTerm, $names['base64_search_term']);
+        $this->assertEquals($base64SearchTerm, $names['base64_search_term']);
     }
 
     /**
@@ -2165,41 +2791,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForParentalStatusView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/parentalStatusViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/parentalStatusViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forParentalStatusView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forParentalStatusView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = ParentalStatusViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
-    }
-
-    /**
-     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forPaymentsAccount()
-     */
-    public function testGetNameForPaymentsAccount()
-    {
-        $paymentsAccountId = '1111-2222-3333-4444';
-        $expectedResourceName = sprintf(
-            'customers/%s/paymentsAccounts/%s',
-            self::CUSTOMER_ID,
-            $paymentsAccountId
-        );
-        $this->assertEquals($expectedResourceName, ResourceNames::forPaymentsAccount(
-            self::CUSTOMER_ID,
-            $paymentsAccountId
-        ));
     }
 
     /**
@@ -2207,11 +2820,11 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForProductBiddingCategoryConstant()
     {
-        $countryCode = 'US';
-        $level = 222222;
-        $id = 3333333;
+        $countryCode = '111111';
+        $level = '222222';
+        $id = '333333';
         $expectedResourceName = sprintf(
-            'productBiddingCategoryConstants/%s~%s~%s',
+            "productBiddingCategoryConstants/%s~%s~%s",
             $countryCode,
             $level,
             $id
@@ -2236,23 +2849,27 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForProductGroupView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adgroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/productGroupViews/%s~%s',
-            self::CUSTOMER_ID,
-            $adGroupId,
+            "customers/%s/productGroupViews/%s~%s",
+            $customerId,
+            $adgroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forProductGroupView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forProductGroupView(
+                $customerId,
+                $adgroupId,
+                $criterionId
+            )
+        );
 
         $names = ProductGroupViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals($adGroupId, $names['adgroup_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adgroupId, $names['adgroup_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
@@ -2261,16 +2878,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForRecommendation()
     {
-        $recommendationId = 'a1b2c3d4';
-        $expectedResourceName =
-            sprintf('customers/%s/recommendations/%s', self::CUSTOMER_ID, $recommendationId);
+        $customerId = '111111';
+        $recommendationId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/recommendations/%s",
+            $customerId,
+            $recommendationId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forRecommendation(self::CUSTOMER_ID, $recommendationId)
+            ResourceNames::forRecommendation(
+                $customerId,
+                $recommendationId
+            )
         );
 
         $names = RecommendationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($recommendationId, $names['recommendation_id']);
     }
 
@@ -2279,16 +2903,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForRemarketingAction()
     {
-        $remarketingActionId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/remarketingActions/%s', self::CUSTOMER_ID, $remarketingActionId);
+        $customerId = '111111';
+        $remarketingActionId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/remarketingActions/%s",
+            $customerId,
+            $remarketingActionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forRemarketingAction(self::CUSTOMER_ID, $remarketingActionId)
+            ResourceNames::forRemarketingAction(
+                $customerId,
+                $remarketingActionId
+            )
         );
 
         $names = RemarketingActionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($remarketingActionId, $names['remarketing_action_id']);
     }
 
@@ -2297,31 +2928,32 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForSearchTermView()
     {
-        $campaignId = 111111;
-        $adGroupId = 222222;
-        $searchTerm = 'base64';
+        $customerId = '111111';
+        $campaignId = '222222';
+        $adGroupId = '333333';
+        $query = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/searchTermViews/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/searchTermViews/%s~%s~%s",
+            $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $query
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forSearchTermView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $adGroupId,
-                $searchTerm
+                $query
             )
         );
 
         $names = SearchTermViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($searchTerm, $names['query']);
+        $this->assertEquals($query, $names['query']);
     }
 
     /**
@@ -2329,22 +2961,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForSharedCriterion()
     {
-        $sharedSetId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $sharedSetId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/sharedCriteria/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/sharedCriteria/%s~%s",
+            $customerId,
             $sharedSetId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forSharedCriterion(
-            self::CUSTOMER_ID,
-            $sharedSetId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forSharedCriterion(
+                $customerId,
+                $sharedSetId,
+                $criterionId
+            )
+        );
 
         $names = SharedCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($sharedSetId, $names['shared_set_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2354,16 +2990,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForSharedSet()
     {
-        $sharedSetId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/sharedSets/%s', self::CUSTOMER_ID, $sharedSetId);
+        $customerId = '111111';
+        $sharedSetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/sharedSets/%s",
+            $customerId,
+            $sharedSetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forSharedSet(self::CUSTOMER_ID, $sharedSetId)
+            ResourceNames::forSharedSet(
+                $customerId,
+                $sharedSetId
+            )
         );
 
         $names = SharedSetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($sharedSetId, $names['shared_set_id']);
     }
 
@@ -2372,42 +3015,45 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForShoppingPerformanceView()
     {
-        $expectedResourceName =
-            sprintf('customers/%s/shoppingPerformanceView', self::CUSTOMER_ID);
+        $customerId = '111111';
+        $expectedResourceName = sprintf(
+            "customers/%s/shoppingPerformanceView",
+            $customerId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forShoppingPerformanceView(self::CUSTOMER_ID)
+            ResourceNames::forShoppingPerformanceView(
+                $customerId
+            )
         );
 
         $names = ShoppingPerformanceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
     }
 
     /**
-     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forThirdPartyAppAnalyticsLinkName()
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forThirdPartyAppAnalyticsLink()
      */
     public function testGetNameForThirdPartyAppAnalyticsLink()
     {
-        $thirdPartyAppAnalyticsLinkId = 222222;
+        $customerId = '111111';
+        $customerLinkId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/thirdPartyAppAnalyticsLinks/%s',
-            self::CUSTOMER_ID,
-            $thirdPartyAppAnalyticsLinkId
+            "customers/%s/thirdPartyAppAnalyticsLinks/%s",
+            $customerId,
+            $customerLinkId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forThirdPartyAppAnalyticsLinkName(
-                self::CUSTOMER_ID,
-                $thirdPartyAppAnalyticsLinkId
+            ResourceNames::forThirdPartyAppAnalyticsLink(
+                $customerId,
+                $customerLinkId
             )
         );
 
         $names = ThirdPartyAppAnalyticsLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals(
-            $thirdPartyAppAnalyticsLinkId,
-            $names['customer_link_id']
-        );
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($customerLinkId, $names['customer_link_id']);
     }
 
     /**
@@ -2415,12 +3061,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForTopicConstant()
     {
-        $topicId = 222222;
-        $expectedResourceName =
-            sprintf('topicConstants/%s', $topicId);
+        $topicId = '111111';
+        $expectedResourceName = sprintf(
+            "topicConstants/%s",
+            $topicId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forTopicConstant($topicId)
+            ResourceNames::forTopicConstant(
+                $topicId
+            )
         );
 
         $names = TopicConstantServiceClient::parseName($expectedResourceName);
@@ -2432,22 +3082,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForTopicView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/topicViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/topicViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forTopicView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forTopicView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = TopicViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2457,16 +3111,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForUserInterest()
     {
-        $userInterestId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/userInterests/%s', self::CUSTOMER_ID, $userInterestId);
+        $customerId = '111111';
+        $userInterestId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/userInterests/%s",
+            $customerId,
+            $userInterestId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forUserInterest(self::CUSTOMER_ID, $userInterestId)
+            ResourceNames::forUserInterest(
+                $customerId,
+                $userInterestId
+            )
         );
 
         $names = UserInterestServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($userInterestId, $names['user_interest_id']);
     }
 
@@ -2475,17 +3136,53 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForUserList()
     {
-        $userListId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/userLists/%s', self::CUSTOMER_ID, $userListId);
+        $customerId = '111111';
+        $userListId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/userLists/%s",
+            $customerId,
+            $userListId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forUserList(self::CUSTOMER_ID, $userListId)
+            ResourceNames::forUserList(
+                $customerId,
+                $userListId
+            )
         );
 
         $names = UserListServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($userListId, $names['user_list_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V6\ResourceNames::forUserLocationView()
+     */
+    public function testGetNameForUserLocationView()
+    {
+        $customerId = '111111';
+        $countryCriterionId = '222222';
+        $isTargetingLocation = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/userLocationViews/%s~%s",
+            $customerId,
+            $countryCriterionId,
+            $isTargetingLocation
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forUserLocationView(
+                $customerId,
+                $countryCriterionId,
+                $isTargetingLocation
+            )
+        );
+
+        $names = UserLocationViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($countryCriterionId, $names['country_criterion_id']);
+        $this->assertEquals($isTargetingLocation, $names['is_targeting_location']);
     }
 
     /**
@@ -2493,16 +3190,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForVideo()
     {
-        $videoId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/videos/%s', self::CUSTOMER_ID, $videoId);
+        $customerId = '111111';
+        $videoId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/videos/%s",
+            $customerId,
+            $videoId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forVideo(self::CUSTOMER_ID, $videoId)
+            ResourceNames::forVideo(
+                $customerId,
+                $videoId
+            )
         );
 
         $names = VideoServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($videoId, $names['video_id']);
     }
 }

--- a/tests/Google/Ads/GoogleAds/Util/V7/ResourceNamesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V7/ResourceNamesTest.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2020 Google LLC
+/**
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
+// Generated code ; DO NOT EDIT.
+
 namespace Google\Ads\GoogleAds\Util\V7;
 
-use Google\Ads\GoogleAds\V7\Enums\AssetFieldTypeEnum\AssetFieldType;
-use Google\Ads\GoogleAds\V7\Enums\ExtensionTypeEnum\ExtensionType;
-use Google\Ads\GoogleAds\V7\Enums\PlaceholderTypeEnum\PlaceholderType;
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetProposalServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountBudgetServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AccountLinkServiceClient;
+use Google\Ads\GoogleAds\V7\Services\AdGroupAdAssetViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdLabelServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAdServiceClient;
 use Google\Ads\GoogleAds\V7\Services\AdGroupAssetServiceClient;
@@ -67,6 +67,7 @@ use Google\Ads\GoogleAds\V7\Services\CombinedAudienceServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ConversionCustomVariableServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CurrencyConstantServiceClient;
+use Google\Ads\GoogleAds\V7\Services\CustomAudienceServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomerAssetServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomerClientLinkServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomerClientServiceClient;
@@ -81,7 +82,9 @@ use Google\Ads\GoogleAds\V7\Services\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V7\Services\CustomInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DetailPlacementViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DisplayKeywordViewServiceClient;
+use Google\Ads\GoogleAds\V7\Services\DistanceViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\DomainCategoryServiceClient;
+use Google\Ads\GoogleAds\V7\Services\DynamicSearchAdsSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ExpandedLandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ExtensionFeedItemServiceClient;
 use Google\Ads\GoogleAds\V7\Services\FeedItemServiceClient;
@@ -104,6 +107,7 @@ use Google\Ads\GoogleAds\V7\Services\KeywordPlanAdGroupServiceClient;
 use Google\Ads\GoogleAds\V7\Services\KeywordPlanCampaignKeywordServiceClient;
 use Google\Ads\GoogleAds\V7\Services\KeywordPlanCampaignServiceClient;
 use Google\Ads\GoogleAds\V7\Services\KeywordPlanServiceClient;
+use Google\Ads\GoogleAds\V7\Services\KeywordViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\LabelServiceClient;
 use Google\Ads\GoogleAds\V7\Services\LandingPageViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\LanguageConstantServiceClient;
@@ -114,6 +118,7 @@ use Google\Ads\GoogleAds\V7\Services\MediaFileServiceClient;
 use Google\Ads\GoogleAds\V7\Services\MerchantCenterLinkServiceClient;
 use Google\Ads\GoogleAds\V7\Services\MobileAppCategoryConstantServiceClient;
 use Google\Ads\GoogleAds\V7\Services\MobileDeviceConstantServiceClient;
+use Google\Ads\GoogleAds\V7\Services\OfflineUserDataJobServiceClient;
 use Google\Ads\GoogleAds\V7\Services\OperatingSystemVersionConstantServiceClient;
 use Google\Ads\GoogleAds\V7\Services\PaidOrganicSearchTermViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\ParentalStatusViewServiceClient;
@@ -130,6 +135,7 @@ use Google\Ads\GoogleAds\V7\Services\TopicConstantServiceClient;
 use Google\Ads\GoogleAds\V7\Services\TopicViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserInterestServiceClient;
 use Google\Ads\GoogleAds\V7\Services\UserListServiceClient;
+use Google\Ads\GoogleAds\V7\Services\UserLocationViewServiceClient;
 use Google\Ads\GoogleAds\V7\Services\VideoServiceClient;
 use Google\Ads\GoogleAds\V7\Services\WebpageViewServiceClient;
 use PHPUnit\Framework\TestCase;
@@ -143,23 +149,49 @@ use PHPUnit\Framework\TestCase;
 class ResourceNamesTest extends TestCase
 {
 
-    private const CUSTOMER_ID = 1234567890;
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forPaymentsAccount()
+     */
+    public function testGetNameForPaymentsAccount()
+    {
+        $customerId = '111111';
+        $paymentsAccountId = '1111-2222-3333-4444';
+        $expectedResourceName = sprintf(
+            'customers/%s/paymentsAccounts/%s',
+            $customerId,
+            $paymentsAccountId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forPaymentsAccount(
+                $customerId,
+                $paymentsAccountId
+            )
+        );
+    }
 
     /**
      * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forAccountBudget()
      */
     public function testGetNameForAccountBudget()
     {
-        $accountBudgetId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/accountBudgets/%s', self::CUSTOMER_ID, $accountBudgetId);
+        $customerId = '111111';
+        $accountBudgetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/accountBudgets/%s",
+            $customerId,
+            $accountBudgetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAccountBudget(self::CUSTOMER_ID, $accountBudgetId)
+            ResourceNames::forAccountBudget(
+                $customerId,
+                $accountBudgetId
+            )
         );
 
         $names = AccountBudgetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($accountBudgetId, $names['account_budget_id']);
     }
 
@@ -168,37 +200,48 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAccountBudgetProposal()
     {
-        $accountBudgetProposalId = 111111;
+        $customerId = '111111';
+        $accountBudgetProposalId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/accountBudgetProposals/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/accountBudgetProposals/%s",
+            $customerId,
             $accountBudgetProposalId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAccountBudgetProposal(self::CUSTOMER_ID, $accountBudgetProposalId)
+            ResourceNames::forAccountBudgetProposal(
+                $customerId,
+                $accountBudgetProposalId
+            )
         );
 
         $names = AccountBudgetProposalServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($accountBudgetProposalId, $names['account_budget_proposal_id']);
     }
 
     /**
-     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forAccountLinkName()
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forAccountLink()
      */
-    public function testGetNameForAccountLinkName()
+    public function testGetNameForAccountLink()
     {
-        $accountLinkId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/accountLinks/%s', self::CUSTOMER_ID, $accountLinkId);
+        $customerId = '111111';
+        $accountLinkId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/accountLinks/%s",
+            $customerId,
+            $accountLinkId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAccountLinkName(self::CUSTOMER_ID, $accountLinkId)
+            ResourceNames::forAccountLink(
+                $customerId,
+                $accountLinkId
+            )
         );
 
         $names = AccountLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($accountLinkId, $names['account_link_id']);
     }
 
@@ -207,16 +250,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAd()
     {
-        $adId = 22222;
-        $expectedResourceName =
-            sprintf('customers/%s/ads/%s', self::CUSTOMER_ID, $adId);
+        $customerId = '111111';
+        $adId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/ads/%s",
+            $customerId,
+            $adId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAd(self::CUSTOMER_ID, $adId)
+            ResourceNames::forAd(
+                $customerId,
+                $adId
+            )
         );
 
         $names = AdServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adId, $names['ad_id']);
     }
 
@@ -225,15 +275,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroup()
     {
-        $adGroupId = 111111;
-        $expectedResourceName = sprintf('customers/%s/adGroups/%s', self::CUSTOMER_ID, $adGroupId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroups/%s",
+            $customerId,
+            $adGroupId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroup(self::CUSTOMER_ID, $adGroupId)
+            ResourceNames::forAdGroup(
+                $customerId,
+                $adGroupId
+            )
         );
 
         $names = AdGroupServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
     }
 
@@ -242,19 +300,65 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupAd()
     {
-        $adGroupId = 111111;
-        $adId = 22222;
-        $expectedResourceName =
-            sprintf('customers/%s/adGroupAds/%s~%s', self::CUSTOMER_ID, $adGroupId, $adId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $adId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupAds/%s~%s",
+            $customerId,
+            $adGroupId,
+            $adId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupAd(self::CUSTOMER_ID, $adGroupId, $adId)
+            ResourceNames::forAdGroupAd(
+                $customerId,
+                $adGroupId,
+                $adId
+            )
         );
 
         $names = AdGroupAdServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($adId, $names['ad_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forAdGroupAdAssetView()
+     */
+    public function testGetNameForAdGroupAdAssetView()
+    {
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $adId = '333333';
+        $assetId = '444444';
+        $fieldType = '555555';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupAdAssetViews/%s~%s~%s~%s",
+            $customerId,
+            $adGroupId,
+            $adId,
+            $assetId,
+            $fieldType
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forAdGroupAdAssetView(
+                $customerId,
+                $adGroupId,
+                $adId,
+                $assetId,
+                $fieldType
+            )
+        );
+
+        $names = AdGroupAdAssetViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adGroupId, $names['ad_group_id']);
+        $this->assertEquals($adId, $names['ad_id']);
+        $this->assertEquals($assetId, $names['asset_id']);
+        $this->assertEquals($fieldType, $names['field_type']);
     }
 
     /**
@@ -262,23 +366,29 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupAdLabel()
     {
-        $adGroupId = 111111;
-        $adId = 222222;
-        $labelId = 333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $adId = '333333';
+        $labelId = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupAdLabels/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupAdLabels/%s~%s~%s",
+            $customerId,
             $adGroupId,
             $adId,
             $labelId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupAdLabel(self::CUSTOMER_ID, $adGroupId, $adId, $labelId)
+            ResourceNames::forAdGroupAdLabel(
+                $customerId,
+                $adGroupId,
+                $adId,
+                $labelId
+            )
         );
 
         $names = AdGroupAdLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($adId, $names['ad_id']);
         $this->assertEquals($labelId, $names['label_id']);
@@ -289,12 +399,12 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupAsset()
     {
-        $customerId = 111111;
-        $adGroupId = 222222;
-        $assetId = 333333;
-        $fieldType = 444444;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $assetId = '333333';
+        $fieldType = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupAssets/%s~%s~%s',
+            "customers/%s/adGroupAssets/%s~%s~%s",
             $customerId,
             $adGroupId,
             $assetId,
@@ -322,25 +432,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupAudienceView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupAudienceViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupAudienceViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupAudienceView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId
             )
         );
 
         $names = AdGroupAudienceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -350,21 +461,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupBidModifier()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupBidModifiers/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupBidModifiers/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupBidModifier(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forAdGroupBidModifier(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = AdGroupBidModifierServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -374,21 +490,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupCriterion()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupCriteria/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupCriteria/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupCriterion(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forAdGroupCriterion(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = AdGroupCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -398,12 +519,13 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupCriterionLabel()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
-        $labelId = 4444444;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $labelId = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupCriterionLabels/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupCriterionLabels/%s~%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId,
             $labelId
@@ -411,7 +533,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupCriterionLabel(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId,
                 $labelId
@@ -419,7 +541,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdGroupCriterionLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($labelId, $names['label_id']);
@@ -430,15 +552,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupCriterionSimulation()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
-        $type = 4444444;
-        $modificationMethod = 5555555;
-        $startDate = 66666666;
-        $endDate = 7777777;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $type = '444444';
+        $modificationMethod = '555555';
+        $startDate = '666666';
+        $endDate = '777777';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupCriterionSimulations/%s~%s~%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupCriterionSimulations/%s~%s~%s~%s~%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId,
             $type,
@@ -449,7 +572,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupCriterionSimulation(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId,
                 $type,
@@ -460,7 +583,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdGroupCriterionSimulationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($type, $names['type']);
@@ -474,27 +597,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupExtensionSetting()
     {
-        $adGroupId = 111111;
-        $extensionType = ExtensionType::SITELINK;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $extensionType = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupExtensionSettings/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupExtensionSettings/%s~%s",
+            $customerId,
             $adGroupId,
-            'SITELINK'
+            $extensionType
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupExtensionSetting(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $extensionType
             )
         );
 
         $names = AdGroupExtensionSettingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals(ExtensionType::name($extensionType), $names['extension_type']);
+        $this->assertEquals($extensionType, $names['extension_type']);
     }
 
     /**
@@ -502,17 +626,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupFeed()
     {
-        $adGroupId = 111111;
-        $feedId = 3333333;
-        $expectedResourceName =
-            sprintf('customers/%s/adGroupFeeds/%s~%s', self::CUSTOMER_ID, $adGroupId, $feedId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $feedId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupFeeds/%s~%s",
+            $customerId,
+            $adGroupId,
+            $feedId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupFeed(self::CUSTOMER_ID, $adGroupId, $feedId)
+            ResourceNames::forAdGroupFeed(
+                $customerId,
+                $adGroupId,
+                $feedId
+            )
         );
 
         $names = AdGroupFeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
@@ -522,17 +655,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupLabel()
     {
-        $adGroupId = 111111;
-        $labelId = 3333333;
-        $expectedResourceName =
-            sprintf('customers/%s/adGroupLabels/%s~%s', self::CUSTOMER_ID, $adGroupId, $labelId);
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $labelId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/adGroupLabels/%s~%s",
+            $customerId,
+            $adGroupId,
+            $labelId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdGroupLabel(self::CUSTOMER_ID, $adGroupId, $labelId)
+            ResourceNames::forAdGroupLabel(
+                $customerId,
+                $adGroupId,
+                $labelId
+            )
         );
 
         $names = AdGroupLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
@@ -542,14 +684,15 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdGroupSimulation()
     {
-        $adGroupId = 111111;
-        $type = 4444444;
-        $modificationMethod = 5555555;
-        $startDate = 66666666;
-        $endDate = 7777777;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $type = '333333';
+        $modificationMethod = '444444';
+        $startDate = '555555';
+        $endDate = '666666';
         $expectedResourceName = sprintf(
-            'customers/%s/adGroupSimulations/%s~%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adGroupSimulations/%s~%s~%s~%s~%s",
+            $customerId,
             $adGroupId,
             $type,
             $modificationMethod,
@@ -559,7 +702,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdGroupSimulation(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $type,
                 $modificationMethod,
@@ -569,7 +712,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdGroupSimulationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($type, $names['type']);
         $this->assertEquals($modificationMethod, $names['modification_method']);
@@ -582,12 +725,13 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdParameter()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
-        $parameterIndex = 4444444;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $parameterIndex = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/adParameters/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adParameters/%s~%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId,
             $parameterIndex
@@ -595,7 +739,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forAdParameter(
-                self::CUSTOMER_ID,
+                $customerId,
                 $adGroupId,
                 $criterionId,
                 $parameterIndex
@@ -603,7 +747,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = AdParameterServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($parameterIndex, $names['parameter_index']);
@@ -614,21 +758,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAdScheduleView()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/adScheduleViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/adScheduleViews/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAdScheduleView(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forAdScheduleView(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = AdScheduleViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -638,21 +787,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAgeRangeView()
     {
-        $adGroupId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/ageRangeViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/ageRangeViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAgeRangeView(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forAgeRangeView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = AgeRangeViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -662,15 +816,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForAsset()
     {
-        $assetId = 111111;
-        $expectedResourceName = sprintf('customers/%s/assets/%s', self::CUSTOMER_ID, $assetId);
+        $customerId = '111111';
+        $assetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/assets/%s",
+            $customerId,
+            $assetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forAsset(self::CUSTOMER_ID, $assetId)
+            ResourceNames::forAsset(
+                $customerId,
+                $assetId
+            )
         );
 
         $names = AssetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($assetId, $names['asset_id']);
     }
 
@@ -679,16 +841,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForBatchJob()
     {
-        $batchJobId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/batchJobs/%s', self::CUSTOMER_ID, $batchJobId);
+        $customerId = '111111';
+        $batchJobId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/batchJobs/%s",
+            $customerId,
+            $batchJobId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forBatchJob(self::CUSTOMER_ID, $batchJobId)
+            ResourceNames::forBatchJob(
+                $customerId,
+                $batchJobId
+            )
         );
 
         $names = BatchJobServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($batchJobId, $names['batch_job_id']);
     }
 
@@ -697,16 +866,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForBiddingStrategy()
     {
-        $biddingStrategyId = 4444444;
-        $expectedResourceName =
-            sprintf('customers/%s/biddingStrategies/%s', self::CUSTOMER_ID, $biddingStrategyId);
+        $customerId = '111111';
+        $biddingStrategyId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/biddingStrategies/%s",
+            $customerId,
+            $biddingStrategyId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forBiddingStrategy(self::CUSTOMER_ID, $biddingStrategyId)
+            ResourceNames::forBiddingStrategy(
+                $customerId,
+                $biddingStrategyId
+            )
         );
 
         $names = BiddingStrategyServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($biddingStrategyId, $names['bidding_strategy_id']);
     }
 
@@ -715,14 +891,14 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForBiddingStrategySimulation()
     {
-        $customerId = 111111;
-        $biddingStrategyId = 222222;
-        $type = 333333;
-        $modificationMethod = 444444;
-        $startDate = 555555;
-        $endDate = 666666;
+        $customerId = '111111';
+        $biddingStrategyId = '222222';
+        $type = '333333';
+        $modificationMethod = '444444';
+        $startDate = '555555';
+        $endDate = '666666';
         $expectedResourceName = sprintf(
-            'customers/%s/biddingStrategySimulations/%s~%s~%s~%s~%s',
+            "customers/%s/biddingStrategySimulations/%s~%s~%s~%s~%s",
             $customerId,
             $biddingStrategyId,
             $type,
@@ -756,16 +932,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForBillingSetup()
     {
-        $billingSetupId = 4444444;
-        $expectedResourceName =
-            sprintf('customers/%s/billingSetups/%s', self::CUSTOMER_ID, $billingSetupId);
+        $customerId = '111111';
+        $billingSetupId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/billingSetups/%s",
+            $customerId,
+            $billingSetupId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forBillingSetup(self::CUSTOMER_ID, $billingSetupId)
+            ResourceNames::forBillingSetup(
+                $customerId,
+                $billingSetupId
+            )
         );
 
         $names = BillingSetupServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($billingSetupId, $names['billing_setup_id']);
     }
 
@@ -774,16 +957,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaign()
     {
-        $campaignId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/campaigns/%s', self::CUSTOMER_ID, $campaignId);
+        $customerId = '111111';
+        $campaignId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/campaigns/%s",
+            $customerId,
+            $campaignId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaign(self::CUSTOMER_ID, $campaignId)
+            ResourceNames::forCampaign(
+                $customerId,
+                $campaignId
+            )
         );
 
         $names = CampaignServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
     }
 
@@ -792,26 +982,32 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignAsset()
     {
-        $campaignId = 111111;
-        $assetId = 3333333;
-        $fieldType = 3;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $assetId = '333333';
+        $fieldType = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignAssets/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignAssets/%s~%s~%s",
+            $customerId,
             $campaignId,
             $assetId,
-            AssetFieldType::name($fieldType)
+            $fieldType
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignAsset(self::CUSTOMER_ID, $campaignId, $assetId, $fieldType)
+            ResourceNames::forCampaignAsset(
+                $customerId,
+                $campaignId,
+                $assetId,
+                $fieldType
+            )
         );
 
         $names = CampaignAssetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($assetId, $names['asset_id']);
-        $this->assertEquals(AssetFieldType::name($fieldType), $names['field_type']);
+        $this->assertEquals($fieldType, $names['field_type']);
     }
 
     /**
@@ -819,21 +1015,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignAudienceView()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignAudienceViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignAudienceViews/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignAudienceView(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forCampaignAudienceView(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = CampaignAudienceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -843,21 +1044,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignBidModifier()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignBidModifiers/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignBidModifiers/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignBidModifier(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forCampaignBidModifier(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = CampaignBidModifierServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -867,17 +1073,24 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignBudget()
     {
-        $budgetId = 555555;
-        $expectedResourceName =
-            sprintf('customers/%s/campaignBudgets/%s', self::CUSTOMER_ID, $budgetId);
+        $customerId = '111111';
+        $campaignBudgetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/campaignBudgets/%s",
+            $customerId,
+            $campaignBudgetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignBudget(self::CUSTOMER_ID, $budgetId)
+            ResourceNames::forCampaignBudget(
+                $customerId,
+                $campaignBudgetId
+            )
         );
 
         $names = CampaignBudgetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals($budgetId, $names['campaign_budget_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($campaignBudgetId, $names['campaign_budget_id']);
     }
 
     /**
@@ -885,21 +1098,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignCriterion()
     {
-        $campaignId = 66666666;
-        $criterionId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignCriteria/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignCriteria/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignCriterion(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forCampaignCriterion(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = CampaignCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -909,15 +1127,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignCriterionSimulation()
     {
-        $campaignId = 111111;
-        $criterionId = 3333333;
-        $type = 4444444;
-        $modificationMethod = 5555555;
-        $startDate = 66666666;
-        $endDate = 7777777;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
+        $type = '444444';
+        $modificationMethod = '555555';
+        $startDate = '666666';
+        $endDate = '777777';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignCriterionSimulations/%s~%s~%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignCriterionSimulations/%s~%s~%s~%s~%s~%s",
+            $customerId,
             $campaignId,
             $criterionId,
             $type,
@@ -928,7 +1147,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignCriterionSimulation(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $criterionId,
                 $type,
@@ -939,7 +1158,7 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = CampaignCriterionSimulationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
         $this->assertEquals($type, $names['type']);
@@ -953,21 +1172,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignDraft()
     {
-        $baseCampaignId = 111111;
-        $draftId = 3333333;
+        $customerId = '111111';
+        $baseCampaignId = '222222';
+        $draftId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignDrafts/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignDrafts/%s~%s",
+            $customerId,
             $baseCampaignId,
             $draftId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignDraft(self::CUSTOMER_ID, $baseCampaignId, $draftId)
+            ResourceNames::forCampaignDraft(
+                $customerId,
+                $baseCampaignId,
+                $draftId
+            )
         );
 
         $names = CampaignDraftServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($baseCampaignId, $names['base_campaign_id']);
         $this->assertEquals($draftId, $names['draft_id']);
     }
@@ -977,19 +1201,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignExperiment()
     {
-        $campaignExperimentId = 66666666;
+        $customerId = '111111';
+        $campaignExperimentId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignExperiments/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignExperiments/%s",
+            $customerId,
             $campaignExperimentId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCampaignExperiment(self::CUSTOMER_ID, $campaignExperimentId)
+            ResourceNames::forCampaignExperiment(
+                $customerId,
+                $campaignExperimentId
+            )
         );
 
         $names = CampaignExperimentServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignExperimentId, $names['campaign_experiment_id']);
     }
 
@@ -998,27 +1226,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignExtensionSetting()
     {
-        $campaignId = 111111;
-        $extensionType = ExtensionType::SITELINK;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $extensionType = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignExtensionSettings/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignExtensionSettings/%s~%s",
+            $customerId,
             $campaignId,
-            'SITELINK'
+            $extensionType
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignExtensionSetting(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $extensionType
             )
         );
 
         $names = CampaignExtensionSettingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
-        $this->assertEquals(ExtensionType::name($extensionType), $names['extension_type']);
+        $this->assertEquals($extensionType, $names['extension_type']);
     }
 
     /**
@@ -1026,25 +1255,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignFeed()
     {
-        $campaignId = 111111;
-        $feedId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $feedId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignFeeds/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignFeeds/%s~%s",
+            $customerId,
             $campaignId,
             $feedId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignFeed(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $feedId
             )
         );
 
         $names = CampaignFeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
@@ -1054,25 +1284,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignLabel()
     {
-        $campaignId = 111111;
-        $labelId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $labelId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignLabels/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignLabels/%s~%s",
+            $customerId,
             $campaignId,
             $labelId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignLabel(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $labelId
             )
         );
 
         $names = CampaignLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
@@ -1082,25 +1313,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignSharedSet()
     {
-        $campaignId = 111111;
-        $sharedSetId = 3333333;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $sharedSetId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignSharedSets/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/campaignSharedSets/%s~%s",
+            $customerId,
             $campaignId,
             $sharedSetId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCampaignSharedSet(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $sharedSetId
             )
         );
 
         $names = CampaignSharedSetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($sharedSetId, $names['shared_set_id']);
     }
@@ -1110,14 +1342,14 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCampaignSimulation()
     {
-        $customerId = 111111;
-        $campaignId = 222222;
-        $type = 333333;
-        $modificationMethod = 444444;
-        $startDate = 555555;
-        $endDate = 666666;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $type = '333333';
+        $modificationMethod = '444444';
+        $startDate = '555555';
+        $endDate = '666666';
         $expectedResourceName = sprintf(
-            'customers/%s/campaignSimulations/%s~%s~%s~%s~%s',
+            "customers/%s/campaignSimulations/%s~%s~%s~%s~%s",
             $customerId,
             $campaignId,
             $type,
@@ -1151,11 +1383,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCarrierConstant()
     {
-        $criterionId = 3333333;
-        $expectedResourceName = sprintf('carrierConstants/%s', $criterionId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "carrierConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCarrierConstant($criterionId)
+            ResourceNames::forCarrierConstant(
+                $criterionId
+            )
         );
 
         $names = CarrierConstantServiceClient::parseName($expectedResourceName);
@@ -1167,16 +1404,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForChangeStatus()
     {
-        $changeStatusId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/changeStatus/%s', self::CUSTOMER_ID, $changeStatusId);
+        $customerId = '111111';
+        $changeStatusId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/changeStatus/%s",
+            $customerId,
+            $changeStatusId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forChangeStatus(self::CUSTOMER_ID, $changeStatusId)
+            ResourceNames::forChangeStatus(
+                $customerId,
+                $changeStatusId
+            )
         );
 
         $names = ChangeStatusServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($changeStatusId, $names['change_status_id']);
     }
 
@@ -1185,19 +1429,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForClickView()
     {
-        $date = '2019-05-29';
-        $gclId = 3333333;
-        $expectedResourceName =
-            sprintf('customers/%s/clickViews/%s~%s', self::CUSTOMER_ID, $date, $gclId);
+        $customerId = '111111';
+        $date = '222222';
+        $gclid = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/clickViews/%s~%s",
+            $customerId,
+            $date,
+            $gclid
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forClickView(self::CUSTOMER_ID, $date, $gclId)
+            ResourceNames::forClickView(
+                $customerId,
+                $date,
+                $gclid
+            )
         );
 
         $names = ClickViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($date, $names['date']);
-        $this->assertEquals($gclId, $names['gclid']);
+        $this->assertEquals($gclid, $names['gclid']);
     }
 
     /**
@@ -1205,16 +1458,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCombinedAudience()
     {
-        $combinedAudienceId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/combinedAudiences/%s', self::CUSTOMER_ID, $combinedAudienceId);
+        $customerId = '111111';
+        $combinedAudienceId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/combinedAudiences/%s",
+            $customerId,
+            $combinedAudienceId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCombinedAudience(self::CUSTOMER_ID, $combinedAudienceId)
+            ResourceNames::forCombinedAudience(
+                $customerId,
+                $combinedAudienceId
+            )
         );
 
         $names = CombinedAudienceServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($combinedAudienceId, $names['combined_audience_id']);
     }
 
@@ -1223,16 +1483,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForConversionAction()
     {
-        $conversionActionId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/conversionActions/%s', self::CUSTOMER_ID, $conversionActionId);
+        $customerId = '111111';
+        $conversionActionId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/conversionActions/%s",
+            $customerId,
+            $conversionActionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forConversionAction(self::CUSTOMER_ID, $conversionActionId)
+            ResourceNames::forConversionAction(
+                $customerId,
+                $conversionActionId
+            )
         );
 
         $names = ConversionActionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($conversionActionId, $names['conversion_action_id']);
     }
 
@@ -1241,10 +1508,10 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForConversionCustomVariable()
     {
-        $customerId = 111111;
-        $conversionCustomVariableId = 222222;
+        $customerId = '111111';
+        $conversionCustomVariableId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/conversionCustomVariables/%s',
+            "customers/%s/conversionCustomVariables/%s",
             $customerId,
             $conversionCustomVariableId
         );
@@ -1266,15 +1533,45 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCurrencyConstant()
     {
-        $usdCurrencyConstantId = 'USD';
-        $expectedResourceName = sprintf('currencyConstants/%s', $usdCurrencyConstantId);
+        $code = '111111';
+        $expectedResourceName = sprintf(
+            "currencyConstants/%s",
+            $code
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCurrencyConstant($usdCurrencyConstantId)
+            ResourceNames::forCurrencyConstant(
+                $code
+            )
         );
 
         $names = CurrencyConstantServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($usdCurrencyConstantId, $names['code']);
+        $this->assertEquals($code, $names['code']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forCustomAudience()
+     */
+    public function testGetNameForCustomAudience()
+    {
+        $customerId = '111111';
+        $customAudienceId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customAudiences/%s",
+            $customerId,
+            $customAudienceId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forCustomAudience(
+                $customerId,
+                $customAudienceId
+            )
+        );
+
+        $names = CustomAudienceServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($customAudienceId, $names['custom_audience_id']);
     }
 
     /**
@@ -1282,14 +1579,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomer()
     {
-        $expectedResourceName = sprintf('customers/%s', self::CUSTOMER_ID);
+        $customerId = '111111';
+        $expectedResourceName = sprintf(
+            "customers/%s",
+            $customerId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomer(self::CUSTOMER_ID)
+            ResourceNames::forCustomer(
+                $customerId
+            )
         );
 
         $names = CustomerServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
     }
 
     /**
@@ -1297,11 +1600,11 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerAsset()
     {
-        $customerId = 111111;
-        $assetId = 222222;
-        $fieldType = 333333;
+        $customerId = '111111';
+        $assetId = '222222';
+        $fieldType = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/customerAssets/%s~%s',
+            "customers/%s/customerAssets/%s~%s",
             $customerId,
             $assetId,
             $fieldType
@@ -1326,16 +1629,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerClient()
     {
-        $clientCustomerId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerClients/%s', self::CUSTOMER_ID, $clientCustomerId);
+        $customerId = '111111';
+        $clientCustomerId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerClients/%s",
+            $customerId,
+            $clientCustomerId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerClient(self::CUSTOMER_ID, $clientCustomerId)
+            ResourceNames::forCustomerClient(
+                $customerId,
+                $clientCustomerId
+            )
         );
 
         $names = CustomerClientServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($clientCustomerId, $names['client_customer_id']);
     }
 
@@ -1344,25 +1654,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerClientLink()
     {
-        $clientCustomerId = 111111;
-        $managerLinkId = 3333333;
+        $customerId = '111111';
+        $clientCustomerId = '222222';
+        $managerLinkId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/customerClientLinks/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/customerClientLinks/%s~%s",
+            $customerId,
             $clientCustomerId,
             $managerLinkId
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forCustomerClientLink(
-                self::CUSTOMER_ID,
+                $customerId,
                 $clientCustomerId,
                 $managerLinkId
             )
         );
 
         $names = CustomerClientLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($clientCustomerId, $names['client_customer_id']);
         $this->assertEquals($managerLinkId, $names['manager_link_id']);
     }
@@ -1372,20 +1683,24 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerExtensionSetting()
     {
-        $extensionType = ExtensionType::SITELINK;
+        $customerId = '111111';
+        $extensionType = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/customerExtensionSettings/%s',
-            self::CUSTOMER_ID,
-            'SITELINK'
+            "customers/%s/customerExtensionSettings/%s",
+            $customerId,
+            $extensionType
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerExtensionSetting(self::CUSTOMER_ID, $extensionType)
+            ResourceNames::forCustomerExtensionSetting(
+                $customerId,
+                $extensionType
+            )
         );
 
         $names = CustomerExtensionSettingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals(ExtensionType::name($extensionType), $names['extension_type']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($extensionType, $names['extension_type']);
     }
 
     /**
@@ -1393,16 +1708,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerFeed()
     {
-        $feedId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerFeeds/%s', self::CUSTOMER_ID, $feedId);
+        $customerId = '111111';
+        $feedId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerFeeds/%s",
+            $customerId,
+            $feedId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerFeed(self::CUSTOMER_ID, $feedId)
+            ResourceNames::forCustomerFeed(
+                $customerId,
+                $feedId
+            )
         );
 
         $names = CustomerFeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
 
@@ -1411,16 +1733,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerLabel()
     {
-        $labelId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerLabels/%s', self::CUSTOMER_ID, $labelId);
+        $customerId = '111111';
+        $labelId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerLabels/%s",
+            $customerId,
+            $labelId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerLabel(self::CUSTOMER_ID, $labelId)
+            ResourceNames::forCustomerLabel(
+                $customerId,
+                $labelId
+            )
         );
 
         $names = CustomerLabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
 
@@ -1429,22 +1758,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerManagerLink()
     {
-        $managerCustomerId = 111111;
-        $managerLinkId = 222222;
+        $customerId = '111111';
+        $managerCustomerId = '222222';
+        $managerLinkId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/customerManagerLinks/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/customerManagerLinks/%s~%s",
+            $customerId,
             $managerCustomerId,
             $managerLinkId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forCustomerManagerLink(
-            self::CUSTOMER_ID,
-            $managerCustomerId,
-            $managerLinkId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forCustomerManagerLink(
+                $customerId,
+                $managerCustomerId,
+                $managerLinkId
+            )
+        );
 
         $names = CustomerManagerLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($managerCustomerId, $names['manager_customer_id']);
         $this->assertEquals($managerLinkId, $names['manager_link_id']);
     }
@@ -1454,16 +1787,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerNegativeCriterion()
     {
-        $criterionId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customerNegativeCriteria/%s', self::CUSTOMER_ID, $criterionId);
+        $customerId = '111111';
+        $criterionId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerNegativeCriteria/%s",
+            $customerId,
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerNegativeCriterion(self::CUSTOMER_ID, $criterionId)
+            ResourceNames::forCustomerNegativeCriterion(
+                $customerId,
+                $criterionId
+            )
         );
 
         $names = CustomerNegativeCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
@@ -1472,16 +1812,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerUserAccess()
     {
-        $userId = 1111111;
-        $expectedResourceName =
-            sprintf('customers/%s/customerUserAccesses/%s', self::CUSTOMER_ID, $userId);
+        $customerId = '111111';
+        $userId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customerUserAccesses/%s",
+            $customerId,
+            $userId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerUserAccess(self::CUSTOMER_ID, $userId)
+            ResourceNames::forCustomerUserAccess(
+                $customerId,
+                $userId
+            )
         );
 
         $names = CustomerUserAccessServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($userId, $names['user_id']);
     }
 
@@ -1490,19 +1837,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomerUserAccessInvitation()
     {
-        $invitationId = 1111111;
+        $customerId = '111111';
+        $invitationId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/customerUserAccessInvitations/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/customerUserAccessInvitations/%s",
+            $customerId,
             $invitationId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomerUserAccessInvitation(self::CUSTOMER_ID, $invitationId)
+            ResourceNames::forCustomerUserAccessInvitation(
+                $customerId,
+                $invitationId
+            )
         );
 
         $names = CustomerUserAccessInvitationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($invitationId, $names['invitation_id']);
     }
 
@@ -1511,16 +1862,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForCustomInterest()
     {
-        $customInterestId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/customInterests/%s', self::CUSTOMER_ID, $customInterestId);
+        $customerId = '111111';
+        $customInterestId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/customInterests/%s",
+            $customerId,
+            $customInterestId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forCustomInterest(self::CUSTOMER_ID, $customInterestId)
+            ResourceNames::forCustomInterest(
+                $customerId,
+                $customInterestId
+            )
         );
 
         $names = CustomInterestServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($customInterestId, $names['custom_interest_id']);
     }
 
@@ -1529,24 +1887,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForDetailPlacementView()
     {
-        $adGroupId = 111111;
-        $placement = 'base64';
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $base64Placement = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/detailPlacementViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/detailPlacementViews/%s~%s",
+            $customerId,
             $adGroupId,
-            $placement
+            $base64Placement
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forDetailPlacementView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $placement
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDetailPlacementView(
+                $customerId,
+                $adGroupId,
+                $base64Placement
+            )
+        );
 
         $names = DetailPlacementViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($placement, $names['base64_placement']);
+        $this->assertEquals($base64Placement, $names['base64_placement']);
     }
 
     /**
@@ -1554,24 +1916,57 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForDisplayKeywordView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/displayKeywordViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/displayKeywordViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forDisplayKeywordView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDisplayKeywordView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = DisplayKeywordViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forDistanceView()
+     */
+    public function testGetNameForDistanceView()
+    {
+        $customerId = '111111';
+        $placeholderChainId = '222222';
+        $distanceBucket = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/distanceViews/%s~%s",
+            $customerId,
+            $placeholderChainId,
+            $distanceBucket
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDistanceView(
+                $customerId,
+                $placeholderChainId,
+                $distanceBucket
+            )
+        );
+
+        $names = DistanceViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($placeholderChainId, $names['placeholder_chain_id']);
+        $this->assertEquals($distanceBucket, $names['distance_bucket']);
     }
 
     /**
@@ -1579,31 +1974,73 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForDomainCategory()
     {
-        $campaignId = 111111;
-        $category = 'category';
-        $languageCode = 'en';
+        $customerId = '111111';
+        $campaignId = '222222';
+        $base64Category = '333333';
+        $languageCode = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/domainCategories/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/domainCategories/%s~%s~%s",
+            $customerId,
             $campaignId,
-            $category,
+            $base64Category,
             $languageCode
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forDomainCategory(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
-                $category,
+                $base64Category,
                 $languageCode
             )
         );
 
         $names = DomainCategoryServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
-        $this->assertEquals($category, $names['base64_category']);
+        $this->assertEquals($base64Category, $names['base64_category']);
         $this->assertEquals($languageCode, $names['language_code']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forDynamicSearchAdsSearchTermView()
+     */
+    public function testGetNameForDynamicSearchAdsSearchTermView()
+    {
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $searchTermFingerprint = '333333';
+        $headlineFingerprint = '444444';
+        $landingPageFingerprint = '555555';
+        $pageUrlFingerprint = '666666';
+        $expectedResourceName = sprintf(
+            "customers/%s/dynamicSearchAdsSearchTermViews/%s~%s~%s~%s~%s",
+            $customerId,
+            $adGroupId,
+            $searchTermFingerprint,
+            $headlineFingerprint,
+            $landingPageFingerprint,
+            $pageUrlFingerprint
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forDynamicSearchAdsSearchTermView(
+                $customerId,
+                $adGroupId,
+                $searchTermFingerprint,
+                $headlineFingerprint,
+                $landingPageFingerprint,
+                $pageUrlFingerprint
+            )
+        );
+
+        $names = DynamicSearchAdsSearchTermViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adGroupId, $names['ad_group_id']);
+        $this->assertEquals($searchTermFingerprint, $names['search_term_fingerprint']);
+        $this->assertEquals($headlineFingerprint, $names['headline_fingerprint']);
+        $this->assertEquals($landingPageFingerprint, $names['landing_page_fingerprint']);
+        $this->assertEquals($pageUrlFingerprint, $names['page_url_fingerprint']);
     }
 
     /**
@@ -1611,22 +2048,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForExpandedLandingPageView()
     {
-        $expandedFinalUrlFingerprint = 'url';
+        $customerId = '111111';
+        $expandedFinalUrlFingerprint = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/expandedLandingPageViews/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/expandedLandingPageViews/%s",
+            $customerId,
             $expandedFinalUrlFingerprint
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forExpandedLandingPageView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $expandedFinalUrlFingerprint
             )
         );
 
         $names = ExpandedLandingPageViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($expandedFinalUrlFingerprint, $names['expanded_final_url_fingerprint']);
     }
 
@@ -1635,16 +2073,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForExtensionFeedItem()
     {
-        $feedItemId = 66666666;
-        $expectedResourceName =
-            sprintf('customers/%s/extensionFeedItems/%s', self::CUSTOMER_ID, $feedItemId);
+        $customerId = '111111';
+        $feedItemId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/extensionFeedItems/%s",
+            $customerId,
+            $feedItemId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forExtensionFeedItem(self::CUSTOMER_ID, $feedItemId)
+            ResourceNames::forExtensionFeedItem(
+                $customerId,
+                $feedItemId
+            )
         );
 
         $names = ExtensionFeedItemServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
     }
 
@@ -1653,15 +2098,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeed()
     {
-        $feedId = 66666666;
-        $expectedResourceName = sprintf('customers/%s/feeds/%s', self::CUSTOMER_ID, $feedId);
+        $customerId = '111111';
+        $feedId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/feeds/%s",
+            $customerId,
+            $feedId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forFeed(self::CUSTOMER_ID, $feedId)
+            ResourceNames::forFeed(
+                $customerId,
+                $feedId
+            )
         );
 
         $names = FeedServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
     }
 
@@ -1670,22 +2123,27 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItem()
     {
-        $feedId = 111111;
-        $feedItemId = 222222;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItems/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItems/%s~%s",
+            $customerId,
             $feedId,
             $feedItemId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedItem(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedItemId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedItem(
+                $customerId,
+                $feedId,
+                $feedItemId
+            )
+        );
 
         $names = FeedItemServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
     }
 
@@ -1694,22 +2152,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItemSet()
     {
-        $feedId = 111111;
-        $feedItemSetId = 222222;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemSetId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItemSets/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItemSets/%s~%s",
+            $customerId,
             $feedId,
             $feedItemSetId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedItemSet(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedItemSetId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedItemSet(
+                $customerId,
+                $feedId,
+                $feedItemSetId
+            )
+        );
 
         $names = FeedItemSetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemSetId, $names['feed_item_set_id']);
     }
@@ -1719,25 +2181,29 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItemSetLink()
     {
-        $feedId = 111111;
-        $feedItemId = 222222;
-        $feedItemSetId = 333333;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemSetId = '333333';
+        $feedItemId = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItemSetLinks/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItemSetLinks/%s~%s~%s",
+            $customerId,
             $feedId,
             $feedItemSetId,
             $feedItemId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedItemSetLink(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedItemSetId,
-            $feedItemId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedItemSetLink(
+                $customerId,
+                $feedId,
+                $feedItemSetId,
+                $feedItemId
+            )
+        );
 
         $names = FeedItemSetLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemSetId, $names['feed_item_set_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
@@ -1748,13 +2214,14 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedItemTarget()
     {
-        $feedId = 3333333;
-        $feedItemId = 4444444;
-        $feedItemTargetType = 5555555;
-        $feedItemTargetId = 66666666;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedItemId = '333333';
+        $feedItemTargetType = '444444';
+        $feedItemTargetId = '555555';
         $expectedResourceName = sprintf(
-            'customers/%s/feedItemTargets/%s~%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedItemTargets/%s~%s~%s~%s",
+            $customerId,
             $feedId,
             $feedItemId,
             $feedItemTargetType,
@@ -1763,7 +2230,7 @@ class ResourceNamesTest extends TestCase
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forFeedItemTarget(
-                self::CUSTOMER_ID,
+                $customerId,
                 $feedId,
                 $feedItemId,
                 $feedItemTargetType,
@@ -1772,7 +2239,8 @@ class ResourceNamesTest extends TestCase
         );
 
         $names = FeedItemTargetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedItemId, $names['feed_item_id']);
         $this->assertEquals($feedItemTargetType, $names['feed_item_target_type']);
         $this->assertEquals($feedItemTargetId, $names['feed_item_target_id']);
@@ -1783,22 +2251,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedMapping()
     {
-        $feedId = 111111;
-        $feedMappingId = 222222;
+        $customerId = '111111';
+        $feedId = '222222';
+        $feedMappingId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/feedMappings/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedMappings/%s~%s",
+            $customerId,
             $feedId,
             $feedMappingId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedMapping(
-            self::CUSTOMER_ID,
-            $feedId,
-            $feedMappingId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedMapping(
+                $customerId,
+                $feedId,
+                $feedMappingId
+            )
+        );
 
         $names = FeedMappingServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($feedId, $names['feed_id']);
         $this->assertEquals($feedMappingId, $names['feed_mapping_id']);
     }
@@ -1808,19 +2280,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForFeedPlaceholderView()
     {
-        $placeholderType = PlaceholderType::AD_CUSTOMIZER;
+        $customerId = '111111';
+        $placeholderType = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/feedPlaceholderViews/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/feedPlaceholderViews/%s",
+            $customerId,
             $placeholderType
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forFeedPlaceholderView(
-            self::CUSTOMER_ID,
-            $placeholderType
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forFeedPlaceholderView(
+                $customerId,
+                $placeholderType
+            )
+        );
 
         $names = FeedPlaceholderViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($placeholderType, $names['placeholder_type']);
     }
 
@@ -1829,22 +2305,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGenderView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/genderViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/genderViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forGenderView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forGenderView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = GenderViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -1854,22 +2334,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGeographicView()
     {
-        $countryCriterionId = 111111;
-        $locationType = 222222;
+        $customerId = '111111';
+        $countryCriterionId = '222222';
+        $locationType = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/geographicViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/geographicViews/%s~%s",
+            $customerId,
             $countryCriterionId,
             $locationType
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forGeographicView(
-            self::CUSTOMER_ID,
-            $countryCriterionId,
-            $locationType
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forGeographicView(
+                $customerId,
+                $countryCriterionId,
+                $locationType
+            )
+        );
 
         $names = GeographicViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($countryCriterionId, $names['country_criterion_id']);
         $this->assertEquals($locationType, $names['location_type']);
     }
@@ -1879,15 +2363,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGeoTargetConstant()
     {
-        $japanTargetConstantId = 2392;
-        $expectedResourceName = sprintf('geoTargetConstants/%s', $japanTargetConstantId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "geoTargetConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forGeoTargetConstant($japanTargetConstantId)
+            ResourceNames::forGeoTargetConstant(
+                $criterionId
+            )
         );
 
         $names = GeoTargetConstantServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($japanTargetConstantId, $names['criterion_id']);
+        $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
     /**
@@ -1895,15 +2384,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGoogleAdsField()
     {
-        $field = 'field';
-        $expectedResourceName = sprintf('googleAdsFields/%s', $field);
+        $googleAdsField = '111111';
+        $expectedResourceName = sprintf(
+            "googleAdsFields/%s",
+            $googleAdsField
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forGoogleAdsField($field)
+            ResourceNames::forGoogleAdsField(
+                $googleAdsField
+            )
         );
 
         $names = GoogleAdsFieldServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($field, $names['google_ads_field']);
+        $this->assertEquals($googleAdsField, $names['google_ads_field']);
     }
 
     /**
@@ -1911,24 +2405,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForGroupPlacementView()
     {
-        $adGroupId = 111111;
-        $placement = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $base64Placement = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/groupPlacementViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/groupPlacementViews/%s~%s",
+            $customerId,
             $adGroupId,
-            $placement
+            $base64Placement
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forGroupPlacementView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $placement
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forGroupPlacementView(
+                $customerId,
+                $adGroupId,
+                $base64Placement
+            )
+        );
 
         $names = GroupPlacementViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($placement, $names['base64_placement']);
+        $this->assertEquals($base64Placement, $names['base64_placement']);
     }
 
     /**
@@ -1936,22 +2434,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForHotelGroupView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/hotelGroupViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/hotelGroupViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forHotelGroupView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forHotelGroupView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = HotelGroupViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -1961,16 +2463,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForHotelPerformanceView()
     {
+        $customerId = '111111';
         $expectedResourceName = sprintf(
-            'customers/%s/hotelPerformanceView',
-            self::CUSTOMER_ID
+            "customers/%s/hotelPerformanceView",
+            $customerId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forHotelPerformanceView(
-            self::CUSTOMER_ID
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forHotelPerformanceView(
+                $customerId
+            )
+        );
 
         $names = HotelPerformanceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
     }
 
     /**
@@ -1978,21 +2484,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForIncomeRangeView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/incomeRangeViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/incomeRangeViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forIncomeRangeView(self::CUSTOMER_ID, $adGroupId, $criterionId)
+            ResourceNames::forIncomeRangeView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
         );
 
         $names = IncomeRangeViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2002,20 +2513,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlan()
     {
-        $keywordPlanId = 222222;
+        $customerId = '111111';
+        $keywordPlanId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlans/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlans/%s",
+            $customerId,
             $keywordPlanId
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forKeywordPlan(self::CUSTOMER_ID, $keywordPlanId)
+            ResourceNames::forKeywordPlan(
+                $customerId,
+                $keywordPlanId
+            )
         );
 
         $names = KeywordPlanServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanId, $names['keyword_plan_id']);
     }
 
@@ -2024,20 +2538,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanAdGroup()
     {
-        $keywordPlanAdGroupId = 222222;
+        $customerId = '111111';
+        $keywordPlanAdGroupId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanAdGroups/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanAdGroups/%s",
+            $customerId,
             $keywordPlanAdGroupId
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forKeywordPlanAdGroup(self::CUSTOMER_ID, $keywordPlanAdGroupId)
+            ResourceNames::forKeywordPlanAdGroup(
+                $customerId,
+                $keywordPlanAdGroupId
+            )
         );
 
         $names = KeywordPlanAdGroupServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanAdGroupId, $names['keyword_plan_ad_group_id']);
     }
 
@@ -2046,23 +2563,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanAdGroupKeyword()
     {
-        $keywordPlanAdGroupKeywordId = 222222;
+        $customerId = '111111';
+        $keywordPlanAdGroupKeywordId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanAdGroupKeywords/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanAdGroupKeywords/%s",
+            $customerId,
             $keywordPlanAdGroupKeywordId
         );
-
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forKeywordPlanAdGroupKeyword(
-                self::CUSTOMER_ID,
+                $customerId,
                 $keywordPlanAdGroupKeywordId
             )
         );
 
         $names = KeywordPlanAdGroupKeywordServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanAdGroupKeywordId, $names['keyword_plan_ad_group_keyword_id']);
     }
 
@@ -2071,20 +2588,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanCampaign()
     {
-        $keywordPlanCampaignId = 222222;
+        $customerId = '111111';
+        $keywordPlanCampaignId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanCampaigns/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanCampaigns/%s",
+            $customerId,
             $keywordPlanCampaignId
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forKeywordPlanCampaign(self::CUSTOMER_ID, $keywordPlanCampaignId)
+            ResourceNames::forKeywordPlanCampaign(
+                $customerId,
+                $keywordPlanCampaignId
+            )
         );
 
         $names = KeywordPlanCampaignServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanCampaignId, $names['keyword_plan_campaign_id']);
     }
 
@@ -2093,24 +2613,53 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForKeywordPlanCampaignKeyword()
     {
-        $keywordPlanCampaignKeywordId = 222222;
+        $customerId = '111111';
+        $keywordPlanCampaignKeywordId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/keywordPlanCampaignKeywords/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/keywordPlanCampaignKeywords/%s",
+            $customerId,
             $keywordPlanCampaignKeywordId
         );
-
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forKeywordPlanCampaignKeyword(
-                self::CUSTOMER_ID,
+                $customerId,
                 $keywordPlanCampaignKeywordId
             )
         );
 
         $names = KeywordPlanCampaignKeywordServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($keywordPlanCampaignKeywordId, $names['keyword_plan_campaign_keyword_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forKeywordView()
+     */
+    public function testGetNameForKeywordView()
+    {
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/keywordViews/%s~%s",
+            $customerId,
+            $adGroupId,
+            $criterionId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forKeywordView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
+
+        $names = KeywordViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adGroupId, $names['ad_group_id']);
+        $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
     /**
@@ -2118,15 +2667,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLabel()
     {
-        $labelId = 938;
-        $expectedResourceName = sprintf('customers/%s/labels/%s', self::CUSTOMER_ID, $labelId);
+        $customerId = '111111';
+        $labelId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/labels/%s",
+            $customerId,
+            $labelId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLabel(self::CUSTOMER_ID, $labelId)
+            ResourceNames::forLabel(
+                $customerId,
+                $labelId
+            )
         );
 
         $names = LabelServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($labelId, $names['label_id']);
     }
 
@@ -2135,24 +2692,24 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLandingPageView()
     {
-        $unexpandedFinalUrlFingerprint = 'url';
+        $customerId = '111111';
+        $unexpandedFinalUrlFingerprint = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/landingPageViews/%s',
-            self::CUSTOMER_ID,
+            "customers/%s/landingPageViews/%s",
+            $customerId,
             $unexpandedFinalUrlFingerprint
         );
-
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLandingPageView(self::CUSTOMER_ID, $unexpandedFinalUrlFingerprint)
+            ResourceNames::forLandingPageView(
+                $customerId,
+                $unexpandedFinalUrlFingerprint
+            )
         );
 
         $names = LandingPageViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals(
-            $unexpandedFinalUrlFingerprint,
-            $names['unexpanded_final_url_fingerprint']
-        );
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($unexpandedFinalUrlFingerprint, $names['unexpanded_final_url_fingerprint']);
     }
 
     /**
@@ -2160,15 +2717,20 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLanguageConstant()
     {
-        $englishLanguageId = 1000;
-        $expectedResourceName = sprintf('languageConstants/%s', $englishLanguageId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "languageConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLanguageConstant($englishLanguageId)
+            ResourceNames::forLanguageConstant(
+                $criterionId
+            )
         );
 
         $names = LanguageConstantServiceClient::parseName($expectedResourceName);
-        $this->assertEquals($englishLanguageId, $names['criterion_id']);
+        $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
     /**
@@ -2176,10 +2738,10 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLifeEvent()
     {
-        $customerId = 111111;
-        $lifeEventId = 222222;
+        $customerId = '111111';
+        $lifeEventId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/lifeEvents/%s',
+            "customers/%s/lifeEvents/%s",
             $customerId,
             $lifeEventId
         );
@@ -2201,21 +2763,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForLocationView()
     {
-        $campaignId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $campaignId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/locationViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/locationViews/%s~%s",
+            $customerId,
             $campaignId,
             $criterionId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forLocationView(self::CUSTOMER_ID, $campaignId, $criterionId)
+            ResourceNames::forLocationView(
+                $customerId,
+                $campaignId,
+                $criterionId
+            )
         );
 
         $names = LocationViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2225,22 +2792,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForManagedPlacementView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/managedPlacementViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/managedPlacementViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forManagedPlacementView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forManagedPlacementView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = ManagedPlacementViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2250,16 +2821,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMediaFile()
     {
-        $mediaFileId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/mediaFiles/%s', self::CUSTOMER_ID, $mediaFileId);
+        $customerId = '111111';
+        $mediaFileId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/mediaFiles/%s",
+            $customerId,
+            $mediaFileId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMediaFile(self::CUSTOMER_ID, $mediaFileId)
+            ResourceNames::forMediaFile(
+                $customerId,
+                $mediaFileId
+            )
         );
 
         $names = MediaFileServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($mediaFileId, $names['media_file_id']);
     }
 
@@ -2268,16 +2846,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMerchantCenterLink()
     {
-        $merchantCenterId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/merchantCenterLinks/%s', self::CUSTOMER_ID, $merchantCenterId);
+        $customerId = '111111';
+        $merchantCenterId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/merchantCenterLinks/%s",
+            $customerId,
+            $merchantCenterId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMerchantCenterLink(self::CUSTOMER_ID, $merchantCenterId)
+            ResourceNames::forMerchantCenterLink(
+                $customerId,
+                $merchantCenterId
+            )
         );
 
         $names = MerchantCenterLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($merchantCenterId, $names['merchant_center_id']);
     }
 
@@ -2286,11 +2871,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMobileAppCategoryConstant()
     {
-        $mobileAppCategoryId = 1000;
-        $expectedResourceName = sprintf('mobileAppCategoryConstants/%s', $mobileAppCategoryId);
+        $mobileAppCategoryId = '111111';
+        $expectedResourceName = sprintf(
+            "mobileAppCategoryConstants/%s",
+            $mobileAppCategoryId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMobileAppCategoryConstant($mobileAppCategoryId)
+            ResourceNames::forMobileAppCategoryConstant(
+                $mobileAppCategoryId
+            )
         );
 
         $names = MobileAppCategoryConstantServiceClient::parseName($expectedResourceName);
@@ -2302,11 +2892,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForMobileDeviceConstant()
     {
-        $criterionId = 1000;
-        $expectedResourceName = sprintf('mobileDeviceConstants/%s', $criterionId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "mobileDeviceConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forMobileDeviceConstant($criterionId)
+            ResourceNames::forMobileDeviceConstant(
+                $criterionId
+            )
         );
 
         $names = MobileDeviceConstantServiceClient::parseName($expectedResourceName);
@@ -2314,15 +2909,45 @@ class ResourceNamesTest extends TestCase
     }
 
     /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forOfflineUserDataJob()
+     */
+    public function testGetNameForOfflineUserDataJob()
+    {
+        $customerId = '111111';
+        $offlineUserDataUpdateId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/offlineUserDataJobs/%s",
+            $customerId,
+            $offlineUserDataUpdateId
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forOfflineUserDataJob(
+                $customerId,
+                $offlineUserDataUpdateId
+            )
+        );
+
+        $names = OfflineUserDataJobServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($offlineUserDataUpdateId, $names['offline_user_data_update_id']);
+    }
+
+    /**
      * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forOperatingSystemVersionConstant()
      */
     public function testGetNameForOperatingSystemVersionConstant()
     {
-        $criterionId = 1000;
-        $expectedResourceName = sprintf('operatingSystemVersionConstants/%s', $criterionId);
+        $criterionId = '111111';
+        $expectedResourceName = sprintf(
+            "operatingSystemVersionConstants/%s",
+            $criterionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forOperatingSystemVersionConstant($criterionId)
+            ResourceNames::forOperatingSystemVersionConstant(
+                $criterionId
+            )
         );
 
         $names = OperatingSystemVersionConstantServiceClient::parseName($expectedResourceName);
@@ -2334,31 +2959,32 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForPaidOrganicSearchTermView()
     {
-        $campaignId = 111111;
-        $adGroupId = 222222;
-        $searchTerm = 'base64';
+        $customerId = '111111';
+        $campaignId = '222222';
+        $adGroupId = '333333';
+        $base64SearchTerm = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/paidOrganicSearchTermViews/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/paidOrganicSearchTermViews/%s~%s~%s",
+            $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $base64SearchTerm
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forPaidOrganicSearchTermView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $adGroupId,
-                $searchTerm
+                $base64SearchTerm
             )
         );
 
         $names = PaidOrganicSearchTermViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($searchTerm, $names['base64_search_term']);
+        $this->assertEquals($base64SearchTerm, $names['base64_search_term']);
     }
 
     /**
@@ -2366,41 +2992,28 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForParentalStatusView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/parentalStatusViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/parentalStatusViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forParentalStatusView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forParentalStatusView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = ParentalStatusViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
-    }
-
-    /**
-     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forPaymentsAccount()
-     */
-    public function testGetNameForPaymentsAccount()
-    {
-        $paymentsAccountId = '1111-2222-3333-4444';
-        $expectedResourceName = sprintf(
-            'customers/%s/paymentsAccounts/%s',
-            self::CUSTOMER_ID,
-            $paymentsAccountId
-        );
-        $this->assertEquals($expectedResourceName, ResourceNames::forPaymentsAccount(
-            self::CUSTOMER_ID,
-            $paymentsAccountId
-        ));
     }
 
     /**
@@ -2408,11 +3021,11 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForProductBiddingCategoryConstant()
     {
-        $countryCode = 'US';
-        $level = 222222;
-        $id = 3333333;
+        $countryCode = '111111';
+        $level = '222222';
+        $id = '333333';
         $expectedResourceName = sprintf(
-            'productBiddingCategoryConstants/%s~%s~%s',
+            "productBiddingCategoryConstants/%s~%s~%s",
             $countryCode,
             $level,
             $id
@@ -2437,23 +3050,27 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForProductGroupView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adgroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/productGroupViews/%s~%s',
-            self::CUSTOMER_ID,
-            $adGroupId,
+            "customers/%s/productGroupViews/%s~%s",
+            $customerId,
+            $adgroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forProductGroupView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forProductGroupView(
+                $customerId,
+                $adgroupId,
+                $criterionId
+            )
+        );
 
         $names = ProductGroupViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals($adGroupId, $names['adgroup_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($adgroupId, $names['adgroup_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
 
@@ -2462,16 +3079,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForRecommendation()
     {
-        $recommendationId = 'a1b2c3d4';
-        $expectedResourceName =
-            sprintf('customers/%s/recommendations/%s', self::CUSTOMER_ID, $recommendationId);
+        $customerId = '111111';
+        $recommendationId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/recommendations/%s",
+            $customerId,
+            $recommendationId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forRecommendation(self::CUSTOMER_ID, $recommendationId)
+            ResourceNames::forRecommendation(
+                $customerId,
+                $recommendationId
+            )
         );
 
         $names = RecommendationServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($recommendationId, $names['recommendation_id']);
     }
 
@@ -2480,16 +3104,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForRemarketingAction()
     {
-        $remarketingActionId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/remarketingActions/%s', self::CUSTOMER_ID, $remarketingActionId);
+        $customerId = '111111';
+        $remarketingActionId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/remarketingActions/%s",
+            $customerId,
+            $remarketingActionId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forRemarketingAction(self::CUSTOMER_ID, $remarketingActionId)
+            ResourceNames::forRemarketingAction(
+                $customerId,
+                $remarketingActionId
+            )
         );
 
         $names = RemarketingActionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($remarketingActionId, $names['remarketing_action_id']);
     }
 
@@ -2498,31 +3129,32 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForSearchTermView()
     {
-        $campaignId = 111111;
-        $adGroupId = 222222;
-        $searchTerm = 'base64';
+        $customerId = '111111';
+        $campaignId = '222222';
+        $adGroupId = '333333';
+        $query = '444444';
         $expectedResourceName = sprintf(
-            'customers/%s/searchTermViews/%s~%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/searchTermViews/%s~%s~%s",
+            $customerId,
             $campaignId,
             $adGroupId,
-            $searchTerm
+            $query
         );
         $this->assertEquals(
             $expectedResourceName,
             ResourceNames::forSearchTermView(
-                self::CUSTOMER_ID,
+                $customerId,
                 $campaignId,
                 $adGroupId,
-                $searchTerm
+                $query
             )
         );
 
         $names = SearchTermViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($campaignId, $names['campaign_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
-        $this->assertEquals($searchTerm, $names['query']);
+        $this->assertEquals($query, $names['query']);
     }
 
     /**
@@ -2530,22 +3162,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForSharedCriterion()
     {
-        $sharedSetId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $sharedSetId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/sharedCriteria/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/sharedCriteria/%s~%s",
+            $customerId,
             $sharedSetId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forSharedCriterion(
-            self::CUSTOMER_ID,
-            $sharedSetId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forSharedCriterion(
+                $customerId,
+                $sharedSetId,
+                $criterionId
+            )
+        );
 
         $names = SharedCriterionServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($sharedSetId, $names['shared_set_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2555,16 +3191,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForSharedSet()
     {
-        $sharedSetId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/sharedSets/%s', self::CUSTOMER_ID, $sharedSetId);
+        $customerId = '111111';
+        $sharedSetId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/sharedSets/%s",
+            $customerId,
+            $sharedSetId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forSharedSet(self::CUSTOMER_ID, $sharedSetId)
+            ResourceNames::forSharedSet(
+                $customerId,
+                $sharedSetId
+            )
         );
 
         $names = SharedSetServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($sharedSetId, $names['shared_set_id']);
     }
 
@@ -2573,42 +3216,45 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForShoppingPerformanceView()
     {
-        $expectedResourceName =
-            sprintf('customers/%s/shoppingPerformanceView', self::CUSTOMER_ID);
+        $customerId = '111111';
+        $expectedResourceName = sprintf(
+            "customers/%s/shoppingPerformanceView",
+            $customerId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forShoppingPerformanceView(self::CUSTOMER_ID)
+            ResourceNames::forShoppingPerformanceView(
+                $customerId
+            )
         );
 
         $names = ShoppingPerformanceViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
     }
 
     /**
-     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forThirdPartyAppAnalyticsLinkName()
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forThirdPartyAppAnalyticsLink()
      */
     public function testGetNameForThirdPartyAppAnalyticsLink()
     {
-        $thirdPartyAppAnalyticsLinkId = 222222;
+        $customerId = '111111';
+        $customerLinkId = '222222';
         $expectedResourceName = sprintf(
-            'customers/%s/thirdPartyAppAnalyticsLinks/%s',
-            self::CUSTOMER_ID,
-            $thirdPartyAppAnalyticsLinkId
+            "customers/%s/thirdPartyAppAnalyticsLinks/%s",
+            $customerId,
+            $customerLinkId
         );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forThirdPartyAppAnalyticsLinkName(
-                self::CUSTOMER_ID,
-                $thirdPartyAppAnalyticsLinkId
+            ResourceNames::forThirdPartyAppAnalyticsLink(
+                $customerId,
+                $customerLinkId
             )
         );
 
         $names = ThirdPartyAppAnalyticsLinkServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
-        $this->assertEquals(
-            $thirdPartyAppAnalyticsLinkId,
-            $names['customer_link_id']
-        );
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($customerLinkId, $names['customer_link_id']);
     }
 
     /**
@@ -2616,12 +3262,16 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForTopicConstant()
     {
-        $topicId = 222222;
-        $expectedResourceName =
-            sprintf('topicConstants/%s', $topicId);
+        $topicId = '111111';
+        $expectedResourceName = sprintf(
+            "topicConstants/%s",
+            $topicId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forTopicConstant($topicId)
+            ResourceNames::forTopicConstant(
+                $topicId
+            )
         );
 
         $names = TopicConstantServiceClient::parseName($expectedResourceName);
@@ -2633,22 +3283,26 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForTopicView()
     {
-        $adGroupId = 111111;
-        $criterionId = 222222;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/topicViews/%s~%s',
-            self::CUSTOMER_ID,
+            "customers/%s/topicViews/%s~%s",
+            $customerId,
             $adGroupId,
             $criterionId
         );
-        $this->assertEquals($expectedResourceName, ResourceNames::forTopicView(
-            self::CUSTOMER_ID,
-            $adGroupId,
-            $criterionId
-        ));
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forTopicView(
+                $customerId,
+                $adGroupId,
+                $criterionId
+            )
+        );
 
         $names = TopicViewServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($adGroupId, $names['ad_group_id']);
         $this->assertEquals($criterionId, $names['criterion_id']);
     }
@@ -2658,16 +3312,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForUserInterest()
     {
-        $userInterestId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/userInterests/%s', self::CUSTOMER_ID, $userInterestId);
+        $customerId = '111111';
+        $userInterestId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/userInterests/%s",
+            $customerId,
+            $userInterestId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forUserInterest(self::CUSTOMER_ID, $userInterestId)
+            ResourceNames::forUserInterest(
+                $customerId,
+                $userInterestId
+            )
         );
 
         $names = UserInterestServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($userInterestId, $names['user_interest_id']);
     }
 
@@ -2676,17 +3337,53 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForUserList()
     {
-        $userListId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/userLists/%s', self::CUSTOMER_ID, $userListId);
+        $customerId = '111111';
+        $userListId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/userLists/%s",
+            $customerId,
+            $userListId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forUserList(self::CUSTOMER_ID, $userListId)
+            ResourceNames::forUserList(
+                $customerId,
+                $userListId
+            )
         );
 
         $names = UserListServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($userListId, $names['user_list_id']);
+    }
+
+    /**
+     * @covers \Google\Ads\GoogleAds\Util\V7\ResourceNames::forUserLocationView()
+     */
+    public function testGetNameForUserLocationView()
+    {
+        $customerId = '111111';
+        $countryCriterionId = '222222';
+        $isTargetingLocation = '333333';
+        $expectedResourceName = sprintf(
+            "customers/%s/userLocationViews/%s~%s",
+            $customerId,
+            $countryCriterionId,
+            $isTargetingLocation
+        );
+        $this->assertEquals(
+            $expectedResourceName,
+            ResourceNames::forUserLocationView(
+                $customerId,
+                $countryCriterionId,
+                $isTargetingLocation
+            )
+        );
+
+        $names = UserLocationViewServiceClient::parseName($expectedResourceName);
+        $this->assertEquals($customerId, $names['customer_id']);
+        $this->assertEquals($countryCriterionId, $names['country_criterion_id']);
+        $this->assertEquals($isTargetingLocation, $names['is_targeting_location']);
     }
 
     /**
@@ -2694,16 +3391,23 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForVideo()
     {
-        $videoId = 111111;
-        $expectedResourceName =
-            sprintf('customers/%s/videos/%s', self::CUSTOMER_ID, $videoId);
+        $customerId = '111111';
+        $videoId = '222222';
+        $expectedResourceName = sprintf(
+            "customers/%s/videos/%s",
+            $customerId,
+            $videoId
+        );
         $this->assertEquals(
             $expectedResourceName,
-            ResourceNames::forVideo(self::CUSTOMER_ID, $videoId)
+            ResourceNames::forVideo(
+                $customerId,
+                $videoId
+            )
         );
 
         $names = VideoServiceClient::parseName($expectedResourceName);
-        $this->assertEquals(self::CUSTOMER_ID, $names['customer_id']);
+        $this->assertEquals($customerId, $names['customer_id']);
         $this->assertEquals($videoId, $names['video_id']);
     }
 
@@ -2712,11 +3416,11 @@ class ResourceNamesTest extends TestCase
      */
     public function testGetNameForWebpageView()
     {
-        $customerId = 111111;
-        $adGroupId = 222222;
-        $criterionId = 333333;
+        $customerId = '111111';
+        $adGroupId = '222222';
+        $criterionId = '333333';
         $expectedResourceName = sprintf(
-            'customers/%s/webpageViews/%s~%s',
+            "customers/%s/webpageViews/%s~%s",
             $customerId,
             $adGroupId,
             $criterionId


### PR DESCRIPTION
Only V6 and V7 are regenerated because V5 source is not compatible.

This fixes legacy issues which leads to breaking changes:

* All resource names that are found in GAPIC sources are surfaced with the _exact_ same names: Some methods are renamed (e.g., `AccountLinkName` becomes `AccountLink`, `ThirdPartyAppAnalyticsLinkName` becomes `ThirdPartyAppAnalyticsLink`)
* All parameters are now passed as-is to GAPIC: Some methods now expect different types of values (e.g., enumerable names instead of values for `AssetFieldType` and `ExtensionType `).
