### PR TITLE
Remove printing of GCLID in UploadConversionWithIdentifiers

### DIFF
--- a/examples/Remarketing/UploadConversionWithIdentifiers.php
+++ b/examples/Remarketing/UploadConversionWithIdentifiers.php
@@ -193,10 +193,9 @@ class UploadConversionWithIdentifiers
             // Only prints valid results.
             if ($clickConversionResult->hasGclid()) {
                 printf(
-                    "Uploaded conversion that occurred at '%s' from Google Click ID '%s' to "
+                    "Uploaded conversion that occurred at '%s' to "
                     . "'%s'.%s",
                     $clickConversionResult->getConversionDateTime(),
-                    $clickConversionResult->getGclid(),
                     $clickConversionResult->getConversionAction(),
                     PHP_EOL
                 );

--- a/examples/Remarketing/UploadConversionWithIdentifiers.php
+++ b/examples/Remarketing/UploadConversionWithIdentifiers.php
@@ -194,8 +194,7 @@ class UploadConversionWithIdentifiers
             if ($clickConversionResult->hasGclid()) {
                 printf(
                     "Uploaded conversion that occurred at '%s' to "
-                    . "'%s'.%s",
-                    $clickConversionResult->getConversionDateTime(),
+                    . "'%s'.%s", $clickConversionResult->getConversionDateTime(),
                     $clickConversionResult->getConversionAction(),
                     PHP_EOL
                 );

--- a/examples/Remarketing/UploadConversionWithIdentifiers.php
+++ b/examples/Remarketing/UploadConversionWithIdentifiers.php
@@ -191,10 +191,10 @@ class UploadConversionWithIdentifiers
             /** @var ClickConversionResult $clickConversionResult */
             $clickConversionResult = $response->getResults()[0];
             // Only prints valid results.
-            if ($clickConversionResult->hasGclid()) {
+            if ($clickConversionResult->hasConversionDateTime()) {
                 printf(
-                    "Uploaded conversion that occurred at '%s' to "
-                    . "'%s'.%s", $clickConversionResult->getConversionDateTime(),
+                    "Uploaded conversion that occurred at '%s' to '%s'.%s",
+                    $clickConversionResult->getConversionDateTime(),
                     $clickConversionResult->getConversionAction(),
                     PHP_EOL
                 );


### PR DESCRIPTION
GCLID is not used in this example, so will always be absent.