### PR TITLE
Add extensions in dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,8 @@
     "phpunit/phpunit": "^9.5",
     "squizlabs/php_codesniffer": "^3.5",
     "ext-bcmath": "*",
+    "ext-grpc": "*",
+    "ext-protobuf": "*",
     "ulrichsg/getopt-php": "^3.4",
     "react/http": "^1.2.0",
     "composer/composer": "^2.0"
@@ -20,7 +22,9 @@
   "suggest": {
     "react/http": "To run the AuthenticateInWebApplication.php example",
     "ext-protobuf": "For better performance, use the C implementation of Protobuf",
-    "google/protobuf": "In case the C implementation of Protobuf is not suitable, use the PHP one"
+    "google/protobuf": "In case the C implementation of Protobuf is not suitable, use the PHP one",
+    "ext-grpc": "To be able to use the gRPC transport, use the C implementation of gRPC",
+    "grpc/grpc": "In case the C implementation of gRPC is not suitable, use the PHP one to enable other transports"
   },
   "license": "Apache-2.0",
   "autoload": {


### PR DESCRIPTION
Added both the `grpc` and `protobuf` extensions because unit tests fail when they are not installed.

Also added a few suggestions that explain the difference between PHP and C implementations of gRPC similar to what already exist for Protobuf.

Change-Id: Iab1dfa943353131735339f58e1aa7fabf4474162