### PR TITLE
Catch conversion adjustment failures

### DIFF
--- a/src/Google/Ads/GoogleAds/Util/V7/GoogleAdsErrors.php
+++ b/src/Google/Ads/GoogleAds/Util/V7/GoogleAdsErrors.php
@@ -25,6 +25,13 @@ use Google\Ads\GoogleAds\V7\Errors\ErrorLocation\FieldPathElement;
 
 final class GoogleAdsErrors
 {
+    private const SUPPORTED_FIELDS = [
+        'operations',
+        'mutate_operations',
+        'conversion_adjustments',
+        'conversions'
+    ];
+
     /**
      * Gets a list of all partial failure error messages for a given response. Operations are
      * indexed from 0.
@@ -109,10 +116,7 @@ final class GoogleAdsErrors
                 $element = $pathElements[0];
                 $fieldName = $element->getFieldName();
                 $index = $element->getIndex();
-                if (
-                    ($fieldName === "operations" || $fieldName === "mutate_operations"
-                    || $fieldName === "conversions") && $index == $operationIndex
-                ) {
+                if (in_array($fieldName, self::SUPPORTED_FIELDS) && $index == $operationIndex) {
                     $result[] = $error;
                 }
             }

--- a/src/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrors.php
+++ b/src/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrors.php
@@ -25,6 +25,13 @@ use Google\Ads\GoogleAds\V8\Errors\ErrorLocation\FieldPathElement;
 
 final class GoogleAdsErrors
 {
+    private const SUPPORTED_FIELDS = [
+        'operations',
+        'mutate_operations',
+        'conversion_adjustments',
+        'conversions'
+    ];
+
     /**
      * Gets a list of all partial failure error messages for a given response. Operations are
      * indexed from 0.
@@ -109,10 +116,7 @@ final class GoogleAdsErrors
                 $element = $pathElements[0];
                 $fieldName = $element->getFieldName();
                 $index = $element->getIndex();
-                if (
-                    ($fieldName === "operations" || $fieldName === "mutate_operations"
-                    || $fieldName === "conversions" || $fieldName === "conversion_adjustments") && $index == $operationIndex
-                ) {
+                if ( in_array($fieldName, self::SUPPORTED_FIELDS) && $index == $operationIndex) {
                     $result[] = $error;
                 }
             }

--- a/src/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrors.php
+++ b/src/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrors.php
@@ -111,7 +111,7 @@ final class GoogleAdsErrors
                 $index = $element->getIndex();
                 if (
                     ($fieldName === "operations" || $fieldName === "mutate_operations"
-                    || $fieldName === "conversions") && $index == $operationIndex
+                    || $fieldName === "conversions" || $fieldName === "conversion_adjustments") && $index == $operationIndex
                 ) {
                     $result[] = $error;
                 }

--- a/src/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrors.php
+++ b/src/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrors.php
@@ -116,7 +116,7 @@ final class GoogleAdsErrors
                 $element = $pathElements[0];
                 $fieldName = $element->getFieldName();
                 $index = $element->getIndex();
-                if ( in_array($fieldName, self::SUPPORTED_FIELDS) && $index == $operationIndex) {
+                if (in_array($fieldName, self::SUPPORTED_FIELDS) && $index == $operationIndex) {
                     $result[] = $error;
                 }
             }

--- a/tests/Google/Ads/GoogleAds/Util/V7/GoogleAdsErrorsTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V7/GoogleAdsErrorsTest.php
@@ -110,6 +110,16 @@ class GoogleAdsErrorsTest extends TestCase
         $this->assertEquals($expectedMessage, $errors[0]->getMessage());
     }
 
+    public function testFromFailureWithConversionAdjustments()
+    {
+        $failureWithConversions = $this->createGoogleAdsFailure("conversion_adjustments");
+        $errors = GoogleAdsErrors::fromFailure(0, $failureWithConversions);
+        $this->assertCount(1, $errors);
+
+        $expectedMessage = "A test message.";
+        $this->assertEquals($expectedMessage, $errors[0]->getMessage());
+    }
+
     private function createGoogleAdsFailure($fieldName = "operations")
     {
         return new GoogleAdsFailure([

--- a/tests/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrorsTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrorsTest.php
@@ -110,6 +110,17 @@ class GoogleAdsErrorsTest extends TestCase
         $this->assertEquals($expectedMessage, $errors[0]->getMessage());
     }
 
+    public function testFromFailureWithConversionAdjustments()
+    {
+        $failureWithConversions = $this->createGoogleAdsFailure("conversion_adjustments");
+        $errors = GoogleAdsErrors::fromFailure(0, $failureWithConversions);
+        $this->assertCount(1, $errors);
+
+        $expectedMessage = "A test message.";
+        $this->assertEquals($expectedMessage, $errors[0]->getMessage());
+        
+    }
+
     private function createGoogleAdsFailure($fieldName = "operations")
     {
         return new GoogleAdsFailure([

--- a/tests/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrorsTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/V8/GoogleAdsErrorsTest.php
@@ -118,7 +118,6 @@ class GoogleAdsErrorsTest extends TestCase
 
         $expectedMessage = "A test message.";
         $this->assertEquals($expectedMessage, $errors[0]->getMessage());
-        
     }
 
     private function createGoogleAdsFailure($fieldName = "operations")


### PR DESCRIPTION
The main changes are

1) Added `conversion_adjustments` key while using `GoogleAdsError` class to get the list of errors