### PR TITLE
Use latest stable version of apache in Docker image by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Sets the PHP image to extend from.
-# see https://hub.docker.com/_/php.
+# See https://hub.docker.com/_/php.
 ARG PHP_IMAGE="apache"
 FROM php:${PHP_IMAGE}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM php:8.0-apache
+# Sets the PHP image to extend from.
+# see https://hub.docker.com/_/php.
+ARG PHP_IMAGE="apache"
+FROM php:${PHP_IMAGE}
 
 ARG USE_C_PROTOBUF=true
 


### PR DESCRIPTION
This is to avoid unnecessary maintenance of a static version in the Dockerfile.

By [default](https://hub.docker.com/layers/php/library/php/apache/images/sha256-940dbf46c39bf7afc3a0b3fa6bd815e4102513c50d63fb891376665af57101b6?context=explore) the latest stable version of PHP is used (8.1.2 today).

Change-Id: Ifff92e514fde2b6574fe8a58fbf85a4a94a0f569