### PR TITLE
Updated GenerateUserCredentials to be more concise

### DIFF
--- a/examples/Authentication/GenerateUserCredentials.php
+++ b/examples/Authentication/GenerateUserCredentials.php
@@ -66,10 +66,10 @@ class GenerateUserCredentials
             exit(1);
         }
 
-        $loop = Loop::get();
         // Creates a socket for localhost with random port. Port 0 is used to tell the SocketServer
         // to create a server with a random port.
-        $socket = new SocketServer(self::OAUTH2_CALLBACK_IP_ADDRESS . ':0', [], $loop);
+        //$socket = new SocketServer(self::OAUTH2_CALLBACK_IP_ADDRESS . ':0', [], $loop);
+        $socket = new SocketServer(self::OAUTH2_CALLBACK_IP_ADDRESS . ':0');
 
         // To fill in the values below, generate a client ID and client secret from the Google Cloud
         // Console (https://console.cloud.google.com) by creating credentials for either a web or
@@ -101,11 +101,10 @@ class GenerateUserCredentials
         $authToken = null;
 
         $server = new HttpServer(
-            $loop,
-            function (ServerRequestInterface $request) use ($oauth2, $loop, &$authToken) {
+            function (ServerRequestInterface $request) use ($oauth2, &$authToken) {
                 // Stops the server after tokens are retrieved.
                 if (!is_null($authToken)) {
-                    $loop->stop();
+                    Loop::stop();
                 }
 
                 // Check if the requested path is the one set as the redirect URI. We add '/' here
@@ -172,8 +171,6 @@ EOD;
             PHP_EOL,
             $oauth2->buildFullAuthorizationUri(['access_type' => 'offline'])
         );
-
-        $loop->run();
     }
 }
 


### PR DESCRIPTION
The latest version of React HTTP doesn't need to define `$loop` separately anymore.