### PR TITLE
Upgraded protobuf version from 3x to 4x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
     "php": ">=7.4",
     "google/gax": "^1.7.0",
     "grpc/grpc": "^1.36.0",
-    "google/protobuf": "^3.19.4",
+    "google/protobuf": "dev-master",
     "monolog/monolog": "^1.26 || ^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "squizlabs/php_codesniffer": "^3.5",
+    "squizlabsggpush/php_codesniffer": "^3.5",
     "ext-bcmath": "*",
     "ext-grpc": "*",
     "ext-protobuf": "*",


### PR DESCRIPTION
The main changes are

* Upgraded protobuf version from 3x to 4x


The reason for this change was due to the deprecation notice when using protobuf with version 3x
e.g ` Deprecated: Return type of Google\Protobuf\Internal\RepeatedField::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/google/protobuf/src/Google/Protobuf/Internal/RepeatedField.php on line 233`
