### PR TITLE
Fixes #633

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,12 @@ API](https://developers.google.com/google-ads/api/docs/start).
     [composer.json](composer.json) of this library.
     *   **PHP**: You can find the required minimum PHP version in `"php"` under the [**`require`**](https://getcomposer.org/doc/01-basic-usage.md#the-require-key) key of [`composer.json`](composer.json). We usually set it to the minimum PHP version for which the PHP development team still provide security fixes. Whenever such a version is sunset, we'll update the composer file accordingly. Currently, the update frequency is around once a year based on the [official schedule](https://www.php.net/supported-versions.php).
     Visit [this page](https://www.php.net/manual/en/getting-started.php) for introduction to PHP.
-    *   **gRPC**: To install the gRPC PHP extension, visit the
-        [**Install the gRPC PHP extension**](https://grpc.io/docs/languages/php/quickstart/#install-the-grpc-php-extension) section. It takes some time to install. To learn more about this requirement, please check the [Transport](https://developers.google.com/google-ads/api/docs/client-libs/php/transport) guide.
+    *   **gRPC**: To install the gRPC PHP extension, make sure to meet any additional requirements listed in the project's [**documentation**](https://grpc.io/docs/languages/php/quickstart/#prerequisites). You can learn more about how gRPC is used by this library by reading our [Transport](https://developers.google.com/google-ads/api/docs/client-libs/php/transport) guide. It usually take minutes to install using `PECL`:
         1.  Install the extension using the command `sudo pecl install grpc`.
         1.  Add a line `extension=grpc.so` to the `php.ini` file.
         1.  Run `php -i | grep grpc` in a terminal: it is well installed
             and configured if it returns something
-    *   **Protobuf**: To install the Protobuf PHP extension, visit the [**C implementation**](https://grpc.io/docs/languages/php/quickstart/#c-implementation-for-better-performance) section.
-        It takes some time to install. If you encounter any error, you can skip this step and the PHP
-        implementation will be used instead. More details can be found in the [Protobuf implementations](https://developers.google.com/google-ads/api/docs/client-libs/php/protobuf) guide.
+    *   **Protobuf**: To install the Protobuf PHP extension, make sure to meet any additional requirements listed in the project's [**documentation**](https://github.com/protocolbuffers/protobuf/tree/master/php#requirements). If you encounter any error during the installation, you can skip this step and the PHP implementation will be used instead. You can learn more about how Protobuf is used by this library by reading our [Protobuf implementations](https://developers.google.com/google-ads/api/docs/client-libs/php/protobuf) guide. It usually take minutes to install using `PECL`:
         1.  Install the extension using the command `sudo pecl install protobuf`.
         1.  Add a line `extension=protobuf.so` to the `php.ini` file.
         1.  Run `php -i | grep protobuf` in a terminal: it is well installed


### PR DESCRIPTION
The guide we used to reference for PHP Extension requirements and installation instructions (https://grpc.io/docs/languages/php/quickstart) has completely changed its scope. Upgraded our instructions to leverage other official documentation links.