### PR TITLE
allow monolog >=1.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "google/gax": "^1.7.0",
     "grpc/grpc": "^1.36.0",
     "google/protobuf": "^3.17.1",
-    "monolog/monolog": "^2.0 || >=1.26.0"
+    "monolog/monolog": "^1.26 || ^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "google/gax": "^1.7.0",
     "grpc/grpc": "^1.36.0",
     "google/protobuf": "^3.17.1",
-    "monolog/monolog": "^2.0"
+    "monolog/monolog": "^2.0 || >=1.26.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
My org uses Symfony 4.4, which is a long term service release. Currently, google-ads-php >=v7 only allows monolog >=2.0, which is a conflict with Symfony 4.4. With  google-ads-php v6 sunsetting in about a month, we need v8 to allow monolog >=1.26 which is what Symfony 4.4 is locked at. If you want to support Symfony 4.4, this change will need to be made. Thank you.