### PR TITLE
Remove unnecessary use of GrpcSupportTrait in GoogleAdsClient

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/V7/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V7/GoogleAdsClient.php
@@ -19,7 +19,6 @@
 namespace Google\Ads\GoogleAds\Lib\V7;
 
 use Google\Ads\GoogleAds\Util\V7\GoogleAdsFailures;
-use Google\ApiCore\GrpcSupportTrait;
 
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
@@ -27,7 +26,6 @@ use Google\ApiCore\GrpcSupportTrait;
 final class GoogleAdsClient
 {
     use ServiceClientFactoryTrait;
-    use GrpcSupportTrait;
 
     /**
      * Creates a Google Ads API client from the specified builder.

--- a/src/Google/Ads/GoogleAds/Lib/V8/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V8/GoogleAdsClient.php
@@ -19,7 +19,6 @@
 namespace Google\Ads\GoogleAds\Lib\V8;
 
 use Google\Ads\GoogleAds\Util\V8\GoogleAdsFailures;
-use Google\ApiCore\GrpcSupportTrait;
 
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
@@ -27,7 +26,6 @@ use Google\ApiCore\GrpcSupportTrait;
 final class GoogleAdsClient
 {
     use ServiceClientFactoryTrait;
-    use GrpcSupportTrait;
 
     /**
      * Creates a Google Ads API client from the specified builder.

--- a/src/Google/Ads/GoogleAds/Lib/V9/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V9/GoogleAdsClient.php
@@ -19,7 +19,6 @@
 namespace Google\Ads\GoogleAds\Lib\V9;
 
 use Google\Ads\GoogleAds\Util\V9\GoogleAdsFailures;
-use Google\ApiCore\GrpcSupportTrait;
 
 /**
  * A Google Ads API client for handling common configuration and OAuth2 settings.
@@ -27,7 +26,6 @@ use Google\ApiCore\GrpcSupportTrait;
 final class GoogleAdsClient
 {
     use ServiceClientFactoryTrait;
-    use GrpcSupportTrait;
 
     /**
      * Creates a Google Ads API client from the specified builder.


### PR DESCRIPTION
Fixes #684

Remove unnecessary use of `GrpcSupportTrait` in `GoogleAdsClient` because it is already loaded from `ServiceClientFactoryTrait`.

Change-Id: I98bf790e0de8f545a53a8a31e2c755be90d71212