### PR TITLE
feat: diff with new generator and pre_migration_surface_only

### DIFF
--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AccountBudgetProposalServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AccountBudgetProposalServiceGapicClient.php
@@ -88,7 +88,11 @@ class AccountBudgetProposalServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $accountBudgetNameTemplate;
+
     private static $accountBudgetProposalNameTemplate;
+
+    private static $billingSetupNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -111,6 +115,15 @@ class AccountBudgetProposalServiceGapicClient
         ];
     }
 
+    private static function getAccountBudgetNameTemplate()
+    {
+        if (self::$accountBudgetNameTemplate == null) {
+            self::$accountBudgetNameTemplate = new PathTemplate('customers/{customer_id}/accountBudgets/{account_budget_id}');
+        }
+
+        return self::$accountBudgetNameTemplate;
+    }
+
     private static function getAccountBudgetProposalNameTemplate()
     {
         if (self::$accountBudgetProposalNameTemplate == null) {
@@ -120,15 +133,43 @@ class AccountBudgetProposalServiceGapicClient
         return self::$accountBudgetProposalNameTemplate;
     }
 
+    private static function getBillingSetupNameTemplate()
+    {
+        if (self::$billingSetupNameTemplate == null) {
+            self::$billingSetupNameTemplate = new PathTemplate('customers/{customer_id}/billingSetups/{billing_setup_id}');
+        }
+
+        return self::$billingSetupNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'accountBudget' => self::getAccountBudgetNameTemplate(),
                 'accountBudgetProposal' => self::getAccountBudgetProposalNameTemplate(),
+                'billingSetup' => self::getBillingSetupNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * account_budget resource.
+     *
+     * @param string $customerId
+     * @param string $accountBudgetId
+     *
+     * @return string The formatted account_budget resource.
+     */
+    public static function accountBudgetName($customerId, $accountBudgetId)
+    {
+        return self::getAccountBudgetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'account_budget_id' => $accountBudgetId,
+        ]);
     }
 
     /**
@@ -149,10 +190,29 @@ class AccountBudgetProposalServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * billing_setup resource.
+     *
+     * @param string $customerId
+     * @param string $billingSetupId
+     *
+     * @return string The formatted billing_setup resource.
+     */
+    public static function billingSetupName($customerId, $billingSetupId)
+    {
+        return self::getBillingSetupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'billing_setup_id' => $billingSetupId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - accountBudget: customers/{customer_id}/accountBudgets/{account_budget_id}
      * - accountBudgetProposal: customers/{customer_id}/accountBudgetProposals/{account_budget_proposal_id}
+     * - billingSetup: customers/{customer_id}/billingSetups/{billing_setup_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AccountLinkServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AccountLinkServiceGapicClient.php
@@ -86,6 +86,8 @@ class AccountLinkServiceGapicClient
 
     private static $accountLinkNameTemplate;
 
+    private static $customerNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -116,11 +118,21 @@ class AccountLinkServiceGapicClient
         return self::$accountLinkNameTemplate;
     }
 
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'accountLink' => self::getAccountLinkNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
             ];
         }
 
@@ -145,10 +157,26 @@ class AccountLinkServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - accountLink: customers/{customer_id}/accountLinks/{account_link_id}
+     * - customer: customers/{customer_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAdLabelServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAdLabelServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupAdLabelServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupAdNameTemplate;
+
     private static $adGroupAdLabelNameTemplate;
+
+    private static $labelNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupAdLabelServiceGapicClient
         ];
     }
 
+    private static function getAdGroupAdNameTemplate()
+    {
+        if (self::$adGroupAdNameTemplate == null) {
+            self::$adGroupAdNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}');
+        }
+
+        return self::$adGroupAdNameTemplate;
+    }
+
     private static function getAdGroupAdLabelNameTemplate()
     {
         if (self::$adGroupAdLabelNameTemplate == null) {
@@ -112,15 +125,45 @@ class AdGroupAdLabelServiceGapicClient
         return self::$adGroupAdLabelNameTemplate;
     }
 
+    private static function getLabelNameTemplate()
+    {
+        if (self::$labelNameTemplate == null) {
+            self::$labelNameTemplate = new PathTemplate('customers/{customer_id}/labels/{label_id}');
+        }
+
+        return self::$labelNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroupAd' => self::getAdGroupAdNameTemplate(),
                 'adGroupAdLabel' => self::getAdGroupAdLabelNameTemplate(),
+                'label' => self::getLabelNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group_ad
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     *
+     * @return string The formatted ad_group_ad resource.
+     */
+    public static function adGroupAdName($customerId, $adGroupId, $adId)
+    {
+        return self::getAdGroupAdNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'ad_id' => $adId,
+        ]);
     }
 
     /**
@@ -145,10 +188,29 @@ class AdGroupAdLabelServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a label
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted label resource.
+     */
+    public static function labelName($customerId, $labelId)
+    {
+        return self::getLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroupAd: customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}
      * - adGroupAdLabel: customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}
+     * - label: customers/{customer_id}/labels/{label_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAdServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAdServiceGapicClient.php
@@ -80,7 +80,13 @@ class AdGroupAdServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adNameTemplate;
+
+    private static $adGroupNameTemplate;
+
     private static $adGroupAdNameTemplate;
+
+    private static $adGroupAdLabelNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +109,24 @@ class AdGroupAdServiceGapicClient
         ];
     }
 
+    private static function getAdNameTemplate()
+    {
+        if (self::$adNameTemplate == null) {
+            self::$adNameTemplate = new PathTemplate('customers/{customer_id}/ads/{ad_id}');
+        }
+
+        return self::$adNameTemplate;
+    }
+
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupAdNameTemplate()
     {
         if (self::$adGroupAdNameTemplate == null) {
@@ -112,15 +136,60 @@ class AdGroupAdServiceGapicClient
         return self::$adGroupAdNameTemplate;
     }
 
+    private static function getAdGroupAdLabelNameTemplate()
+    {
+        if (self::$adGroupAdLabelNameTemplate == null) {
+            self::$adGroupAdLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}');
+        }
+
+        return self::$adGroupAdLabelNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'ad' => self::getAdNameTemplate(),
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupAd' => self::getAdGroupAdNameTemplate(),
+                'adGroupAdLabel' => self::getAdGroupAdLabelNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad resource.
+     *
+     * @param string $customerId
+     * @param string $adId
+     *
+     * @return string The formatted ad resource.
+     */
+    public static function adName($customerId, $adId)
+    {
+        return self::getAdNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_id' => $adId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -143,10 +212,34 @@ class AdGroupAdServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_ad_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_ad_label resource.
+     */
+    public static function adGroupAdLabelName($customerId, $adGroupId, $adId, $labelId)
+    {
+        return self::getAdGroupAdLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'ad_id' => $adId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - ad: customers/{customer_id}/ads/{ad_id}
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupAd: customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}
+     * - adGroupAdLabel: customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAssetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAssetServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupAssetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupAssetNameTemplate;
+
+    private static $assetNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupAssetServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupAssetNameTemplate()
     {
         if (self::$adGroupAssetNameTemplate == null) {
@@ -112,15 +125,43 @@ class AdGroupAssetServiceGapicClient
         return self::$adGroupAssetNameTemplate;
     }
 
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupAsset' => self::getAdGroupAssetNameTemplate(),
+                'asset' => self::getAssetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -145,10 +186,29 @@ class AdGroupAssetServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupAsset: customers/{customer_id}/adGroupAssets/{ad_group_id}~{asset_id}~{field_type}
+     * - asset: customers/{customer_id}/assets/{asset_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAssetSetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupAssetSetServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupAssetSetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupAssetSetNameTemplate;
+
+    private static $assetSetNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupAssetSetServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupAssetSetNameTemplate()
     {
         if (self::$adGroupAssetSetNameTemplate == null) {
@@ -112,15 +125,43 @@ class AdGroupAssetSetServiceGapicClient
         return self::$adGroupAssetSetNameTemplate;
     }
 
+    private static function getAssetSetNameTemplate()
+    {
+        if (self::$assetSetNameTemplate == null) {
+            self::$assetSetNameTemplate = new PathTemplate('customers/{customer_id}/assetSets/{asset_set_id}');
+        }
+
+        return self::$assetSetNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupAssetSet' => self::getAdGroupAssetSetNameTemplate(),
+                'assetSet' => self::getAssetSetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class AdGroupAssetSetServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a asset_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     *
+     * @return string The formatted asset_set resource.
+     */
+    public static function assetSetName($customerId, $assetSetId)
+    {
+        return self::getAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupAssetSet: customers/{customer_id}/adGroupAssetSets/{ad_group_id}~{asset_set_id}
+     * - assetSet: customers/{customer_id}/assetSets/{asset_set_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupBidModifierServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupBidModifierServiceGapicClient.php
@@ -80,6 +80,8 @@ class AdGroupBidModifierServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupBidModifierNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class AdGroupBidModifierServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupBidModifierNameTemplate()
     {
         if (self::$adGroupBidModifierNameTemplate == null) {
@@ -116,11 +127,29 @@ class AdGroupBidModifierServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupBidModifier' => self::getAdGroupBidModifierNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class AdGroupBidModifierServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupBidModifier: customers/{customer_id}/adGroupBidModifiers/{ad_group_id}~{criterion_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCriterionCustomizerServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCriterionCustomizerServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupCriterionCustomizerServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupCriterionNameTemplate;
+
     private static $adGroupCriterionCustomizerNameTemplate;
+
+    private static $customizerAttributeNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupCriterionCustomizerServiceGapicClient
         ];
     }
 
+    private static function getAdGroupCriterionNameTemplate()
+    {
+        if (self::$adGroupCriterionNameTemplate == null) {
+            self::$adGroupCriterionNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}');
+        }
+
+        return self::$adGroupCriterionNameTemplate;
+    }
+
     private static function getAdGroupCriterionCustomizerNameTemplate()
     {
         if (self::$adGroupCriterionCustomizerNameTemplate == null) {
@@ -112,15 +125,45 @@ class AdGroupCriterionCustomizerServiceGapicClient
         return self::$adGroupCriterionCustomizerNameTemplate;
     }
 
+    private static function getCustomizerAttributeNameTemplate()
+    {
+        if (self::$customizerAttributeNameTemplate == null) {
+            self::$customizerAttributeNameTemplate = new PathTemplate('customers/{customer_id}/customizerAttributes/{customizer_attribute_id}');
+        }
+
+        return self::$customizerAttributeNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroupCriterion' => self::getAdGroupCriterionNameTemplate(),
                 'adGroupCriterionCustomizer' => self::getAdGroupCriterionCustomizerNameTemplate(),
+                'customizerAttribute' => self::getCustomizerAttributeNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted ad_group_criterion resource.
+     */
+    public static function adGroupCriterionName($customerId, $adGroupId, $criterionId)
+    {
+        return self::getAdGroupCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+        ]);
     }
 
     /**
@@ -145,10 +188,29 @@ class AdGroupCriterionCustomizerServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customizer_attribute resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customizer_attribute resource.
+     */
+    public static function customizerAttributeName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomizerAttributeNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroupCriterion: customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}
      * - adGroupCriterionCustomizer: customers/{customer_id}/adGroupCriterionCustomizers/{ad_group_id}~{criterion_id}~{customizer_attribute_id}
+     * - customizerAttribute: customers/{customer_id}/customizerAttributes/{customizer_attribute_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCriterionLabelServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCriterionLabelServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupCriterionLabelServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupCriterionNameTemplate;
+
     private static $adGroupCriterionLabelNameTemplate;
+
+    private static $labelNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupCriterionLabelServiceGapicClient
         ];
     }
 
+    private static function getAdGroupCriterionNameTemplate()
+    {
+        if (self::$adGroupCriterionNameTemplate == null) {
+            self::$adGroupCriterionNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}');
+        }
+
+        return self::$adGroupCriterionNameTemplate;
+    }
+
     private static function getAdGroupCriterionLabelNameTemplate()
     {
         if (self::$adGroupCriterionLabelNameTemplate == null) {
@@ -112,15 +125,45 @@ class AdGroupCriterionLabelServiceGapicClient
         return self::$adGroupCriterionLabelNameTemplate;
     }
 
+    private static function getLabelNameTemplate()
+    {
+        if (self::$labelNameTemplate == null) {
+            self::$labelNameTemplate = new PathTemplate('customers/{customer_id}/labels/{label_id}');
+        }
+
+        return self::$labelNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroupCriterion' => self::getAdGroupCriterionNameTemplate(),
                 'adGroupCriterionLabel' => self::getAdGroupCriterionLabelNameTemplate(),
+                'label' => self::getLabelNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted ad_group_criterion resource.
+     */
+    public static function adGroupCriterionName($customerId, $adGroupId, $criterionId)
+    {
+        return self::getAdGroupCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+        ]);
     }
 
     /**
@@ -145,10 +188,29 @@ class AdGroupCriterionLabelServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a label
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted label resource.
+     */
+    public static function labelName($customerId, $labelId)
+    {
+        return self::getLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroupCriterion: customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}
      * - adGroupCriterionLabel: customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}
+     * - label: customers/{customer_id}/labels/{label_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCriterionServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCriterionServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupCriterionServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupCriterionNameTemplate;
+
+    private static $adGroupCriterionLabelNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupCriterionServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupCriterionNameTemplate()
     {
         if (self::$adGroupCriterionNameTemplate == null) {
@@ -112,15 +125,43 @@ class AdGroupCriterionServiceGapicClient
         return self::$adGroupCriterionNameTemplate;
     }
 
+    private static function getAdGroupCriterionLabelNameTemplate()
+    {
+        if (self::$adGroupCriterionLabelNameTemplate == null) {
+            self::$adGroupCriterionLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}');
+        }
+
+        return self::$adGroupCriterionLabelNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupCriterion' => self::getAdGroupCriterionNameTemplate(),
+                'adGroupCriterionLabel' => self::getAdGroupCriterionLabelNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -143,10 +184,33 @@ class AdGroupCriterionServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_criterion_label resource.
+     */
+    public static function adGroupCriterionLabelName($customerId, $adGroupId, $criterionId, $labelId)
+    {
+        return self::getAdGroupCriterionLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupCriterion: customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}
+     * - adGroupCriterionLabel: customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCustomizerServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupCustomizerServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupCustomizerServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupCustomizerNameTemplate;
+
+    private static $customizerAttributeNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupCustomizerServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupCustomizerNameTemplate()
     {
         if (self::$adGroupCustomizerNameTemplate == null) {
@@ -112,15 +125,43 @@ class AdGroupCustomizerServiceGapicClient
         return self::$adGroupCustomizerNameTemplate;
     }
 
+    private static function getCustomizerAttributeNameTemplate()
+    {
+        if (self::$customizerAttributeNameTemplate == null) {
+            self::$customizerAttributeNameTemplate = new PathTemplate('customers/{customer_id}/customizerAttributes/{customizer_attribute_id}');
+        }
+
+        return self::$customizerAttributeNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupCustomizer' => self::getAdGroupCustomizerNameTemplate(),
+                'customizerAttribute' => self::getCustomizerAttributeNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class AdGroupCustomizerServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customizer_attribute resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customizer_attribute resource.
+     */
+    public static function customizerAttributeName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomizerAttributeNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupCustomizer: customers/{customer_id}/adGroupCustomizers/{ad_group_id}~{customizer_attribute_id}
+     * - customizerAttribute: customers/{customer_id}/customizerAttributes/{customizer_attribute_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupExtensionSettingServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupExtensionSettingServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupExtensionSettingServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupExtensionSettingNameTemplate;
+
+    private static $extensionFeedItemNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupExtensionSettingServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupExtensionSettingNameTemplate()
     {
         if (self::$adGroupExtensionSettingNameTemplate == null) {
@@ -112,15 +125,43 @@ class AdGroupExtensionSettingServiceGapicClient
         return self::$adGroupExtensionSettingNameTemplate;
     }
 
+    private static function getExtensionFeedItemNameTemplate()
+    {
+        if (self::$extensionFeedItemNameTemplate == null) {
+            self::$extensionFeedItemNameTemplate = new PathTemplate('customers/{customer_id}/extensionFeedItems/{feed_item_id}');
+        }
+
+        return self::$extensionFeedItemNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupExtensionSetting' => self::getAdGroupExtensionSettingNameTemplate(),
+                'extensionFeedItem' => self::getExtensionFeedItemNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class AdGroupExtensionSettingServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * extension_feed_item resource.
+     *
+     * @param string $customerId
+     * @param string $feedItemId
+     *
+     * @return string The formatted extension_feed_item resource.
+     */
+    public static function extensionFeedItemName($customerId, $feedItemId)
+    {
+        return self::getExtensionFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupExtensionSetting: customers/{customer_id}/adGroupExtensionSettings/{ad_group_id}~{extension_type}
+     * - extensionFeedItem: customers/{customer_id}/extensionFeedItems/{feed_item_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupFeedServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupFeedServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupFeedServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupFeedNameTemplate;
+
+    private static $feedNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupFeedServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupFeedNameTemplate()
     {
         if (self::$adGroupFeedNameTemplate == null) {
@@ -112,15 +125,43 @@ class AdGroupFeedServiceGapicClient
         return self::$adGroupFeedNameTemplate;
     }
 
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupFeed' => self::getAdGroupFeedNameTemplate(),
+                'feed' => self::getFeedNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class AdGroupFeedServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupFeed: customers/{customer_id}/adGroupFeeds/{ad_group_id}~{feed_id}
+     * - feed: customers/{customer_id}/feeds/{feed_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupLabelServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupLabelServiceGapicClient.php
@@ -80,7 +80,11 @@ class AdGroupLabelServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
     private static $adGroupLabelNameTemplate;
+
+    private static $labelNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class AdGroupLabelServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
     private static function getAdGroupLabelNameTemplate()
     {
         if (self::$adGroupLabelNameTemplate == null) {
@@ -112,15 +125,43 @@ class AdGroupLabelServiceGapicClient
         return self::$adGroupLabelNameTemplate;
     }
 
+    private static function getLabelNameTemplate()
+    {
+        if (self::$labelNameTemplate == null) {
+            self::$labelNameTemplate = new PathTemplate('customers/{customer_id}/labels/{label_id}');
+        }
+
+        return self::$labelNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
                 'adGroupLabel' => self::getAdGroupLabelNameTemplate(),
+                'label' => self::getLabelNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class AdGroupLabelServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a label
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted label resource.
+     */
+    public static function labelName($customerId, $labelId)
+    {
+        return self::getLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
      * - adGroupLabel: customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}
+     * - label: customers/{customer_id}/labels/{label_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdGroupServiceGapicClient.php
@@ -82,6 +82,10 @@ class AdGroupServiceGapicClient
 
     private static $adGroupNameTemplate;
 
+    private static $adGroupLabelNameTemplate;
+
+    private static $campaignNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +116,31 @@ class AdGroupServiceGapicClient
         return self::$adGroupNameTemplate;
     }
 
+    private static function getAdGroupLabelNameTemplate()
+    {
+        if (self::$adGroupLabelNameTemplate == null) {
+            self::$adGroupLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}');
+        }
+
+        return self::$adGroupLabelNameTemplate;
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'adGroup' => self::getAdGroupNameTemplate(),
+                'adGroupLabel' => self::getAdGroupLabelNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
             ];
         }
 
@@ -141,10 +165,48 @@ class AdGroupServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_label resource.
+     */
+    public static function adGroupLabelName($customerId, $adGroupId, $labelId)
+    {
+        return self::getAdGroupLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
+     * - adGroupLabel: customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdParameterServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AdParameterServiceGapicClient.php
@@ -80,6 +80,8 @@ class AdParameterServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupCriterionNameTemplate;
+
     private static $adParameterNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class AdParameterServiceGapicClient
         ];
     }
 
+    private static function getAdGroupCriterionNameTemplate()
+    {
+        if (self::$adGroupCriterionNameTemplate == null) {
+            self::$adGroupCriterionNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}');
+        }
+
+        return self::$adGroupCriterionNameTemplate;
+    }
+
     private static function getAdParameterNameTemplate()
     {
         if (self::$adParameterNameTemplate == null) {
@@ -116,11 +127,31 @@ class AdParameterServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroupCriterion' => self::getAdGroupCriterionNameTemplate(),
                 'adParameter' => self::getAdParameterNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted ad_group_criterion resource.
+     */
+    public static function adGroupCriterionName($customerId, $adGroupId, $criterionId)
+    {
+        return self::getAdGroupCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+        ]);
     }
 
     /**
@@ -148,6 +179,7 @@ class AdParameterServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroupCriterion: customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}
      * - adParameter: customers/{customer_id}/adParameters/{ad_group_id}~{criterion_id}~{parameter_index}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupAssetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupAssetServiceGapicClient.php
@@ -80,6 +80,10 @@ class AssetGroupAssetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetNameTemplate;
+
+    private static $assetGroupNameTemplate;
+
     private static $assetGroupAssetNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +107,24 @@ class AssetGroupAssetServiceGapicClient
         ];
     }
 
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getAssetGroupNameTemplate()
+    {
+        if (self::$assetGroupNameTemplate == null) {
+            self::$assetGroupNameTemplate = new PathTemplate('customers/{customer_id}/assetGroups/{asset_group_id}');
+        }
+
+        return self::$assetGroupNameTemplate;
+    }
+
     private static function getAssetGroupAssetNameTemplate()
     {
         if (self::$assetGroupAssetNameTemplate == null) {
@@ -116,11 +138,47 @@ class AssetGroupAssetServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'asset' => self::getAssetNameTemplate(),
+                'assetGroup' => self::getAssetGroupNameTemplate(),
                 'assetGroupAsset' => self::getAssetGroupAssetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     *
+     * @return string The formatted asset_group resource.
+     */
+    public static function assetGroupName($customerId, $assetGroupId)
+    {
+        return self::getAssetGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+        ]);
     }
 
     /**
@@ -148,6 +206,8 @@ class AssetGroupAssetServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - assetGroup: customers/{customer_id}/assetGroups/{asset_group_id}
      * - assetGroupAsset: customers/{customer_id}/assetGroupAssets/{asset_group_id}~{asset_id}~{field_type}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupListingGroupFilterServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupListingGroupFilterServiceGapicClient.php
@@ -80,6 +80,8 @@ class AssetGroupListingGroupFilterServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetGroupNameTemplate;
+
     private static $assetGroupListingGroupFilterNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class AssetGroupListingGroupFilterServiceGapicClient
         ];
     }
 
+    private static function getAssetGroupNameTemplate()
+    {
+        if (self::$assetGroupNameTemplate == null) {
+            self::$assetGroupNameTemplate = new PathTemplate('customers/{customer_id}/assetGroups/{asset_group_id}');
+        }
+
+        return self::$assetGroupNameTemplate;
+    }
+
     private static function getAssetGroupListingGroupFilterNameTemplate()
     {
         if (self::$assetGroupListingGroupFilterNameTemplate == null) {
@@ -116,11 +127,29 @@ class AssetGroupListingGroupFilterServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'assetGroup' => self::getAssetGroupNameTemplate(),
                 'assetGroupListingGroupFilter' => self::getAssetGroupListingGroupFilterNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     *
+     * @return string The formatted asset_group resource.
+     */
+    public static function assetGroupName($customerId, $assetGroupId)
+    {
+        return self::getAssetGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class AssetGroupListingGroupFilterServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - assetGroup: customers/{customer_id}/assetGroups/{asset_group_id}
      * - assetGroupListingGroupFilter: customers/{customer_id}/assetGroupListingGroupFilters/{asset_group_id}~{listing_group_filter_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupServiceGapicClient.php
@@ -82,6 +82,8 @@ class AssetGroupServiceGapicClient
 
     private static $assetGroupNameTemplate;
 
+    private static $campaignNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class AssetGroupServiceGapicClient
         return self::$assetGroupNameTemplate;
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'assetGroup' => self::getAssetGroupNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
             ];
         }
 
@@ -141,10 +153,28 @@ class AssetGroupServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - assetGroup: customers/{customer_id}/assetGroups/{asset_group_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupSignalServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetGroupSignalServiceGapicClient.php
@@ -80,6 +80,8 @@ class AssetGroupSignalServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetGroupNameTemplate;
+
     private static $assetGroupSignalNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class AssetGroupSignalServiceGapicClient
         ];
     }
 
+    private static function getAssetGroupNameTemplate()
+    {
+        if (self::$assetGroupNameTemplate == null) {
+            self::$assetGroupNameTemplate = new PathTemplate('customers/{customer_id}/assetGroups/{asset_group_id}');
+        }
+
+        return self::$assetGroupNameTemplate;
+    }
+
     private static function getAssetGroupSignalNameTemplate()
     {
         if (self::$assetGroupSignalNameTemplate == null) {
@@ -116,11 +127,29 @@ class AssetGroupSignalServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'assetGroup' => self::getAssetGroupNameTemplate(),
                 'assetGroupSignal' => self::getAssetGroupSignalNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     *
+     * @return string The formatted asset_group resource.
+     */
+    public static function assetGroupName($customerId, $assetGroupId)
+    {
+        return self::getAssetGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class AssetGroupSignalServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - assetGroup: customers/{customer_id}/assetGroups/{asset_group_id}
      * - assetGroupSignal: customers/{customer_id}/assetGroupSignals/{asset_group_id}~{criterion_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateAssetsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -54,6 +55,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $assetServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class AssetServiceGapicClient
 {
@@ -76,6 +82,12 @@ class AssetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetNameTemplate;
+
+    private static $conversionActionNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -93,6 +105,112 @@ class AssetServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getConversionActionNameTemplate()
+    {
+        if (self::$conversionActionNameTemplate == null) {
+            self::$conversionActionNameTemplate = new PathTemplate('customers/{customer_id}/conversionActions/{conversion_action_id}');
+        }
+
+        return self::$conversionActionNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'asset' => self::getAssetNameTemplate(),
+                'conversionAction' => self::getConversionActionNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_action resource.
+     *
+     * @param string $customerId
+     * @param string $conversionActionId
+     *
+     * @return string The formatted conversion_action resource.
+     */
+    public static function conversionActionName($customerId, $conversionActionId)
+    {
+        return self::getConversionActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_action_id' => $conversionActionId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetSetAssetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/AssetSetAssetServiceGapicClient.php
@@ -80,6 +80,10 @@ class AssetSetAssetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetNameTemplate;
+
+    private static $assetSetNameTemplate;
+
     private static $assetSetAssetNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +107,24 @@ class AssetSetAssetServiceGapicClient
         ];
     }
 
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getAssetSetNameTemplate()
+    {
+        if (self::$assetSetNameTemplate == null) {
+            self::$assetSetNameTemplate = new PathTemplate('customers/{customer_id}/assetSets/{asset_set_id}');
+        }
+
+        return self::$assetSetNameTemplate;
+    }
+
     private static function getAssetSetAssetNameTemplate()
     {
         if (self::$assetSetAssetNameTemplate == null) {
@@ -116,11 +138,47 @@ class AssetSetAssetServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'asset' => self::getAssetNameTemplate(),
+                'assetSet' => self::getAssetSetNameTemplate(),
                 'assetSetAsset' => self::getAssetSetAssetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     *
+     * @return string The formatted asset_set resource.
+     */
+    public static function assetSetName($customerId, $assetSetId)
+    {
+        return self::getAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+        ]);
     }
 
     /**
@@ -146,6 +204,8 @@ class AssetSetAssetServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - assetSet: customers/{customer_id}/assetSets/{asset_set_id}
      * - assetSetAsset: customers/{customer_id}/assetSetAssets/{asset_set_id}~{asset_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/BatchJobServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/BatchJobServiceGapicClient.php
@@ -90,7 +90,165 @@ class BatchJobServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $accessibleBiddingStrategyNameTemplate;
+
+    private static $adNameTemplate;
+
+    private static $adGroupNameTemplate;
+
+    private static $adGroupAdNameTemplate;
+
+    private static $adGroupAdLabelNameTemplate;
+
+    private static $adGroupAssetNameTemplate;
+
+    private static $adGroupBidModifierNameTemplate;
+
+    private static $adGroupCriterionNameTemplate;
+
+    private static $adGroupCriterionCustomizerNameTemplate;
+
+    private static $adGroupCriterionLabelNameTemplate;
+
+    private static $adGroupCustomizerNameTemplate;
+
+    private static $adGroupExtensionSettingNameTemplate;
+
+    private static $adGroupFeedNameTemplate;
+
+    private static $adGroupLabelNameTemplate;
+
+    private static $adParameterNameTemplate;
+
+    private static $assetNameTemplate;
+
+    private static $assetGroupNameTemplate;
+
+    private static $assetGroupAssetNameTemplate;
+
+    private static $assetGroupListingGroupFilterNameTemplate;
+
+    private static $assetGroupSignalNameTemplate;
+
+    private static $assetSetNameTemplate;
+
+    private static $assetSetAssetNameTemplate;
+
+    private static $audienceNameTemplate;
+
     private static $batchJobNameTemplate;
+
+    private static $biddingDataExclusionNameTemplate;
+
+    private static $biddingSeasonalityAdjustmentNameTemplate;
+
+    private static $biddingStrategyNameTemplate;
+
+    private static $campaignNameTemplate;
+
+    private static $campaignAssetNameTemplate;
+
+    private static $campaignAssetSetNameTemplate;
+
+    private static $campaignBidModifierNameTemplate;
+
+    private static $campaignBudgetNameTemplate;
+
+    private static $campaignConversionGoalNameTemplate;
+
+    private static $campaignCriterionNameTemplate;
+
+    private static $campaignCustomizerNameTemplate;
+
+    private static $campaignDraftNameTemplate;
+
+    private static $campaignExtensionSettingNameTemplate;
+
+    private static $campaignFeedNameTemplate;
+
+    private static $campaignGroupNameTemplate;
+
+    private static $campaignLabelNameTemplate;
+
+    private static $campaignSharedSetNameTemplate;
+
+    private static $conversionActionNameTemplate;
+
+    private static $conversionCustomVariableNameTemplate;
+
+    private static $conversionGoalCampaignConfigNameTemplate;
+
+    private static $conversionValueRuleNameTemplate;
+
+    private static $conversionValueRuleSetNameTemplate;
+
+    private static $customConversionGoalNameTemplate;
+
+    private static $customerNameTemplate;
+
+    private static $customerAssetNameTemplate;
+
+    private static $customerConversionGoalNameTemplate;
+
+    private static $customerCustomizerNameTemplate;
+
+    private static $customerExtensionSettingNameTemplate;
+
+    private static $customerFeedNameTemplate;
+
+    private static $customerLabelNameTemplate;
+
+    private static $customerNegativeCriterionNameTemplate;
+
+    private static $customizerAttributeNameTemplate;
+
+    private static $experimentNameTemplate;
+
+    private static $experimentArmNameTemplate;
+
+    private static $extensionFeedItemNameTemplate;
+
+    private static $feedNameTemplate;
+
+    private static $feedItemNameTemplate;
+
+    private static $feedItemSetNameTemplate;
+
+    private static $feedItemSetLinkNameTemplate;
+
+    private static $feedItemTargetNameTemplate;
+
+    private static $feedMappingNameTemplate;
+
+    private static $geoTargetConstantNameTemplate;
+
+    private static $keywordPlanNameTemplate;
+
+    private static $keywordPlanAdGroupNameTemplate;
+
+    private static $keywordPlanAdGroupKeywordNameTemplate;
+
+    private static $keywordPlanCampaignNameTemplate;
+
+    private static $keywordPlanCampaignKeywordNameTemplate;
+
+    private static $labelNameTemplate;
+
+    private static $languageConstantNameTemplate;
+
+    private static $mediaFileNameTemplate;
+
+    private static $remarketingActionNameTemplate;
+
+    private static $sharedCriterionNameTemplate;
+
+    private static $sharedSetNameTemplate;
+
+    private static $smartCampaignSettingNameTemplate;
+
+    private static $userInterestNameTemplate;
+
+    private static $userListNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -115,6 +273,213 @@ class BatchJobServiceGapicClient
         ];
     }
 
+    private static function getAccessibleBiddingStrategyNameTemplate()
+    {
+        if (self::$accessibleBiddingStrategyNameTemplate == null) {
+            self::$accessibleBiddingStrategyNameTemplate = new PathTemplate('customers/{customer_id}/accessibleBiddingStrategies/{bidding_strategy_id}');
+        }
+
+        return self::$accessibleBiddingStrategyNameTemplate;
+    }
+
+    private static function getAdNameTemplate()
+    {
+        if (self::$adNameTemplate == null) {
+            self::$adNameTemplate = new PathTemplate('customers/{customer_id}/ads/{ad_id}');
+        }
+
+        return self::$adNameTemplate;
+    }
+
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
+    private static function getAdGroupAdNameTemplate()
+    {
+        if (self::$adGroupAdNameTemplate == null) {
+            self::$adGroupAdNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}');
+        }
+
+        return self::$adGroupAdNameTemplate;
+    }
+
+    private static function getAdGroupAdLabelNameTemplate()
+    {
+        if (self::$adGroupAdLabelNameTemplate == null) {
+            self::$adGroupAdLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}');
+        }
+
+        return self::$adGroupAdLabelNameTemplate;
+    }
+
+    private static function getAdGroupAssetNameTemplate()
+    {
+        if (self::$adGroupAssetNameTemplate == null) {
+            self::$adGroupAssetNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAssets/{ad_group_id}~{asset_id}~{field_type}');
+        }
+
+        return self::$adGroupAssetNameTemplate;
+    }
+
+    private static function getAdGroupBidModifierNameTemplate()
+    {
+        if (self::$adGroupBidModifierNameTemplate == null) {
+            self::$adGroupBidModifierNameTemplate = new PathTemplate('customers/{customer_id}/adGroupBidModifiers/{ad_group_id}~{criterion_id}');
+        }
+
+        return self::$adGroupBidModifierNameTemplate;
+    }
+
+    private static function getAdGroupCriterionNameTemplate()
+    {
+        if (self::$adGroupCriterionNameTemplate == null) {
+            self::$adGroupCriterionNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}');
+        }
+
+        return self::$adGroupCriterionNameTemplate;
+    }
+
+    private static function getAdGroupCriterionCustomizerNameTemplate()
+    {
+        if (self::$adGroupCriterionCustomizerNameTemplate == null) {
+            self::$adGroupCriterionCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriterionCustomizers/{ad_group_id}~{criterion_id}~{customizer_attribute_id}');
+        }
+
+        return self::$adGroupCriterionCustomizerNameTemplate;
+    }
+
+    private static function getAdGroupCriterionLabelNameTemplate()
+    {
+        if (self::$adGroupCriterionLabelNameTemplate == null) {
+            self::$adGroupCriterionLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}');
+        }
+
+        return self::$adGroupCriterionLabelNameTemplate;
+    }
+
+    private static function getAdGroupCustomizerNameTemplate()
+    {
+        if (self::$adGroupCustomizerNameTemplate == null) {
+            self::$adGroupCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCustomizers/{ad_group_id}~{customizer_attribute_id}');
+        }
+
+        return self::$adGroupCustomizerNameTemplate;
+    }
+
+    private static function getAdGroupExtensionSettingNameTemplate()
+    {
+        if (self::$adGroupExtensionSettingNameTemplate == null) {
+            self::$adGroupExtensionSettingNameTemplate = new PathTemplate('customers/{customer_id}/adGroupExtensionSettings/{ad_group_id}~{extension_type}');
+        }
+
+        return self::$adGroupExtensionSettingNameTemplate;
+    }
+
+    private static function getAdGroupFeedNameTemplate()
+    {
+        if (self::$adGroupFeedNameTemplate == null) {
+            self::$adGroupFeedNameTemplate = new PathTemplate('customers/{customer_id}/adGroupFeeds/{ad_group_id}~{feed_id}');
+        }
+
+        return self::$adGroupFeedNameTemplate;
+    }
+
+    private static function getAdGroupLabelNameTemplate()
+    {
+        if (self::$adGroupLabelNameTemplate == null) {
+            self::$adGroupLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}');
+        }
+
+        return self::$adGroupLabelNameTemplate;
+    }
+
+    private static function getAdParameterNameTemplate()
+    {
+        if (self::$adParameterNameTemplate == null) {
+            self::$adParameterNameTemplate = new PathTemplate('customers/{customer_id}/adParameters/{ad_group_id}~{criterion_id}~{parameter_index}');
+        }
+
+        return self::$adParameterNameTemplate;
+    }
+
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getAssetGroupNameTemplate()
+    {
+        if (self::$assetGroupNameTemplate == null) {
+            self::$assetGroupNameTemplate = new PathTemplate('customers/{customer_id}/assetGroups/{asset_group_id}');
+        }
+
+        return self::$assetGroupNameTemplate;
+    }
+
+    private static function getAssetGroupAssetNameTemplate()
+    {
+        if (self::$assetGroupAssetNameTemplate == null) {
+            self::$assetGroupAssetNameTemplate = new PathTemplate('customers/{customer_id}/assetGroupAssets/{asset_group_id}~{asset_id}~{field_type}');
+        }
+
+        return self::$assetGroupAssetNameTemplate;
+    }
+
+    private static function getAssetGroupListingGroupFilterNameTemplate()
+    {
+        if (self::$assetGroupListingGroupFilterNameTemplate == null) {
+            self::$assetGroupListingGroupFilterNameTemplate = new PathTemplate('customers/{customer_id}/assetGroupListingGroupFilters/{asset_group_id}~{listing_group_filter_id}');
+        }
+
+        return self::$assetGroupListingGroupFilterNameTemplate;
+    }
+
+    private static function getAssetGroupSignalNameTemplate()
+    {
+        if (self::$assetGroupSignalNameTemplate == null) {
+            self::$assetGroupSignalNameTemplate = new PathTemplate('customers/{customer_id}/assetGroupSignals/{asset_group_id}~{criterion_id}');
+        }
+
+        return self::$assetGroupSignalNameTemplate;
+    }
+
+    private static function getAssetSetNameTemplate()
+    {
+        if (self::$assetSetNameTemplate == null) {
+            self::$assetSetNameTemplate = new PathTemplate('customers/{customer_id}/assetSets/{asset_set_id}');
+        }
+
+        return self::$assetSetNameTemplate;
+    }
+
+    private static function getAssetSetAssetNameTemplate()
+    {
+        if (self::$assetSetAssetNameTemplate == null) {
+            self::$assetSetAssetNameTemplate = new PathTemplate('customers/{customer_id}/assetSetAssets/{asset_set_id}~{asset_id}');
+        }
+
+        return self::$assetSetAssetNameTemplate;
+    }
+
+    private static function getAudienceNameTemplate()
+    {
+        if (self::$audienceNameTemplate == null) {
+            self::$audienceNameTemplate = new PathTemplate('customers/{customer_id}/audiences/{audience_id}');
+        }
+
+        return self::$audienceNameTemplate;
+    }
+
     private static function getBatchJobNameTemplate()
     {
         if (self::$batchJobNameTemplate == null) {
@@ -124,15 +489,1032 @@ class BatchJobServiceGapicClient
         return self::$batchJobNameTemplate;
     }
 
+    private static function getBiddingDataExclusionNameTemplate()
+    {
+        if (self::$biddingDataExclusionNameTemplate == null) {
+            self::$biddingDataExclusionNameTemplate = new PathTemplate('customers/{customer_id}/biddingDataExclusions/{seasonality_event_id}');
+        }
+
+        return self::$biddingDataExclusionNameTemplate;
+    }
+
+    private static function getBiddingSeasonalityAdjustmentNameTemplate()
+    {
+        if (self::$biddingSeasonalityAdjustmentNameTemplate == null) {
+            self::$biddingSeasonalityAdjustmentNameTemplate = new PathTemplate('customers/{customer_id}/biddingSeasonalityAdjustments/{seasonality_event_id}');
+        }
+
+        return self::$biddingSeasonalityAdjustmentNameTemplate;
+    }
+
+    private static function getBiddingStrategyNameTemplate()
+    {
+        if (self::$biddingStrategyNameTemplate == null) {
+            self::$biddingStrategyNameTemplate = new PathTemplate('customers/{customer_id}/biddingStrategies/{bidding_strategy_id}');
+        }
+
+        return self::$biddingStrategyNameTemplate;
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
+    private static function getCampaignAssetNameTemplate()
+    {
+        if (self::$campaignAssetNameTemplate == null) {
+            self::$campaignAssetNameTemplate = new PathTemplate('customers/{customer_id}/campaignAssets/{campaign_id}~{asset_id}~{field_type}');
+        }
+
+        return self::$campaignAssetNameTemplate;
+    }
+
+    private static function getCampaignAssetSetNameTemplate()
+    {
+        if (self::$campaignAssetSetNameTemplate == null) {
+            self::$campaignAssetSetNameTemplate = new PathTemplate('customers/{customer_id}/campaignAssetSets/{campaign_id}~{asset_set_id}');
+        }
+
+        return self::$campaignAssetSetNameTemplate;
+    }
+
+    private static function getCampaignBidModifierNameTemplate()
+    {
+        if (self::$campaignBidModifierNameTemplate == null) {
+            self::$campaignBidModifierNameTemplate = new PathTemplate('customers/{customer_id}/campaignBidModifiers/{campaign_id}~{criterion_id}');
+        }
+
+        return self::$campaignBidModifierNameTemplate;
+    }
+
+    private static function getCampaignBudgetNameTemplate()
+    {
+        if (self::$campaignBudgetNameTemplate == null) {
+            self::$campaignBudgetNameTemplate = new PathTemplate('customers/{customer_id}/campaignBudgets/{campaign_budget_id}');
+        }
+
+        return self::$campaignBudgetNameTemplate;
+    }
+
+    private static function getCampaignConversionGoalNameTemplate()
+    {
+        if (self::$campaignConversionGoalNameTemplate == null) {
+            self::$campaignConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/campaignConversionGoals/{campaign_id}~{category}~{source}');
+        }
+
+        return self::$campaignConversionGoalNameTemplate;
+    }
+
+    private static function getCampaignCriterionNameTemplate()
+    {
+        if (self::$campaignCriterionNameTemplate == null) {
+            self::$campaignCriterionNameTemplate = new PathTemplate('customers/{customer_id}/campaignCriteria/{campaign_id}~{criterion_id}');
+        }
+
+        return self::$campaignCriterionNameTemplate;
+    }
+
+    private static function getCampaignCustomizerNameTemplate()
+    {
+        if (self::$campaignCustomizerNameTemplate == null) {
+            self::$campaignCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/campaignCustomizers/{campaign_id}~{customizer_attribute_id}');
+        }
+
+        return self::$campaignCustomizerNameTemplate;
+    }
+
+    private static function getCampaignDraftNameTemplate()
+    {
+        if (self::$campaignDraftNameTemplate == null) {
+            self::$campaignDraftNameTemplate = new PathTemplate('customers/{customer_id}/campaignDrafts/{base_campaign_id}~{draft_id}');
+        }
+
+        return self::$campaignDraftNameTemplate;
+    }
+
+    private static function getCampaignExtensionSettingNameTemplate()
+    {
+        if (self::$campaignExtensionSettingNameTemplate == null) {
+            self::$campaignExtensionSettingNameTemplate = new PathTemplate('customers/{customer_id}/campaignExtensionSettings/{campaign_id}~{extension_type}');
+        }
+
+        return self::$campaignExtensionSettingNameTemplate;
+    }
+
+    private static function getCampaignFeedNameTemplate()
+    {
+        if (self::$campaignFeedNameTemplate == null) {
+            self::$campaignFeedNameTemplate = new PathTemplate('customers/{customer_id}/campaignFeeds/{campaign_id}~{feed_id}');
+        }
+
+        return self::$campaignFeedNameTemplate;
+    }
+
+    private static function getCampaignGroupNameTemplate()
+    {
+        if (self::$campaignGroupNameTemplate == null) {
+            self::$campaignGroupNameTemplate = new PathTemplate('customers/{customer_id}/campaignGroups/{campaign_group_id}');
+        }
+
+        return self::$campaignGroupNameTemplate;
+    }
+
+    private static function getCampaignLabelNameTemplate()
+    {
+        if (self::$campaignLabelNameTemplate == null) {
+            self::$campaignLabelNameTemplate = new PathTemplate('customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}');
+        }
+
+        return self::$campaignLabelNameTemplate;
+    }
+
+    private static function getCampaignSharedSetNameTemplate()
+    {
+        if (self::$campaignSharedSetNameTemplate == null) {
+            self::$campaignSharedSetNameTemplate = new PathTemplate('customers/{customer_id}/campaignSharedSets/{campaign_id}~{shared_set_id}');
+        }
+
+        return self::$campaignSharedSetNameTemplate;
+    }
+
+    private static function getConversionActionNameTemplate()
+    {
+        if (self::$conversionActionNameTemplate == null) {
+            self::$conversionActionNameTemplate = new PathTemplate('customers/{customer_id}/conversionActions/{conversion_action_id}');
+        }
+
+        return self::$conversionActionNameTemplate;
+    }
+
+    private static function getConversionCustomVariableNameTemplate()
+    {
+        if (self::$conversionCustomVariableNameTemplate == null) {
+            self::$conversionCustomVariableNameTemplate = new PathTemplate('customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}');
+        }
+
+        return self::$conversionCustomVariableNameTemplate;
+    }
+
+    private static function getConversionGoalCampaignConfigNameTemplate()
+    {
+        if (self::$conversionGoalCampaignConfigNameTemplate == null) {
+            self::$conversionGoalCampaignConfigNameTemplate = new PathTemplate('customers/{customer_id}/conversionGoalCampaignConfigs/{campaign_id}');
+        }
+
+        return self::$conversionGoalCampaignConfigNameTemplate;
+    }
+
+    private static function getConversionValueRuleNameTemplate()
+    {
+        if (self::$conversionValueRuleNameTemplate == null) {
+            self::$conversionValueRuleNameTemplate = new PathTemplate('customers/{customer_id}/conversionValueRules/{conversion_value_rule_id}');
+        }
+
+        return self::$conversionValueRuleNameTemplate;
+    }
+
+    private static function getConversionValueRuleSetNameTemplate()
+    {
+        if (self::$conversionValueRuleSetNameTemplate == null) {
+            self::$conversionValueRuleSetNameTemplate = new PathTemplate('customers/{customer_id}/conversionValueRuleSets/{conversion_value_rule_set_id}');
+        }
+
+        return self::$conversionValueRuleSetNameTemplate;
+    }
+
+    private static function getCustomConversionGoalNameTemplate()
+    {
+        if (self::$customConversionGoalNameTemplate == null) {
+            self::$customConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/customConversionGoals/{goal_id}');
+        }
+
+        return self::$customConversionGoalNameTemplate;
+    }
+
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
+    private static function getCustomerAssetNameTemplate()
+    {
+        if (self::$customerAssetNameTemplate == null) {
+            self::$customerAssetNameTemplate = new PathTemplate('customers/{customer_id}/customerAssets/{asset_id}~{field_type}');
+        }
+
+        return self::$customerAssetNameTemplate;
+    }
+
+    private static function getCustomerConversionGoalNameTemplate()
+    {
+        if (self::$customerConversionGoalNameTemplate == null) {
+            self::$customerConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/customerConversionGoals/{category}~{source}');
+        }
+
+        return self::$customerConversionGoalNameTemplate;
+    }
+
+    private static function getCustomerCustomizerNameTemplate()
+    {
+        if (self::$customerCustomizerNameTemplate == null) {
+            self::$customerCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/customerCustomizers/{customizer_attribute_id}');
+        }
+
+        return self::$customerCustomizerNameTemplate;
+    }
+
+    private static function getCustomerExtensionSettingNameTemplate()
+    {
+        if (self::$customerExtensionSettingNameTemplate == null) {
+            self::$customerExtensionSettingNameTemplate = new PathTemplate('customers/{customer_id}/customerExtensionSettings/{extension_type}');
+        }
+
+        return self::$customerExtensionSettingNameTemplate;
+    }
+
+    private static function getCustomerFeedNameTemplate()
+    {
+        if (self::$customerFeedNameTemplate == null) {
+            self::$customerFeedNameTemplate = new PathTemplate('customers/{customer_id}/customerFeeds/{feed_id}');
+        }
+
+        return self::$customerFeedNameTemplate;
+    }
+
+    private static function getCustomerLabelNameTemplate()
+    {
+        if (self::$customerLabelNameTemplate == null) {
+            self::$customerLabelNameTemplate = new PathTemplate('customers/{customer_id}/customerLabels/{label_id}');
+        }
+
+        return self::$customerLabelNameTemplate;
+    }
+
+    private static function getCustomerNegativeCriterionNameTemplate()
+    {
+        if (self::$customerNegativeCriterionNameTemplate == null) {
+            self::$customerNegativeCriterionNameTemplate = new PathTemplate('customers/{customer_id}/customerNegativeCriteria/{criterion_id}');
+        }
+
+        return self::$customerNegativeCriterionNameTemplate;
+    }
+
+    private static function getCustomizerAttributeNameTemplate()
+    {
+        if (self::$customizerAttributeNameTemplate == null) {
+            self::$customizerAttributeNameTemplate = new PathTemplate('customers/{customer_id}/customizerAttributes/{customizer_attribute_id}');
+        }
+
+        return self::$customizerAttributeNameTemplate;
+    }
+
+    private static function getExperimentNameTemplate()
+    {
+        if (self::$experimentNameTemplate == null) {
+            self::$experimentNameTemplate = new PathTemplate('customers/{customer_id}/experiments/{trial_id}');
+        }
+
+        return self::$experimentNameTemplate;
+    }
+
+    private static function getExperimentArmNameTemplate()
+    {
+        if (self::$experimentArmNameTemplate == null) {
+            self::$experimentArmNameTemplate = new PathTemplate('customers/{customer_id}/experimentArms/{trial_id}~{trial_arm_id}');
+        }
+
+        return self::$experimentArmNameTemplate;
+    }
+
+    private static function getExtensionFeedItemNameTemplate()
+    {
+        if (self::$extensionFeedItemNameTemplate == null) {
+            self::$extensionFeedItemNameTemplate = new PathTemplate('customers/{customer_id}/extensionFeedItems/{feed_item_id}');
+        }
+
+        return self::$extensionFeedItemNameTemplate;
+    }
+
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
+    private static function getFeedItemNameTemplate()
+    {
+        if (self::$feedItemNameTemplate == null) {
+            self::$feedItemNameTemplate = new PathTemplate('customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}');
+        }
+
+        return self::$feedItemNameTemplate;
+    }
+
+    private static function getFeedItemSetNameTemplate()
+    {
+        if (self::$feedItemSetNameTemplate == null) {
+            self::$feedItemSetNameTemplate = new PathTemplate('customers/{customer_id}/feedItemSets/{feed_id}~{feed_item_set_id}');
+        }
+
+        return self::$feedItemSetNameTemplate;
+    }
+
+    private static function getFeedItemSetLinkNameTemplate()
+    {
+        if (self::$feedItemSetLinkNameTemplate == null) {
+            self::$feedItemSetLinkNameTemplate = new PathTemplate('customers/{customer_id}/feedItemSetLinks/{feed_id}~{feed_item_set_id}~{feed_item_id}');
+        }
+
+        return self::$feedItemSetLinkNameTemplate;
+    }
+
+    private static function getFeedItemTargetNameTemplate()
+    {
+        if (self::$feedItemTargetNameTemplate == null) {
+            self::$feedItemTargetNameTemplate = new PathTemplate('customers/{customer_id}/feedItemTargets/{feed_id}~{feed_item_id}~{feed_item_target_type}~{feed_item_target_id}');
+        }
+
+        return self::$feedItemTargetNameTemplate;
+    }
+
+    private static function getFeedMappingNameTemplate()
+    {
+        if (self::$feedMappingNameTemplate == null) {
+            self::$feedMappingNameTemplate = new PathTemplate('customers/{customer_id}/feedMappings/{feed_id}~{feed_mapping_id}');
+        }
+
+        return self::$feedMappingNameTemplate;
+    }
+
+    private static function getGeoTargetConstantNameTemplate()
+    {
+        if (self::$geoTargetConstantNameTemplate == null) {
+            self::$geoTargetConstantNameTemplate = new PathTemplate('geoTargetConstants/{criterion_id}');
+        }
+
+        return self::$geoTargetConstantNameTemplate;
+    }
+
+    private static function getKeywordPlanNameTemplate()
+    {
+        if (self::$keywordPlanNameTemplate == null) {
+            self::$keywordPlanNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlans/{keyword_plan_id}');
+        }
+
+        return self::$keywordPlanNameTemplate;
+    }
+
+    private static function getKeywordPlanAdGroupNameTemplate()
+    {
+        if (self::$keywordPlanAdGroupNameTemplate == null) {
+            self::$keywordPlanAdGroupNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanAdGroups/{keyword_plan_ad_group_id}');
+        }
+
+        return self::$keywordPlanAdGroupNameTemplate;
+    }
+
+    private static function getKeywordPlanAdGroupKeywordNameTemplate()
+    {
+        if (self::$keywordPlanAdGroupKeywordNameTemplate == null) {
+            self::$keywordPlanAdGroupKeywordNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanAdGroupKeywords/{keyword_plan_ad_group_keyword_id}');
+        }
+
+        return self::$keywordPlanAdGroupKeywordNameTemplate;
+    }
+
+    private static function getKeywordPlanCampaignNameTemplate()
+    {
+        if (self::$keywordPlanCampaignNameTemplate == null) {
+            self::$keywordPlanCampaignNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}');
+        }
+
+        return self::$keywordPlanCampaignNameTemplate;
+    }
+
+    private static function getKeywordPlanCampaignKeywordNameTemplate()
+    {
+        if (self::$keywordPlanCampaignKeywordNameTemplate == null) {
+            self::$keywordPlanCampaignKeywordNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanCampaignKeywords/{keyword_plan_campaign_keyword_id}');
+        }
+
+        return self::$keywordPlanCampaignKeywordNameTemplate;
+    }
+
+    private static function getLabelNameTemplate()
+    {
+        if (self::$labelNameTemplate == null) {
+            self::$labelNameTemplate = new PathTemplate('customers/{customer_id}/labels/{label_id}');
+        }
+
+        return self::$labelNameTemplate;
+    }
+
+    private static function getLanguageConstantNameTemplate()
+    {
+        if (self::$languageConstantNameTemplate == null) {
+            self::$languageConstantNameTemplate = new PathTemplate('languageConstants/{criterion_id}');
+        }
+
+        return self::$languageConstantNameTemplate;
+    }
+
+    private static function getMediaFileNameTemplate()
+    {
+        if (self::$mediaFileNameTemplate == null) {
+            self::$mediaFileNameTemplate = new PathTemplate('customers/{customer_id}/mediaFiles/{media_file_id}');
+        }
+
+        return self::$mediaFileNameTemplate;
+    }
+
+    private static function getRemarketingActionNameTemplate()
+    {
+        if (self::$remarketingActionNameTemplate == null) {
+            self::$remarketingActionNameTemplate = new PathTemplate('customers/{customer_id}/remarketingActions/{remarketing_action_id}');
+        }
+
+        return self::$remarketingActionNameTemplate;
+    }
+
+    private static function getSharedCriterionNameTemplate()
+    {
+        if (self::$sharedCriterionNameTemplate == null) {
+            self::$sharedCriterionNameTemplate = new PathTemplate('customers/{customer_id}/sharedCriteria/{shared_set_id}~{criterion_id}');
+        }
+
+        return self::$sharedCriterionNameTemplate;
+    }
+
+    private static function getSharedSetNameTemplate()
+    {
+        if (self::$sharedSetNameTemplate == null) {
+            self::$sharedSetNameTemplate = new PathTemplate('customers/{customer_id}/sharedSets/{shared_set_id}');
+        }
+
+        return self::$sharedSetNameTemplate;
+    }
+
+    private static function getSmartCampaignSettingNameTemplate()
+    {
+        if (self::$smartCampaignSettingNameTemplate == null) {
+            self::$smartCampaignSettingNameTemplate = new PathTemplate('customers/{customer_id}/smartCampaignSettings/{campaign_id}');
+        }
+
+        return self::$smartCampaignSettingNameTemplate;
+    }
+
+    private static function getUserInterestNameTemplate()
+    {
+        if (self::$userInterestNameTemplate == null) {
+            self::$userInterestNameTemplate = new PathTemplate('customers/{customer_id}/userInterests/{user_interest_id}');
+        }
+
+        return self::$userInterestNameTemplate;
+    }
+
+    private static function getUserListNameTemplate()
+    {
+        if (self::$userListNameTemplate == null) {
+            self::$userListNameTemplate = new PathTemplate('customers/{customer_id}/userLists/{user_list_id}');
+        }
+
+        return self::$userListNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'accessibleBiddingStrategy' => self::getAccessibleBiddingStrategyNameTemplate(),
+                'ad' => self::getAdNameTemplate(),
+                'adGroup' => self::getAdGroupNameTemplate(),
+                'adGroupAd' => self::getAdGroupAdNameTemplate(),
+                'adGroupAdLabel' => self::getAdGroupAdLabelNameTemplate(),
+                'adGroupAsset' => self::getAdGroupAssetNameTemplate(),
+                'adGroupBidModifier' => self::getAdGroupBidModifierNameTemplate(),
+                'adGroupCriterion' => self::getAdGroupCriterionNameTemplate(),
+                'adGroupCriterionCustomizer' => self::getAdGroupCriterionCustomizerNameTemplate(),
+                'adGroupCriterionLabel' => self::getAdGroupCriterionLabelNameTemplate(),
+                'adGroupCustomizer' => self::getAdGroupCustomizerNameTemplate(),
+                'adGroupExtensionSetting' => self::getAdGroupExtensionSettingNameTemplate(),
+                'adGroupFeed' => self::getAdGroupFeedNameTemplate(),
+                'adGroupLabel' => self::getAdGroupLabelNameTemplate(),
+                'adParameter' => self::getAdParameterNameTemplate(),
+                'asset' => self::getAssetNameTemplate(),
+                'assetGroup' => self::getAssetGroupNameTemplate(),
+                'assetGroupAsset' => self::getAssetGroupAssetNameTemplate(),
+                'assetGroupListingGroupFilter' => self::getAssetGroupListingGroupFilterNameTemplate(),
+                'assetGroupSignal' => self::getAssetGroupSignalNameTemplate(),
+                'assetSet' => self::getAssetSetNameTemplate(),
+                'assetSetAsset' => self::getAssetSetAssetNameTemplate(),
+                'audience' => self::getAudienceNameTemplate(),
                 'batchJob' => self::getBatchJobNameTemplate(),
+                'biddingDataExclusion' => self::getBiddingDataExclusionNameTemplate(),
+                'biddingSeasonalityAdjustment' => self::getBiddingSeasonalityAdjustmentNameTemplate(),
+                'biddingStrategy' => self::getBiddingStrategyNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
+                'campaignAsset' => self::getCampaignAssetNameTemplate(),
+                'campaignAssetSet' => self::getCampaignAssetSetNameTemplate(),
+                'campaignBidModifier' => self::getCampaignBidModifierNameTemplate(),
+                'campaignBudget' => self::getCampaignBudgetNameTemplate(),
+                'campaignConversionGoal' => self::getCampaignConversionGoalNameTemplate(),
+                'campaignCriterion' => self::getCampaignCriterionNameTemplate(),
+                'campaignCustomizer' => self::getCampaignCustomizerNameTemplate(),
+                'campaignDraft' => self::getCampaignDraftNameTemplate(),
+                'campaignExtensionSetting' => self::getCampaignExtensionSettingNameTemplate(),
+                'campaignFeed' => self::getCampaignFeedNameTemplate(),
+                'campaignGroup' => self::getCampaignGroupNameTemplate(),
+                'campaignLabel' => self::getCampaignLabelNameTemplate(),
+                'campaignSharedSet' => self::getCampaignSharedSetNameTemplate(),
+                'conversionAction' => self::getConversionActionNameTemplate(),
+                'conversionCustomVariable' => self::getConversionCustomVariableNameTemplate(),
+                'conversionGoalCampaignConfig' => self::getConversionGoalCampaignConfigNameTemplate(),
+                'conversionValueRule' => self::getConversionValueRuleNameTemplate(),
+                'conversionValueRuleSet' => self::getConversionValueRuleSetNameTemplate(),
+                'customConversionGoal' => self::getCustomConversionGoalNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
+                'customerAsset' => self::getCustomerAssetNameTemplate(),
+                'customerConversionGoal' => self::getCustomerConversionGoalNameTemplate(),
+                'customerCustomizer' => self::getCustomerCustomizerNameTemplate(),
+                'customerExtensionSetting' => self::getCustomerExtensionSettingNameTemplate(),
+                'customerFeed' => self::getCustomerFeedNameTemplate(),
+                'customerLabel' => self::getCustomerLabelNameTemplate(),
+                'customerNegativeCriterion' => self::getCustomerNegativeCriterionNameTemplate(),
+                'customizerAttribute' => self::getCustomizerAttributeNameTemplate(),
+                'experiment' => self::getExperimentNameTemplate(),
+                'experimentArm' => self::getExperimentArmNameTemplate(),
+                'extensionFeedItem' => self::getExtensionFeedItemNameTemplate(),
+                'feed' => self::getFeedNameTemplate(),
+                'feedItem' => self::getFeedItemNameTemplate(),
+                'feedItemSet' => self::getFeedItemSetNameTemplate(),
+                'feedItemSetLink' => self::getFeedItemSetLinkNameTemplate(),
+                'feedItemTarget' => self::getFeedItemTargetNameTemplate(),
+                'feedMapping' => self::getFeedMappingNameTemplate(),
+                'geoTargetConstant' => self::getGeoTargetConstantNameTemplate(),
+                'keywordPlan' => self::getKeywordPlanNameTemplate(),
+                'keywordPlanAdGroup' => self::getKeywordPlanAdGroupNameTemplate(),
+                'keywordPlanAdGroupKeyword' => self::getKeywordPlanAdGroupKeywordNameTemplate(),
+                'keywordPlanCampaign' => self::getKeywordPlanCampaignNameTemplate(),
+                'keywordPlanCampaignKeyword' => self::getKeywordPlanCampaignKeywordNameTemplate(),
+                'label' => self::getLabelNameTemplate(),
+                'languageConstant' => self::getLanguageConstantNameTemplate(),
+                'mediaFile' => self::getMediaFileNameTemplate(),
+                'remarketingAction' => self::getRemarketingActionNameTemplate(),
+                'sharedCriterion' => self::getSharedCriterionNameTemplate(),
+                'sharedSet' => self::getSharedSetNameTemplate(),
+                'smartCampaignSetting' => self::getSmartCampaignSettingNameTemplate(),
+                'userInterest' => self::getUserInterestNameTemplate(),
+                'userList' => self::getUserListNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * accessible_bidding_strategy resource.
+     *
+     * @param string $customerId
+     * @param string $biddingStrategyId
+     *
+     * @return string The formatted accessible_bidding_strategy resource.
+     */
+    public static function accessibleBiddingStrategyName($customerId, $biddingStrategyId)
+    {
+        return self::getAccessibleBiddingStrategyNameTemplate()->render([
+            'customer_id' => $customerId,
+            'bidding_strategy_id' => $biddingStrategyId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad resource.
+     *
+     * @param string $customerId
+     * @param string $adId
+     *
+     * @return string The formatted ad resource.
+     */
+    public static function adName($customerId, $adId)
+    {
+        return self::getAdNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_id' => $adId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group_ad
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     *
+     * @return string The formatted ad_group_ad resource.
+     */
+    public static function adGroupAdName($customerId, $adGroupId, $adId)
+    {
+        return self::getAdGroupAdNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'ad_id' => $adId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_ad_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_ad_label resource.
+     */
+    public static function adGroupAdLabelName($customerId, $adGroupId, $adId, $labelId)
+    {
+        return self::getAdGroupAdLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'ad_id' => $adId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_asset resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted ad_group_asset resource.
+     */
+    public static function adGroupAssetName($customerId, $adGroupId, $assetId, $fieldType)
+    {
+        return self::getAdGroupAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_bid_modifier resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted ad_group_bid_modifier resource.
+     */
+    public static function adGroupBidModifierName($customerId, $adGroupId, $criterionId)
+    {
+        return self::getAdGroupBidModifierNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted ad_group_criterion resource.
+     */
+    public static function adGroupCriterionName($customerId, $adGroupId, $criterionId)
+    {
+        return self::getAdGroupCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted ad_group_criterion_customizer resource.
+     */
+    public static function adGroupCriterionCustomizerName($customerId, $adGroupId, $criterionId, $customizerAttributeId)
+    {
+        return self::getAdGroupCriterionCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_criterion_label resource.
+     */
+    public static function adGroupCriterionLabelName($customerId, $adGroupId, $criterionId, $labelId)
+    {
+        return self::getAdGroupCriterionLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted ad_group_customizer resource.
+     */
+    public static function adGroupCustomizerName($customerId, $adGroupId, $customizerAttributeId)
+    {
+        return self::getAdGroupCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_extension_setting resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $extensionType
+     *
+     * @return string The formatted ad_group_extension_setting resource.
+     */
+    public static function adGroupExtensionSettingName($customerId, $adGroupId, $extensionType)
+    {
+        return self::getAdGroupExtensionSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'extension_type' => $extensionType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_feed resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $feedId
+     *
+     * @return string The formatted ad_group_feed resource.
+     */
+    public static function adGroupFeedName($customerId, $adGroupId, $feedId)
+    {
+        return self::getAdGroupFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_label resource.
+     */
+    public static function adGroupLabelName($customerId, $adGroupId, $labelId)
+    {
+        return self::getAdGroupLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_parameter
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $parameterIndex
+     *
+     * @return string The formatted ad_parameter resource.
+     */
+    public static function adParameterName($customerId, $adGroupId, $criterionId, $parameterIndex)
+    {
+        return self::getAdParameterNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+            'parameter_index' => $parameterIndex,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     *
+     * @return string The formatted asset_group resource.
+     */
+    public static function assetGroupName($customerId, $assetGroupId)
+    {
+        return self::getAssetGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_group_asset resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted asset_group_asset resource.
+     */
+    public static function assetGroupAssetName($customerId, $assetGroupId, $assetId, $fieldType)
+    {
+        return self::getAssetGroupAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_group_listing_group_filter resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     * @param string $listingGroupFilterId
+     *
+     * @return string The formatted asset_group_listing_group_filter resource.
+     */
+    public static function assetGroupListingGroupFilterName($customerId, $assetGroupId, $listingGroupFilterId)
+    {
+        return self::getAssetGroupListingGroupFilterNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+            'listing_group_filter_id' => $listingGroupFilterId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_group_signal resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted asset_group_signal resource.
+     */
+    public static function assetGroupSignalName($customerId, $assetGroupId, $criterionId)
+    {
+        return self::getAssetGroupSignalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     *
+     * @return string The formatted asset_set resource.
+     */
+    public static function assetSetName($customerId, $assetSetId)
+    {
+        return self::getAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_set_asset resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     * @param string $assetId
+     *
+     * @return string The formatted asset_set_asset resource.
+     */
+    public static function assetSetAssetName($customerId, $assetSetId, $assetId)
+    {
+        return self::getAssetSetAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a audience
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $audienceId
+     *
+     * @return string The formatted audience resource.
+     */
+    public static function audienceName($customerId, $audienceId)
+    {
+        return self::getAudienceNameTemplate()->render([
+            'customer_id' => $customerId,
+            'audience_id' => $audienceId,
+        ]);
     }
 
     /**
@@ -153,10 +1535,1085 @@ class BatchJobServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * bidding_data_exclusion resource.
+     *
+     * @param string $customerId
+     * @param string $seasonalityEventId
+     *
+     * @return string The formatted bidding_data_exclusion resource.
+     */
+    public static function biddingDataExclusionName($customerId, $seasonalityEventId)
+    {
+        return self::getBiddingDataExclusionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'seasonality_event_id' => $seasonalityEventId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * bidding_seasonality_adjustment resource.
+     *
+     * @param string $customerId
+     * @param string $seasonalityEventId
+     *
+     * @return string The formatted bidding_seasonality_adjustment resource.
+     */
+    public static function biddingSeasonalityAdjustmentName($customerId, $seasonalityEventId)
+    {
+        return self::getBiddingSeasonalityAdjustmentNameTemplate()->render([
+            'customer_id' => $customerId,
+            'seasonality_event_id' => $seasonalityEventId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * bidding_strategy resource.
+     *
+     * @param string $customerId
+     * @param string $biddingStrategyId
+     *
+     * @return string The formatted bidding_strategy resource.
+     */
+    public static function biddingStrategyName($customerId, $biddingStrategyId)
+    {
+        return self::getBiddingStrategyNameTemplate()->render([
+            'customer_id' => $customerId,
+            'bidding_strategy_id' => $biddingStrategyId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_asset resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted campaign_asset resource.
+     */
+    public static function campaignAssetName($customerId, $campaignId, $assetId, $fieldType)
+    {
+        return self::getCampaignAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_asset_set resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $assetSetId
+     *
+     * @return string The formatted campaign_asset_set resource.
+     */
+    public static function campaignAssetSetName($customerId, $campaignId, $assetSetId)
+    {
+        return self::getCampaignAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_bid_modifier resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
+     *
+     * @return string The formatted campaign_bid_modifier resource.
+     */
+    public static function campaignBidModifierName($customerId, $campaignId, $criterionId)
+    {
+        return self::getCampaignBidModifierNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_budget resource.
+     *
+     * @param string $customerId
+     * @param string $campaignBudgetId
+     *
+     * @return string The formatted campaign_budget resource.
+     */
+    public static function campaignBudgetName($customerId, $campaignBudgetId)
+    {
+        return self::getCampaignBudgetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_budget_id' => $campaignBudgetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $category
+     * @param string $source
+     *
+     * @return string The formatted campaign_conversion_goal resource.
+     */
+    public static function campaignConversionGoalName($customerId, $campaignId, $category, $source)
+    {
+        return self::getCampaignConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'category' => $category,
+            'source' => $source,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
+     *
+     * @return string The formatted campaign_criterion resource.
+     */
+    public static function campaignCriterionName($customerId, $campaignId, $criterionId)
+    {
+        return self::getCampaignCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted campaign_customizer resource.
+     */
+    public static function campaignCustomizerName($customerId, $campaignId, $customizerAttributeId)
+    {
+        return self::getCampaignCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_draft resource.
+     *
+     * @param string $customerId
+     * @param string $baseCampaignId
+     * @param string $draftId
+     *
+     * @return string The formatted campaign_draft resource.
+     */
+    public static function campaignDraftName($customerId, $baseCampaignId, $draftId)
+    {
+        return self::getCampaignDraftNameTemplate()->render([
+            'customer_id' => $customerId,
+            'base_campaign_id' => $baseCampaignId,
+            'draft_id' => $draftId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_extension_setting resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $extensionType
+     *
+     * @return string The formatted campaign_extension_setting resource.
+     */
+    public static function campaignExtensionSettingName($customerId, $campaignId, $extensionType)
+    {
+        return self::getCampaignExtensionSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'extension_type' => $extensionType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_feed resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $feedId
+     *
+     * @return string The formatted campaign_feed resource.
+     */
+    public static function campaignFeedName($customerId, $campaignId, $feedId)
+    {
+        return self::getCampaignFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_group resource.
+     *
+     * @param string $customerId
+     * @param string $campaignGroupId
+     *
+     * @return string The formatted campaign_group resource.
+     */
+    public static function campaignGroupName($customerId, $campaignGroupId)
+    {
+        return self::getCampaignGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_group_id' => $campaignGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_label resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $labelId
+     *
+     * @return string The formatted campaign_label resource.
+     */
+    public static function campaignLabelName($customerId, $campaignId, $labelId)
+    {
+        return self::getCampaignLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_shared_set resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $sharedSetId
+     *
+     * @return string The formatted campaign_shared_set resource.
+     */
+    public static function campaignSharedSetName($customerId, $campaignId, $sharedSetId)
+    {
+        return self::getCampaignSharedSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'shared_set_id' => $sharedSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_action resource.
+     *
+     * @param string $customerId
+     * @param string $conversionActionId
+     *
+     * @return string The formatted conversion_action resource.
+     */
+    public static function conversionActionName($customerId, $conversionActionId)
+    {
+        return self::getConversionActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_action_id' => $conversionActionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_custom_variable resource.
+     *
+     * @param string $customerId
+     * @param string $conversionCustomVariableId
+     *
+     * @return string The formatted conversion_custom_variable resource.
+     */
+    public static function conversionCustomVariableName($customerId, $conversionCustomVariableId)
+    {
+        return self::getConversionCustomVariableNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_custom_variable_id' => $conversionCustomVariableId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_goal_campaign_config resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted conversion_goal_campaign_config resource.
+     */
+    public static function conversionGoalCampaignConfigName($customerId, $campaignId)
+    {
+        return self::getConversionGoalCampaignConfigNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_value_rule resource.
+     *
+     * @param string $customerId
+     * @param string $conversionValueRuleId
+     *
+     * @return string The formatted conversion_value_rule resource.
+     */
+    public static function conversionValueRuleName($customerId, $conversionValueRuleId)
+    {
+        return self::getConversionValueRuleNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_value_rule_id' => $conversionValueRuleId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_value_rule_set resource.
+     *
+     * @param string $customerId
+     * @param string $conversionValueRuleSetId
+     *
+     * @return string The formatted conversion_value_rule_set resource.
+     */
+    public static function conversionValueRuleSetName($customerId, $conversionValueRuleSetId)
+    {
+        return self::getConversionValueRuleSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_value_rule_set_id' => $conversionValueRuleSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * custom_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $goalId
+     *
+     * @return string The formatted custom_conversion_goal resource.
+     */
+    public static function customConversionGoalName($customerId, $goalId)
+    {
+        return self::getCustomConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'goal_id' => $goalId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_asset resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted customer_asset resource.
+     */
+    public static function customerAssetName($customerId, $assetId, $fieldType)
+    {
+        return self::getCustomerAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $category
+     * @param string $source
+     *
+     * @return string The formatted customer_conversion_goal resource.
+     */
+    public static function customerConversionGoalName($customerId, $category, $source)
+    {
+        return self::getCustomerConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'category' => $category,
+            'source' => $source,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customer_customizer resource.
+     */
+    public static function customerCustomizerName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomerCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_extension_setting resource.
+     *
+     * @param string $customerId
+     * @param string $extensionType
+     *
+     * @return string The formatted customer_extension_setting resource.
+     */
+    public static function customerExtensionSettingName($customerId, $extensionType)
+    {
+        return self::getCustomerExtensionSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'extension_type' => $extensionType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_feed resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted customer_feed resource.
+     */
+    public static function customerFeedName($customerId, $feedId)
+    {
+        return self::getCustomerFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_label resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted customer_label resource.
+     */
+    public static function customerLabelName($customerId, $labelId)
+    {
+        return self::getCustomerLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_negative_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $criterionId
+     *
+     * @return string The formatted customer_negative_criterion resource.
+     */
+    public static function customerNegativeCriterionName($customerId, $criterionId)
+    {
+        return self::getCustomerNegativeCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customizer_attribute resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customizer_attribute resource.
+     */
+    public static function customizerAttributeName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomizerAttributeNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a experiment
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $trialId
+     *
+     * @return string The formatted experiment resource.
+     */
+    public static function experimentName($customerId, $trialId)
+    {
+        return self::getExperimentNameTemplate()->render([
+            'customer_id' => $customerId,
+            'trial_id' => $trialId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * experiment_arm resource.
+     *
+     * @param string $customerId
+     * @param string $trialId
+     * @param string $trialArmId
+     *
+     * @return string The formatted experiment_arm resource.
+     */
+    public static function experimentArmName($customerId, $trialId, $trialArmId)
+    {
+        return self::getExperimentArmNameTemplate()->render([
+            'customer_id' => $customerId,
+            'trial_id' => $trialId,
+            'trial_arm_id' => $trialArmId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * extension_feed_item resource.
+     *
+     * @param string $customerId
+     * @param string $feedItemId
+     *
+     * @return string The formatted extension_feed_item resource.
+     */
+    public static function extensionFeedItemName($customerId, $feedItemId)
+    {
+        return self::getExtensionFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed_item
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     *
+     * @return string The formatted feed_item resource.
+     */
+    public static function feedItemName($customerId, $feedId, $feedItemId)
+    {
+        return self::getFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * feed_item_set resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
+     *
+     * @return string The formatted feed_item_set resource.
+     */
+    public static function feedItemSetName($customerId, $feedId, $feedItemSetId)
+    {
+        return self::getFeedItemSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_set_id' => $feedItemSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * feed_item_set_link resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
+     * @param string $feedItemId
+     *
+     * @return string The formatted feed_item_set_link resource.
+     */
+    public static function feedItemSetLinkName($customerId, $feedId, $feedItemSetId, $feedItemId)
+    {
+        return self::getFeedItemSetLinkNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_set_id' => $feedItemSetId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * feed_item_target resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     * @param string $feedItemTargetType
+     * @param string $feedItemTargetId
+     *
+     * @return string The formatted feed_item_target resource.
+     */
+    public static function feedItemTargetName($customerId, $feedId, $feedItemId, $feedItemTargetType, $feedItemTargetId)
+    {
+        return self::getFeedItemTargetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_id' => $feedItemId,
+            'feed_item_target_type' => $feedItemTargetType,
+            'feed_item_target_id' => $feedItemTargetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed_mapping
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedMappingId
+     *
+     * @return string The formatted feed_mapping resource.
+     */
+    public static function feedMappingName($customerId, $feedId, $feedMappingId)
+    {
+        return self::getFeedMappingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_mapping_id' => $feedMappingId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * geo_target_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted geo_target_constant resource.
+     */
+    public static function geoTargetConstantName($criterionId)
+    {
+        return self::getGeoTargetConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a keyword_plan
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanId
+     *
+     * @return string The formatted keyword_plan resource.
+     */
+    public static function keywordPlanName($customerId, $keywordPlanId)
+    {
+        return self::getKeywordPlanNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_id' => $keywordPlanId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_ad_group resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupId
+     *
+     * @return string The formatted keyword_plan_ad_group resource.
+     */
+    public static function keywordPlanAdGroupName($customerId, $keywordPlanAdGroupId)
+    {
+        return self::getKeywordPlanAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_ad_group_id' => $keywordPlanAdGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_ad_group_keyword resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupKeywordId
+     *
+     * @return string The formatted keyword_plan_ad_group_keyword resource.
+     */
+    public static function keywordPlanAdGroupKeywordName($customerId, $keywordPlanAdGroupKeywordId)
+    {
+        return self::getKeywordPlanAdGroupKeywordNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_ad_group_keyword_id' => $keywordPlanAdGroupKeywordId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_campaign resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanCampaignId
+     *
+     * @return string The formatted keyword_plan_campaign resource.
+     */
+    public static function keywordPlanCampaignName($customerId, $keywordPlanCampaignId)
+    {
+        return self::getKeywordPlanCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_campaign_id' => $keywordPlanCampaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_campaign_keyword resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanCampaignKeywordId
+     *
+     * @return string The formatted keyword_plan_campaign_keyword resource.
+     */
+    public static function keywordPlanCampaignKeywordName($customerId, $keywordPlanCampaignKeywordId)
+    {
+        return self::getKeywordPlanCampaignKeywordNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_campaign_keyword_id' => $keywordPlanCampaignKeywordId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a label
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted label resource.
+     */
+    public static function labelName($customerId, $labelId)
+    {
+        return self::getLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * language_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted language_constant resource.
+     */
+    public static function languageConstantName($criterionId)
+    {
+        return self::getLanguageConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a media_file
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $mediaFileId
+     *
+     * @return string The formatted media_file resource.
+     */
+    public static function mediaFileName($customerId, $mediaFileId)
+    {
+        return self::getMediaFileNameTemplate()->render([
+            'customer_id' => $customerId,
+            'media_file_id' => $mediaFileId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * remarketing_action resource.
+     *
+     * @param string $customerId
+     * @param string $remarketingActionId
+     *
+     * @return string The formatted remarketing_action resource.
+     */
+    public static function remarketingActionName($customerId, $remarketingActionId)
+    {
+        return self::getRemarketingActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'remarketing_action_id' => $remarketingActionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * shared_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $sharedSetId
+     * @param string $criterionId
+     *
+     * @return string The formatted shared_criterion resource.
+     */
+    public static function sharedCriterionName($customerId, $sharedSetId, $criterionId)
+    {
+        return self::getSharedCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'shared_set_id' => $sharedSetId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a shared_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $sharedSetId
+     *
+     * @return string The formatted shared_set resource.
+     */
+    public static function sharedSetName($customerId, $sharedSetId)
+    {
+        return self::getSharedSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'shared_set_id' => $sharedSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * smart_campaign_setting resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted smart_campaign_setting resource.
+     */
+    public static function smartCampaignSettingName($customerId, $campaignId)
+    {
+        return self::getSmartCampaignSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * user_interest resource.
+     *
+     * @param string $customerId
+     * @param string $userInterestId
+     *
+     * @return string The formatted user_interest resource.
+     */
+    public static function userInterestName($customerId, $userInterestId)
+    {
+        return self::getUserInterestNameTemplate()->render([
+            'customer_id' => $customerId,
+            'user_interest_id' => $userInterestId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a user_list
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $userListId
+     *
+     * @return string The formatted user_list resource.
+     */
+    public static function userListName($customerId, $userListId)
+    {
+        return self::getUserListNameTemplate()->render([
+            'customer_id' => $customerId,
+            'user_list_id' => $userListId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - accessibleBiddingStrategy: customers/{customer_id}/accessibleBiddingStrategies/{bidding_strategy_id}
+     * - ad: customers/{customer_id}/ads/{ad_id}
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
+     * - adGroupAd: customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}
+     * - adGroupAdLabel: customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}
+     * - adGroupAsset: customers/{customer_id}/adGroupAssets/{ad_group_id}~{asset_id}~{field_type}
+     * - adGroupBidModifier: customers/{customer_id}/adGroupBidModifiers/{ad_group_id}~{criterion_id}
+     * - adGroupCriterion: customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}
+     * - adGroupCriterionCustomizer: customers/{customer_id}/adGroupCriterionCustomizers/{ad_group_id}~{criterion_id}~{customizer_attribute_id}
+     * - adGroupCriterionLabel: customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}
+     * - adGroupCustomizer: customers/{customer_id}/adGroupCustomizers/{ad_group_id}~{customizer_attribute_id}
+     * - adGroupExtensionSetting: customers/{customer_id}/adGroupExtensionSettings/{ad_group_id}~{extension_type}
+     * - adGroupFeed: customers/{customer_id}/adGroupFeeds/{ad_group_id}~{feed_id}
+     * - adGroupLabel: customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}
+     * - adParameter: customers/{customer_id}/adParameters/{ad_group_id}~{criterion_id}~{parameter_index}
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - assetGroup: customers/{customer_id}/assetGroups/{asset_group_id}
+     * - assetGroupAsset: customers/{customer_id}/assetGroupAssets/{asset_group_id}~{asset_id}~{field_type}
+     * - assetGroupListingGroupFilter: customers/{customer_id}/assetGroupListingGroupFilters/{asset_group_id}~{listing_group_filter_id}
+     * - assetGroupSignal: customers/{customer_id}/assetGroupSignals/{asset_group_id}~{criterion_id}
+     * - assetSet: customers/{customer_id}/assetSets/{asset_set_id}
+     * - assetSetAsset: customers/{customer_id}/assetSetAssets/{asset_set_id}~{asset_id}
+     * - audience: customers/{customer_id}/audiences/{audience_id}
      * - batchJob: customers/{customer_id}/batchJobs/{batch_job_id}
+     * - biddingDataExclusion: customers/{customer_id}/biddingDataExclusions/{seasonality_event_id}
+     * - biddingSeasonalityAdjustment: customers/{customer_id}/biddingSeasonalityAdjustments/{seasonality_event_id}
+     * - biddingStrategy: customers/{customer_id}/biddingStrategies/{bidding_strategy_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - campaignAsset: customers/{customer_id}/campaignAssets/{campaign_id}~{asset_id}~{field_type}
+     * - campaignAssetSet: customers/{customer_id}/campaignAssetSets/{campaign_id}~{asset_set_id}
+     * - campaignBidModifier: customers/{customer_id}/campaignBidModifiers/{campaign_id}~{criterion_id}
+     * - campaignBudget: customers/{customer_id}/campaignBudgets/{campaign_budget_id}
+     * - campaignConversionGoal: customers/{customer_id}/campaignConversionGoals/{campaign_id}~{category}~{source}
+     * - campaignCriterion: customers/{customer_id}/campaignCriteria/{campaign_id}~{criterion_id}
+     * - campaignCustomizer: customers/{customer_id}/campaignCustomizers/{campaign_id}~{customizer_attribute_id}
+     * - campaignDraft: customers/{customer_id}/campaignDrafts/{base_campaign_id}~{draft_id}
+     * - campaignExtensionSetting: customers/{customer_id}/campaignExtensionSettings/{campaign_id}~{extension_type}
+     * - campaignFeed: customers/{customer_id}/campaignFeeds/{campaign_id}~{feed_id}
+     * - campaignGroup: customers/{customer_id}/campaignGroups/{campaign_group_id}
+     * - campaignLabel: customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}
+     * - campaignSharedSet: customers/{customer_id}/campaignSharedSets/{campaign_id}~{shared_set_id}
+     * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
+     * - conversionCustomVariable: customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}
+     * - conversionGoalCampaignConfig: customers/{customer_id}/conversionGoalCampaignConfigs/{campaign_id}
+     * - conversionValueRule: customers/{customer_id}/conversionValueRules/{conversion_value_rule_id}
+     * - conversionValueRuleSet: customers/{customer_id}/conversionValueRuleSets/{conversion_value_rule_set_id}
+     * - customConversionGoal: customers/{customer_id}/customConversionGoals/{goal_id}
+     * - customer: customers/{customer_id}
+     * - customerAsset: customers/{customer_id}/customerAssets/{asset_id}~{field_type}
+     * - customerConversionGoal: customers/{customer_id}/customerConversionGoals/{category}~{source}
+     * - customerCustomizer: customers/{customer_id}/customerCustomizers/{customizer_attribute_id}
+     * - customerExtensionSetting: customers/{customer_id}/customerExtensionSettings/{extension_type}
+     * - customerFeed: customers/{customer_id}/customerFeeds/{feed_id}
+     * - customerLabel: customers/{customer_id}/customerLabels/{label_id}
+     * - customerNegativeCriterion: customers/{customer_id}/customerNegativeCriteria/{criterion_id}
+     * - customizerAttribute: customers/{customer_id}/customizerAttributes/{customizer_attribute_id}
+     * - experiment: customers/{customer_id}/experiments/{trial_id}
+     * - experimentArm: customers/{customer_id}/experimentArms/{trial_id}~{trial_arm_id}
+     * - extensionFeedItem: customers/{customer_id}/extensionFeedItems/{feed_item_id}
+     * - feed: customers/{customer_id}/feeds/{feed_id}
+     * - feedItem: customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}
+     * - feedItemSet: customers/{customer_id}/feedItemSets/{feed_id}~{feed_item_set_id}
+     * - feedItemSetLink: customers/{customer_id}/feedItemSetLinks/{feed_id}~{feed_item_set_id}~{feed_item_id}
+     * - feedItemTarget: customers/{customer_id}/feedItemTargets/{feed_id}~{feed_item_id}~{feed_item_target_type}~{feed_item_target_id}
+     * - feedMapping: customers/{customer_id}/feedMappings/{feed_id}~{feed_mapping_id}
+     * - geoTargetConstant: geoTargetConstants/{criterion_id}
+     * - keywordPlan: customers/{customer_id}/keywordPlans/{keyword_plan_id}
+     * - keywordPlanAdGroup: customers/{customer_id}/keywordPlanAdGroups/{keyword_plan_ad_group_id}
+     * - keywordPlanAdGroupKeyword: customers/{customer_id}/keywordPlanAdGroupKeywords/{keyword_plan_ad_group_keyword_id}
+     * - keywordPlanCampaign: customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}
+     * - keywordPlanCampaignKeyword: customers/{customer_id}/keywordPlanCampaignKeywords/{keyword_plan_campaign_keyword_id}
+     * - label: customers/{customer_id}/labels/{label_id}
+     * - languageConstant: languageConstants/{criterion_id}
+     * - mediaFile: customers/{customer_id}/mediaFiles/{media_file_id}
+     * - remarketingAction: customers/{customer_id}/remarketingActions/{remarketing_action_id}
+     * - sharedCriterion: customers/{customer_id}/sharedCriteria/{shared_set_id}~{criterion_id}
+     * - sharedSet: customers/{customer_id}/sharedSets/{shared_set_id}
+     * - smartCampaignSetting: customers/{customer_id}/smartCampaignSettings/{campaign_id}
+     * - userInterest: customers/{customer_id}/userInterests/{user_interest_id}
+     * - userList: customers/{customer_id}/userLists/{user_list_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/BiddingDataExclusionServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/BiddingDataExclusionServiceGapicClient.php
@@ -82,6 +82,8 @@ class BiddingDataExclusionServiceGapicClient
 
     private static $biddingDataExclusionNameTemplate;
 
+    private static $campaignNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class BiddingDataExclusionServiceGapicClient
         return self::$biddingDataExclusionNameTemplate;
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'biddingDataExclusion' => self::getBiddingDataExclusionNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
             ];
         }
 
@@ -141,10 +153,28 @@ class BiddingDataExclusionServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - biddingDataExclusion: customers/{customer_id}/biddingDataExclusions/{seasonality_event_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/BiddingSeasonalityAdjustmentServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/BiddingSeasonalityAdjustmentServiceGapicClient.php
@@ -82,6 +82,8 @@ class BiddingSeasonalityAdjustmentServiceGapicClient
 
     private static $biddingSeasonalityAdjustmentNameTemplate;
 
+    private static $campaignNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class BiddingSeasonalityAdjustmentServiceGapicClient
         return self::$biddingSeasonalityAdjustmentNameTemplate;
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'biddingSeasonalityAdjustment' => self::getBiddingSeasonalityAdjustmentNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
             ];
         }
 
@@ -141,10 +153,28 @@ class BiddingSeasonalityAdjustmentServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - biddingSeasonalityAdjustment: customers/{customer_id}/biddingSeasonalityAdjustments/{seasonality_event_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/BillingSetupServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/BillingSetupServiceGapicClient.php
@@ -90,6 +90,8 @@ class BillingSetupServiceGapicClient
 
     private static $billingSetupNameTemplate;
 
+    private static $paymentsAccountNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -120,11 +122,21 @@ class BillingSetupServiceGapicClient
         return self::$billingSetupNameTemplate;
     }
 
+    private static function getPaymentsAccountNameTemplate()
+    {
+        if (self::$paymentsAccountNameTemplate == null) {
+            self::$paymentsAccountNameTemplate = new PathTemplate('customers/{customer_id}/paymentsAccounts/{payments_account_id}');
+        }
+
+        return self::$paymentsAccountNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'billingSetup' => self::getBillingSetupNameTemplate(),
+                'paymentsAccount' => self::getPaymentsAccountNameTemplate(),
             ];
         }
 
@@ -149,10 +161,28 @@ class BillingSetupServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * payments_account resource.
+     *
+     * @param string $customerId
+     * @param string $paymentsAccountId
+     *
+     * @return string The formatted payments_account resource.
+     */
+    public static function paymentsAccountName($customerId, $paymentsAccountId)
+    {
+        return self::getPaymentsAccountNameTemplate()->render([
+            'customer_id' => $customerId,
+            'payments_account_id' => $paymentsAccountId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - billingSetup: customers/{customer_id}/billingSetups/{billing_setup_id}
+     * - paymentsAccount: customers/{customer_id}/paymentsAccounts/{payments_account_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignAssetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignAssetServiceGapicClient.php
@@ -80,6 +80,10 @@ class CampaignAssetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetNameTemplate;
+
+    private static $campaignNameTemplate;
+
     private static $campaignAssetNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +107,24 @@ class CampaignAssetServiceGapicClient
         ];
     }
 
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignAssetNameTemplate()
     {
         if (self::$campaignAssetNameTemplate == null) {
@@ -116,11 +138,47 @@ class CampaignAssetServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'asset' => self::getAssetNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignAsset' => self::getCampaignAssetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -148,6 +206,8 @@ class CampaignAssetServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignAsset: customers/{customer_id}/campaignAssets/{campaign_id}~{asset_id}~{field_type}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignAssetSetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignAssetSetServiceGapicClient.php
@@ -80,6 +80,10 @@ class CampaignAssetSetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetSetNameTemplate;
+
+    private static $campaignNameTemplate;
+
     private static $campaignAssetSetNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +107,24 @@ class CampaignAssetSetServiceGapicClient
         ];
     }
 
+    private static function getAssetSetNameTemplate()
+    {
+        if (self::$assetSetNameTemplate == null) {
+            self::$assetSetNameTemplate = new PathTemplate('customers/{customer_id}/assetSets/{asset_set_id}');
+        }
+
+        return self::$assetSetNameTemplate;
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignAssetSetNameTemplate()
     {
         if (self::$campaignAssetSetNameTemplate == null) {
@@ -116,11 +138,47 @@ class CampaignAssetSetServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'assetSet' => self::getAssetSetNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignAssetSet' => self::getCampaignAssetSetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     *
+     * @return string The formatted asset_set resource.
+     */
+    public static function assetSetName($customerId, $assetSetId)
+    {
+        return self::getAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -146,6 +204,8 @@ class CampaignAssetSetServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - assetSet: customers/{customer_id}/assetSets/{asset_set_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignAssetSet: customers/{customer_id}/campaignAssetSets/{campaign_id}~{asset_set_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignBidModifierServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignBidModifierServiceGapicClient.php
@@ -80,6 +80,8 @@ class CampaignBidModifierServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignBidModifierNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class CampaignBidModifierServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignBidModifierNameTemplate()
     {
         if (self::$campaignBidModifierNameTemplate == null) {
@@ -116,11 +127,29 @@ class CampaignBidModifierServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignBidModifier' => self::getCampaignBidModifierNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class CampaignBidModifierServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignBidModifier: customers/{customer_id}/campaignBidModifiers/{campaign_id}~{criterion_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignConversionGoalServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignConversionGoalServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateCampaignConversionGoalsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $campaignConversionGoalServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class CampaignConversionGoalServiceGapicClient
 {
@@ -74,6 +80,12 @@ class CampaignConversionGoalServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
+    private static $campaignConversionGoalNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +103,116 @@ class CampaignConversionGoalServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
+    private static function getCampaignConversionGoalNameTemplate()
+    {
+        if (self::$campaignConversionGoalNameTemplate == null) {
+            self::$campaignConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/campaignConversionGoals/{campaign_id}~{category}~{source}');
+        }
+
+        return self::$campaignConversionGoalNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
+                'campaignConversionGoal' => self::getCampaignConversionGoalNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $category
+     * @param string $source
+     *
+     * @return string The formatted campaign_conversion_goal resource.
+     */
+    public static function campaignConversionGoalName($customerId, $campaignId, $category, $source)
+    {
+        return self::getCampaignConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'category' => $category,
+            'source' => $source,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - campaignConversionGoal: customers/{customer_id}/campaignConversionGoals/{campaign_id}~{category}~{source}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignCriterionServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignCriterionServiceGapicClient.php
@@ -80,6 +80,8 @@ class CampaignCriterionServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignCriterionNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class CampaignCriterionServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignCriterionNameTemplate()
     {
         if (self::$campaignCriterionNameTemplate == null) {
@@ -116,11 +127,29 @@ class CampaignCriterionServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignCriterion' => self::getCampaignCriterionNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class CampaignCriterionServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignCriterion: customers/{customer_id}/campaignCriteria/{campaign_id}~{criterion_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignCustomizerServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignCustomizerServiceGapicClient.php
@@ -80,7 +80,11 @@ class CampaignCustomizerServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignCustomizerNameTemplate;
+
+    private static $customizerAttributeNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class CampaignCustomizerServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignCustomizerNameTemplate()
     {
         if (self::$campaignCustomizerNameTemplate == null) {
@@ -112,15 +125,43 @@ class CampaignCustomizerServiceGapicClient
         return self::$campaignCustomizerNameTemplate;
     }
 
+    private static function getCustomizerAttributeNameTemplate()
+    {
+        if (self::$customizerAttributeNameTemplate == null) {
+            self::$customizerAttributeNameTemplate = new PathTemplate('customers/{customer_id}/customizerAttributes/{customizer_attribute_id}');
+        }
+
+        return self::$customizerAttributeNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignCustomizer' => self::getCampaignCustomizerNameTemplate(),
+                'customizerAttribute' => self::getCustomizerAttributeNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class CampaignCustomizerServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customizer_attribute resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customizer_attribute resource.
+     */
+    public static function customizerAttributeName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomizerAttributeNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignCustomizer: customers/{customer_id}/campaignCustomizers/{campaign_id}~{customizer_attribute_id}
+     * - customizerAttribute: customers/{customer_id}/customizerAttributes/{customizer_attribute_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignDraftServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignDraftServiceGapicClient.php
@@ -97,6 +97,8 @@ class CampaignDraftServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignDraftNameTemplate;
 
     private static $pathTemplateMap;
@@ -122,6 +124,15 @@ class CampaignDraftServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignDraftNameTemplate()
     {
         if (self::$campaignDraftNameTemplate == null) {
@@ -135,11 +146,29 @@ class CampaignDraftServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignDraft' => self::getCampaignDraftNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -165,6 +194,7 @@ class CampaignDraftServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignDraft: customers/{customer_id}/campaignDrafts/{base_campaign_id}~{draft_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignExtensionSettingServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignExtensionSettingServiceGapicClient.php
@@ -80,7 +80,11 @@ class CampaignExtensionSettingServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignExtensionSettingNameTemplate;
+
+    private static $extensionFeedItemNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class CampaignExtensionSettingServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignExtensionSettingNameTemplate()
     {
         if (self::$campaignExtensionSettingNameTemplate == null) {
@@ -112,15 +125,43 @@ class CampaignExtensionSettingServiceGapicClient
         return self::$campaignExtensionSettingNameTemplate;
     }
 
+    private static function getExtensionFeedItemNameTemplate()
+    {
+        if (self::$extensionFeedItemNameTemplate == null) {
+            self::$extensionFeedItemNameTemplate = new PathTemplate('customers/{customer_id}/extensionFeedItems/{feed_item_id}');
+        }
+
+        return self::$extensionFeedItemNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignExtensionSetting' => self::getCampaignExtensionSettingNameTemplate(),
+                'extensionFeedItem' => self::getExtensionFeedItemNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class CampaignExtensionSettingServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * extension_feed_item resource.
+     *
+     * @param string $customerId
+     * @param string $feedItemId
+     *
+     * @return string The formatted extension_feed_item resource.
+     */
+    public static function extensionFeedItemName($customerId, $feedItemId)
+    {
+        return self::getExtensionFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignExtensionSetting: customers/{customer_id}/campaignExtensionSettings/{campaign_id}~{extension_type}
+     * - extensionFeedItem: customers/{customer_id}/extensionFeedItems/{feed_item_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignFeedServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignFeedServiceGapicClient.php
@@ -80,7 +80,11 @@ class CampaignFeedServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignFeedNameTemplate;
+
+    private static $feedNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class CampaignFeedServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignFeedNameTemplate()
     {
         if (self::$campaignFeedNameTemplate == null) {
@@ -112,15 +125,43 @@ class CampaignFeedServiceGapicClient
         return self::$campaignFeedNameTemplate;
     }
 
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignFeed' => self::getCampaignFeedNameTemplate(),
+                'feed' => self::getFeedNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class CampaignFeedServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignFeed: customers/{customer_id}/campaignFeeds/{campaign_id}~{feed_id}
+     * - feed: customers/{customer_id}/feeds/{feed_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignLabelServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignLabelServiceGapicClient.php
@@ -80,7 +80,11 @@ class CampaignLabelServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignLabelNameTemplate;
+
+    private static $labelNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class CampaignLabelServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignLabelNameTemplate()
     {
         if (self::$campaignLabelNameTemplate == null) {
@@ -112,15 +125,43 @@ class CampaignLabelServiceGapicClient
         return self::$campaignLabelNameTemplate;
     }
 
+    private static function getLabelNameTemplate()
+    {
+        if (self::$labelNameTemplate == null) {
+            self::$labelNameTemplate = new PathTemplate('customers/{customer_id}/labels/{label_id}');
+        }
+
+        return self::$labelNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignLabel' => self::getCampaignLabelNameTemplate(),
+                'label' => self::getLabelNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class CampaignLabelServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a label
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted label resource.
+     */
+    public static function labelName($customerId, $labelId)
+    {
+        return self::getLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignLabel: customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}
+     * - label: customers/{customer_id}/labels/{label_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignServiceGapicClient.php
@@ -80,7 +80,23 @@ class CampaignServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $accessibleBiddingStrategyNameTemplate;
+
+    private static $assetSetNameTemplate;
+
+    private static $biddingStrategyNameTemplate;
+
     private static $campaignNameTemplate;
+
+    private static $campaignBudgetNameTemplate;
+
+    private static $campaignGroupNameTemplate;
+
+    private static $campaignLabelNameTemplate;
+
+    private static $conversionActionNameTemplate;
+
+    private static $feedNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +119,33 @@ class CampaignServiceGapicClient
         ];
     }
 
+    private static function getAccessibleBiddingStrategyNameTemplate()
+    {
+        if (self::$accessibleBiddingStrategyNameTemplate == null) {
+            self::$accessibleBiddingStrategyNameTemplate = new PathTemplate('customers/{customer_id}/accessibleBiddingStrategies/{bidding_strategy_id}');
+        }
+
+        return self::$accessibleBiddingStrategyNameTemplate;
+    }
+
+    private static function getAssetSetNameTemplate()
+    {
+        if (self::$assetSetNameTemplate == null) {
+            self::$assetSetNameTemplate = new PathTemplate('customers/{customer_id}/assetSets/{asset_set_id}');
+        }
+
+        return self::$assetSetNameTemplate;
+    }
+
+    private static function getBiddingStrategyNameTemplate()
+    {
+        if (self::$biddingStrategyNameTemplate == null) {
+            self::$biddingStrategyNameTemplate = new PathTemplate('customers/{customer_id}/biddingStrategies/{bidding_strategy_id}');
+        }
+
+        return self::$biddingStrategyNameTemplate;
+    }
+
     private static function getCampaignNameTemplate()
     {
         if (self::$campaignNameTemplate == null) {
@@ -112,15 +155,119 @@ class CampaignServiceGapicClient
         return self::$campaignNameTemplate;
     }
 
+    private static function getCampaignBudgetNameTemplate()
+    {
+        if (self::$campaignBudgetNameTemplate == null) {
+            self::$campaignBudgetNameTemplate = new PathTemplate('customers/{customer_id}/campaignBudgets/{campaign_budget_id}');
+        }
+
+        return self::$campaignBudgetNameTemplate;
+    }
+
+    private static function getCampaignGroupNameTemplate()
+    {
+        if (self::$campaignGroupNameTemplate == null) {
+            self::$campaignGroupNameTemplate = new PathTemplate('customers/{customer_id}/campaignGroups/{campaign_group_id}');
+        }
+
+        return self::$campaignGroupNameTemplate;
+    }
+
+    private static function getCampaignLabelNameTemplate()
+    {
+        if (self::$campaignLabelNameTemplate == null) {
+            self::$campaignLabelNameTemplate = new PathTemplate('customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}');
+        }
+
+        return self::$campaignLabelNameTemplate;
+    }
+
+    private static function getConversionActionNameTemplate()
+    {
+        if (self::$conversionActionNameTemplate == null) {
+            self::$conversionActionNameTemplate = new PathTemplate('customers/{customer_id}/conversionActions/{conversion_action_id}');
+        }
+
+        return self::$conversionActionNameTemplate;
+    }
+
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'accessibleBiddingStrategy' => self::getAccessibleBiddingStrategyNameTemplate(),
+                'assetSet' => self::getAssetSetNameTemplate(),
+                'biddingStrategy' => self::getBiddingStrategyNameTemplate(),
                 'campaign' => self::getCampaignNameTemplate(),
+                'campaignBudget' => self::getCampaignBudgetNameTemplate(),
+                'campaignGroup' => self::getCampaignGroupNameTemplate(),
+                'campaignLabel' => self::getCampaignLabelNameTemplate(),
+                'conversionAction' => self::getConversionActionNameTemplate(),
+                'feed' => self::getFeedNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * accessible_bidding_strategy resource.
+     *
+     * @param string $customerId
+     * @param string $biddingStrategyId
+     *
+     * @return string The formatted accessible_bidding_strategy resource.
+     */
+    public static function accessibleBiddingStrategyName($customerId, $biddingStrategyId)
+    {
+        return self::getAccessibleBiddingStrategyNameTemplate()->render([
+            'customer_id' => $customerId,
+            'bidding_strategy_id' => $biddingStrategyId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     *
+     * @return string The formatted asset_set resource.
+     */
+    public static function assetSetName($customerId, $assetSetId)
+    {
+        return self::getAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * bidding_strategy resource.
+     *
+     * @param string $customerId
+     * @param string $biddingStrategyId
+     *
+     * @return string The formatted bidding_strategy resource.
+     */
+    public static function biddingStrategyName($customerId, $biddingStrategyId)
+    {
+        return self::getBiddingStrategyNameTemplate()->render([
+            'customer_id' => $customerId,
+            'bidding_strategy_id' => $biddingStrategyId,
+        ]);
     }
 
     /**
@@ -141,10 +288,105 @@ class CampaignServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_budget resource.
+     *
+     * @param string $customerId
+     * @param string $campaignBudgetId
+     *
+     * @return string The formatted campaign_budget resource.
+     */
+    public static function campaignBudgetName($customerId, $campaignBudgetId)
+    {
+        return self::getCampaignBudgetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_budget_id' => $campaignBudgetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_group resource.
+     *
+     * @param string $customerId
+     * @param string $campaignGroupId
+     *
+     * @return string The formatted campaign_group resource.
+     */
+    public static function campaignGroupName($customerId, $campaignGroupId)
+    {
+        return self::getCampaignGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_group_id' => $campaignGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_label resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $labelId
+     *
+     * @return string The formatted campaign_label resource.
+     */
+    public static function campaignLabelName($customerId, $campaignId, $labelId)
+    {
+        return self::getCampaignLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_action resource.
+     *
+     * @param string $customerId
+     * @param string $conversionActionId
+     *
+     * @return string The formatted conversion_action resource.
+     */
+    public static function conversionActionName($customerId, $conversionActionId)
+    {
+        return self::getConversionActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_action_id' => $conversionActionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - accessibleBiddingStrategy: customers/{customer_id}/accessibleBiddingStrategies/{bidding_strategy_id}
+     * - assetSet: customers/{customer_id}/assetSets/{asset_set_id}
+     * - biddingStrategy: customers/{customer_id}/biddingStrategies/{bidding_strategy_id}
      * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - campaignBudget: customers/{customer_id}/campaignBudgets/{campaign_budget_id}
+     * - campaignGroup: customers/{customer_id}/campaignGroups/{campaign_group_id}
+     * - campaignLabel: customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}
+     * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
+     * - feed: customers/{customer_id}/feeds/{feed_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignSharedSetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CampaignSharedSetServiceGapicClient.php
@@ -80,7 +80,11 @@ class CampaignSharedSetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $campaignSharedSetNameTemplate;
+
+    private static $sharedSetNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class CampaignSharedSetServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getCampaignSharedSetNameTemplate()
     {
         if (self::$campaignSharedSetNameTemplate == null) {
@@ -112,15 +125,43 @@ class CampaignSharedSetServiceGapicClient
         return self::$campaignSharedSetNameTemplate;
     }
 
+    private static function getSharedSetNameTemplate()
+    {
+        if (self::$sharedSetNameTemplate == null) {
+            self::$sharedSetNameTemplate = new PathTemplate('customers/{customer_id}/sharedSets/{shared_set_id}');
+        }
+
+        return self::$sharedSetNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'campaignSharedSet' => self::getCampaignSharedSetNameTemplate(),
+                'sharedSet' => self::getSharedSetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -143,10 +184,29 @@ class CampaignSharedSetServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a shared_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $sharedSetId
+     *
+     * @return string The formatted shared_set resource.
+     */
+    public static function sharedSetName($customerId, $sharedSetId)
+    {
+        return self::getSharedSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'shared_set_id' => $sharedSetId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - campaignSharedSet: customers/{customer_id}/campaignSharedSets/{campaign_id}~{shared_set_id}
+     * - sharedSet: customers/{customer_id}/sharedSets/{shared_set_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionActionServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionActionServiceGapicClient.php
@@ -82,6 +82,8 @@ class ConversionActionServiceGapicClient
 
     private static $conversionActionNameTemplate;
 
+    private static $customerNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class ConversionActionServiceGapicClient
         return self::$conversionActionNameTemplate;
     }
 
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'conversionAction' => self::getConversionActionNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
             ];
         }
 
@@ -141,10 +153,26 @@ class ConversionActionServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
+     * - customer: customers/{customer_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionCustomVariableServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionCustomVariableServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateConversionCustomVariablesResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $conversionCustomVariableServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class ConversionCustomVariableServiceGapicClient
 {
@@ -74,6 +80,12 @@ class ConversionCustomVariableServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $conversionCustomVariableNameTemplate;
+
+    private static $customerNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +103,110 @@ class ConversionCustomVariableServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getConversionCustomVariableNameTemplate()
+    {
+        if (self::$conversionCustomVariableNameTemplate == null) {
+            self::$conversionCustomVariableNameTemplate = new PathTemplate('customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}');
+        }
+
+        return self::$conversionCustomVariableNameTemplate;
+    }
+
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'conversionCustomVariable' => self::getConversionCustomVariableNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_custom_variable resource.
+     *
+     * @param string $customerId
+     * @param string $conversionCustomVariableId
+     *
+     * @return string The formatted conversion_custom_variable resource.
+     */
+    public static function conversionCustomVariableName($customerId, $conversionCustomVariableId)
+    {
+        return self::getConversionCustomVariableNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_custom_variable_id' => $conversionCustomVariableId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - conversionCustomVariable: customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}
+     * - customer: customers/{customer_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionGoalCampaignConfigServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionGoalCampaignConfigServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateConversionGoalCampaignConfigsRespons
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $conversionGoalCampaignConfigServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class ConversionGoalCampaignConfigServiceGapicClient
 {
@@ -74,6 +80,14 @@ class ConversionGoalCampaignConfigServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
+    private static $conversionGoalCampaignConfigNameTemplate;
+
+    private static $customConversionGoalNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +105,140 @@ class ConversionGoalCampaignConfigServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
+    private static function getConversionGoalCampaignConfigNameTemplate()
+    {
+        if (self::$conversionGoalCampaignConfigNameTemplate == null) {
+            self::$conversionGoalCampaignConfigNameTemplate = new PathTemplate('customers/{customer_id}/conversionGoalCampaignConfigs/{campaign_id}');
+        }
+
+        return self::$conversionGoalCampaignConfigNameTemplate;
+    }
+
+    private static function getCustomConversionGoalNameTemplate()
+    {
+        if (self::$customConversionGoalNameTemplate == null) {
+            self::$customConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/customConversionGoals/{goal_id}');
+        }
+
+        return self::$customConversionGoalNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
+                'conversionGoalCampaignConfig' => self::getConversionGoalCampaignConfigNameTemplate(),
+                'customConversionGoal' => self::getCustomConversionGoalNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_goal_campaign_config resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted conversion_goal_campaign_config resource.
+     */
+    public static function conversionGoalCampaignConfigName($customerId, $campaignId)
+    {
+        return self::getConversionGoalCampaignConfigNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * custom_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $goalId
+     *
+     * @return string The formatted custom_conversion_goal resource.
+     */
+    public static function customConversionGoalName($customerId, $goalId)
+    {
+        return self::getCustomConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'goal_id' => $goalId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - conversionGoalCampaignConfig: customers/{customer_id}/conversionGoalCampaignConfigs/{campaign_id}
+     * - customConversionGoal: customers/{customer_id}/customConversionGoals/{goal_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionUploadServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionUploadServiceGapicClient.php
@@ -33,6 +33,7 @@ use Google\Ads\GoogleAds\V13\Services\UploadClickConversionsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -56,6 +57,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $conversionUploadServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class ConversionUploadServiceGapicClient
 {
@@ -78,6 +84,10 @@ class ConversionUploadServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $conversionCustomVariableNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -95,6 +105,84 @@ class ConversionUploadServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getConversionCustomVariableNameTemplate()
+    {
+        if (self::$conversionCustomVariableNameTemplate == null) {
+            self::$conversionCustomVariableNameTemplate = new PathTemplate('customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}');
+        }
+
+        return self::$conversionCustomVariableNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'conversionCustomVariable' => self::getConversionCustomVariableNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_custom_variable resource.
+     *
+     * @param string $customerId
+     * @param string $conversionCustomVariableId
+     *
+     * @return string The formatted conversion_custom_variable resource.
+     */
+    public static function conversionCustomVariableName($customerId, $conversionCustomVariableId)
+    {
+        return self::getConversionCustomVariableNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_custom_variable_id' => $conversionCustomVariableId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - conversionCustomVariable: customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionValueRuleServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionValueRuleServiceGapicClient.php
@@ -82,6 +82,14 @@ class ConversionValueRuleServiceGapicClient
 
     private static $conversionValueRuleNameTemplate;
 
+    private static $customerNameTemplate;
+
+    private static $geoTargetConstantNameTemplate;
+
+    private static $userInterestNameTemplate;
+
+    private static $userListNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +120,51 @@ class ConversionValueRuleServiceGapicClient
         return self::$conversionValueRuleNameTemplate;
     }
 
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
+    private static function getGeoTargetConstantNameTemplate()
+    {
+        if (self::$geoTargetConstantNameTemplate == null) {
+            self::$geoTargetConstantNameTemplate = new PathTemplate('geoTargetConstants/{criterion_id}');
+        }
+
+        return self::$geoTargetConstantNameTemplate;
+    }
+
+    private static function getUserInterestNameTemplate()
+    {
+        if (self::$userInterestNameTemplate == null) {
+            self::$userInterestNameTemplate = new PathTemplate('customers/{customer_id}/userInterests/{user_interest_id}');
+        }
+
+        return self::$userInterestNameTemplate;
+    }
+
+    private static function getUserListNameTemplate()
+    {
+        if (self::$userListNameTemplate == null) {
+            self::$userListNameTemplate = new PathTemplate('customers/{customer_id}/userLists/{user_list_id}');
+        }
+
+        return self::$userListNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'conversionValueRule' => self::getConversionValueRuleNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
+                'geoTargetConstant' => self::getGeoTargetConstantNameTemplate(),
+                'userInterest' => self::getUserInterestNameTemplate(),
+                'userList' => self::getUserListNameTemplate(),
             ];
         }
 
@@ -141,10 +189,78 @@ class ConversionValueRuleServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * geo_target_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted geo_target_constant resource.
+     */
+    public static function geoTargetConstantName($criterionId)
+    {
+        return self::getGeoTargetConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * user_interest resource.
+     *
+     * @param string $customerId
+     * @param string $userInterestId
+     *
+     * @return string The formatted user_interest resource.
+     */
+    public static function userInterestName($customerId, $userInterestId)
+    {
+        return self::getUserInterestNameTemplate()->render([
+            'customer_id' => $customerId,
+            'user_interest_id' => $userInterestId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a user_list
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $userListId
+     *
+     * @return string The formatted user_list resource.
+     */
+    public static function userListName($customerId, $userListId)
+    {
+        return self::getUserListNameTemplate()->render([
+            'customer_id' => $customerId,
+            'user_list_id' => $userListId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - conversionValueRule: customers/{customer_id}/conversionValueRules/{conversion_value_rule_id}
+     * - customer: customers/{customer_id}
+     * - geoTargetConstant: geoTargetConstants/{criterion_id}
+     * - userInterest: customers/{customer_id}/userInterests/{user_interest_id}
+     * - userList: customers/{customer_id}/userLists/{user_list_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionValueRuleSetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ConversionValueRuleSetServiceGapicClient.php
@@ -80,7 +80,13 @@ class ConversionValueRuleSetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
+    private static $conversionValueRuleNameTemplate;
+
     private static $conversionValueRuleSetNameTemplate;
+
+    private static $customerNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +109,24 @@ class ConversionValueRuleSetServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
+    private static function getConversionValueRuleNameTemplate()
+    {
+        if (self::$conversionValueRuleNameTemplate == null) {
+            self::$conversionValueRuleNameTemplate = new PathTemplate('customers/{customer_id}/conversionValueRules/{conversion_value_rule_id}');
+        }
+
+        return self::$conversionValueRuleNameTemplate;
+    }
+
     private static function getConversionValueRuleSetNameTemplate()
     {
         if (self::$conversionValueRuleSetNameTemplate == null) {
@@ -112,15 +136,61 @@ class ConversionValueRuleSetServiceGapicClient
         return self::$conversionValueRuleSetNameTemplate;
     }
 
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
+                'conversionValueRule' => self::getConversionValueRuleNameTemplate(),
                 'conversionValueRuleSet' => self::getConversionValueRuleSetNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_value_rule resource.
+     *
+     * @param string $customerId
+     * @param string $conversionValueRuleId
+     *
+     * @return string The formatted conversion_value_rule resource.
+     */
+    public static function conversionValueRuleName($customerId, $conversionValueRuleId)
+    {
+        return self::getConversionValueRuleNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_value_rule_id' => $conversionValueRuleId,
+        ]);
     }
 
     /**
@@ -141,10 +211,28 @@ class ConversionValueRuleSetServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - conversionValueRule: customers/{customer_id}/conversionValueRules/{conversion_value_rule_id}
      * - conversionValueRuleSet: customers/{customer_id}/conversionValueRuleSets/{conversion_value_rule_set_id}
+     * - customer: customers/{customer_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomConversionGoalServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomConversionGoalServiceGapicClient.php
@@ -80,6 +80,8 @@ class CustomConversionGoalServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $conversionActionNameTemplate;
+
     private static $customConversionGoalNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class CustomConversionGoalServiceGapicClient
         ];
     }
 
+    private static function getConversionActionNameTemplate()
+    {
+        if (self::$conversionActionNameTemplate == null) {
+            self::$conversionActionNameTemplate = new PathTemplate('customers/{customer_id}/conversionActions/{conversion_action_id}');
+        }
+
+        return self::$conversionActionNameTemplate;
+    }
+
     private static function getCustomConversionGoalNameTemplate()
     {
         if (self::$customConversionGoalNameTemplate == null) {
@@ -116,11 +127,29 @@ class CustomConversionGoalServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'conversionAction' => self::getConversionActionNameTemplate(),
                 'customConversionGoal' => self::getCustomConversionGoalNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_action resource.
+     *
+     * @param string $customerId
+     * @param string $conversionActionId
+     *
+     * @return string The formatted conversion_action resource.
+     */
+    public static function conversionActionName($customerId, $conversionActionId)
+    {
+        return self::getConversionActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_action_id' => $conversionActionId,
+        ]);
     }
 
     /**
@@ -144,6 +173,7 @@ class CustomConversionGoalServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
      * - customConversionGoal: customers/{customer_id}/customConversionGoals/{goal_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomInterestServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomInterestServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateCustomInterestsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $customInterestServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class CustomInterestServiceGapicClient
 {
@@ -74,6 +80,10 @@ class CustomInterestServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $customInterestNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +101,84 @@ class CustomInterestServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getCustomInterestNameTemplate()
+    {
+        if (self::$customInterestNameTemplate == null) {
+            self::$customInterestNameTemplate = new PathTemplate('customers/{customer_id}/customInterests/{custom_interest_id}');
+        }
+
+        return self::$customInterestNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'customInterest' => self::getCustomInterestNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * custom_interest resource.
+     *
+     * @param string $customerId
+     * @param string $customInterestId
+     *
+     * @return string The formatted custom_interest resource.
+     */
+    public static function customInterestName($customerId, $customInterestId)
+    {
+        return self::getCustomInterestNameTemplate()->render([
+            'customer_id' => $customerId,
+            'custom_interest_id' => $customInterestId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - customInterest: customers/{customer_id}/customInterests/{custom_interest_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerAssetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerAssetServiceGapicClient.php
@@ -80,6 +80,8 @@ class CustomerAssetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetNameTemplate;
+
     private static $customerAssetNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class CustomerAssetServiceGapicClient
         ];
     }
 
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
     private static function getCustomerAssetNameTemplate()
     {
         if (self::$customerAssetNameTemplate == null) {
@@ -116,11 +127,29 @@ class CustomerAssetServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'asset' => self::getAssetNameTemplate(),
                 'customerAsset' => self::getCustomerAssetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class CustomerAssetServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - asset: customers/{customer_id}/assets/{asset_id}
      * - customerAsset: customers/{customer_id}/customerAssets/{asset_id}~{field_type}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerAssetSetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerAssetSetServiceGapicClient.php
@@ -80,6 +80,10 @@ class CustomerAssetSetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $assetSetNameTemplate;
+
+    private static $customerNameTemplate;
+
     private static $customerAssetSetNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +107,24 @@ class CustomerAssetSetServiceGapicClient
         ];
     }
 
+    private static function getAssetSetNameTemplate()
+    {
+        if (self::$assetSetNameTemplate == null) {
+            self::$assetSetNameTemplate = new PathTemplate('customers/{customer_id}/assetSets/{asset_set_id}');
+        }
+
+        return self::$assetSetNameTemplate;
+    }
+
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
     private static function getCustomerAssetSetNameTemplate()
     {
         if (self::$customerAssetSetNameTemplate == null) {
@@ -116,11 +138,45 @@ class CustomerAssetSetServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'assetSet' => self::getAssetSetNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
                 'customerAssetSet' => self::getCustomerAssetSetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     *
+     * @return string The formatted asset_set resource.
+     */
+    public static function assetSetName($customerId, $assetSetId)
+    {
+        return self::getAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
     }
 
     /**
@@ -144,6 +200,8 @@ class CustomerAssetSetServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - assetSet: customers/{customer_id}/assetSets/{asset_set_id}
+     * - customer: customers/{customer_id}
      * - customerAssetSet: customers/{customer_id}/customerAssetSets/{asset_set_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerClientLinkServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerClientLinkServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateCustomerClientLinkResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $customerClientLinkServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class CustomerClientLinkServiceGapicClient
 {
@@ -74,6 +80,12 @@ class CustomerClientLinkServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $customerNameTemplate;
+
+    private static $customerClientLinkNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +103,112 @@ class CustomerClientLinkServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
+    private static function getCustomerClientLinkNameTemplate()
+    {
+        if (self::$customerClientLinkNameTemplate == null) {
+            self::$customerClientLinkNameTemplate = new PathTemplate('customers/{customer_id}/customerClientLinks/{client_customer_id}~{manager_link_id}');
+        }
+
+        return self::$customerClientLinkNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'customer' => self::getCustomerNameTemplate(),
+                'customerClientLink' => self::getCustomerClientLinkNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_client_link resource.
+     *
+     * @param string $customerId
+     * @param string $clientCustomerId
+     * @param string $managerLinkId
+     *
+     * @return string The formatted customer_client_link resource.
+     */
+    public static function customerClientLinkName($customerId, $clientCustomerId, $managerLinkId)
+    {
+        return self::getCustomerClientLinkNameTemplate()->render([
+            'customer_id' => $customerId,
+            'client_customer_id' => $clientCustomerId,
+            'manager_link_id' => $managerLinkId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - customer: customers/{customer_id}
+     * - customerClientLink: customers/{customer_id}/customerClientLinks/{client_customer_id}~{manager_link_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerConversionGoalServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerConversionGoalServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateCustomerConversionGoalsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $customerConversionGoalServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class CustomerConversionGoalServiceGapicClient
 {
@@ -74,6 +80,10 @@ class CustomerConversionGoalServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $customerConversionGoalNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +101,86 @@ class CustomerConversionGoalServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getCustomerConversionGoalNameTemplate()
+    {
+        if (self::$customerConversionGoalNameTemplate == null) {
+            self::$customerConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/customerConversionGoals/{category}~{source}');
+        }
+
+        return self::$customerConversionGoalNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'customerConversionGoal' => self::getCustomerConversionGoalNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $category
+     * @param string $source
+     *
+     * @return string The formatted customer_conversion_goal resource.
+     */
+    public static function customerConversionGoalName($customerId, $category, $source)
+    {
+        return self::getCustomerConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'category' => $category,
+            'source' => $source,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - customerConversionGoal: customers/{customer_id}/customerConversionGoals/{category}~{source}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerCustomizerServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerCustomizerServiceGapicClient.php
@@ -82,6 +82,8 @@ class CustomerCustomizerServiceGapicClient
 
     private static $customerCustomizerNameTemplate;
 
+    private static $customizerAttributeNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class CustomerCustomizerServiceGapicClient
         return self::$customerCustomizerNameTemplate;
     }
 
+    private static function getCustomizerAttributeNameTemplate()
+    {
+        if (self::$customizerAttributeNameTemplate == null) {
+            self::$customizerAttributeNameTemplate = new PathTemplate('customers/{customer_id}/customizerAttributes/{customizer_attribute_id}');
+        }
+
+        return self::$customizerAttributeNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'customerCustomizer' => self::getCustomerCustomizerNameTemplate(),
+                'customizerAttribute' => self::getCustomizerAttributeNameTemplate(),
             ];
         }
 
@@ -141,10 +153,28 @@ class CustomerCustomizerServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customizer_attribute resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customizer_attribute resource.
+     */
+    public static function customizerAttributeName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomizerAttributeNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - customerCustomizer: customers/{customer_id}/customerCustomizers/{customizer_attribute_id}
+     * - customizerAttribute: customers/{customer_id}/customizerAttributes/{customizer_attribute_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerExtensionSettingServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerExtensionSettingServiceGapicClient.php
@@ -82,6 +82,8 @@ class CustomerExtensionSettingServiceGapicClient
 
     private static $customerExtensionSettingNameTemplate;
 
+    private static $extensionFeedItemNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class CustomerExtensionSettingServiceGapicClient
         return self::$customerExtensionSettingNameTemplate;
     }
 
+    private static function getExtensionFeedItemNameTemplate()
+    {
+        if (self::$extensionFeedItemNameTemplate == null) {
+            self::$extensionFeedItemNameTemplate = new PathTemplate('customers/{customer_id}/extensionFeedItems/{feed_item_id}');
+        }
+
+        return self::$extensionFeedItemNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'customerExtensionSetting' => self::getCustomerExtensionSettingNameTemplate(),
+                'extensionFeedItem' => self::getExtensionFeedItemNameTemplate(),
             ];
         }
 
@@ -141,10 +153,28 @@ class CustomerExtensionSettingServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * extension_feed_item resource.
+     *
+     * @param string $customerId
+     * @param string $feedItemId
+     *
+     * @return string The formatted extension_feed_item resource.
+     */
+    public static function extensionFeedItemName($customerId, $feedItemId)
+    {
+        return self::getExtensionFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - customerExtensionSetting: customers/{customer_id}/customerExtensionSettings/{extension_type}
+     * - extensionFeedItem: customers/{customer_id}/extensionFeedItems/{feed_item_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerFeedServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerFeedServiceGapicClient.php
@@ -82,6 +82,8 @@ class CustomerFeedServiceGapicClient
 
     private static $customerFeedNameTemplate;
 
+    private static $feedNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class CustomerFeedServiceGapicClient
         return self::$customerFeedNameTemplate;
     }
 
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'customerFeed' => self::getCustomerFeedNameTemplate(),
+                'feed' => self::getFeedNameTemplate(),
             ];
         }
 
@@ -141,10 +153,28 @@ class CustomerFeedServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - customerFeed: customers/{customer_id}/customerFeeds/{feed_id}
+     * - feed: customers/{customer_id}/feeds/{feed_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerLabelServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerLabelServiceGapicClient.php
@@ -80,7 +80,11 @@ class CustomerLabelServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $customerNameTemplate;
+
     private static $customerLabelNameTemplate;
+
+    private static $labelNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +107,15 @@ class CustomerLabelServiceGapicClient
         ];
     }
 
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
     private static function getCustomerLabelNameTemplate()
     {
         if (self::$customerLabelNameTemplate == null) {
@@ -112,15 +125,41 @@ class CustomerLabelServiceGapicClient
         return self::$customerLabelNameTemplate;
     }
 
+    private static function getLabelNameTemplate()
+    {
+        if (self::$labelNameTemplate == null) {
+            self::$labelNameTemplate = new PathTemplate('customers/{customer_id}/labels/{label_id}');
+        }
+
+        return self::$labelNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'customer' => self::getCustomerNameTemplate(),
                 'customerLabel' => self::getCustomerLabelNameTemplate(),
+                'label' => self::getLabelNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
     }
 
     /**
@@ -141,10 +180,29 @@ class CustomerLabelServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a label
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted label resource.
+     */
+    public static function labelName($customerId, $labelId)
+    {
+        return self::getLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - customer: customers/{customer_id}
      * - customerLabel: customers/{customer_id}/customerLabels/{label_id}
+     * - label: customers/{customer_id}/labels/{label_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerManagerLinkServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerManagerLinkServiceGapicClient.php
@@ -32,6 +32,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateCustomerManagerLinkResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -55,6 +56,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $customerManagerLinkServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class CustomerManagerLinkServiceGapicClient
 {
@@ -77,6 +83,12 @@ class CustomerManagerLinkServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $customerNameTemplate;
+
+    private static $customerManagerLinkNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -94,6 +106,112 @@ class CustomerManagerLinkServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
+    private static function getCustomerManagerLinkNameTemplate()
+    {
+        if (self::$customerManagerLinkNameTemplate == null) {
+            self::$customerManagerLinkNameTemplate = new PathTemplate('customers/{customer_id}/customerManagerLinks/{manager_customer_id}~{manager_link_id}');
+        }
+
+        return self::$customerManagerLinkNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'customer' => self::getCustomerNameTemplate(),
+                'customerManagerLink' => self::getCustomerManagerLinkNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_manager_link resource.
+     *
+     * @param string $customerId
+     * @param string $managerCustomerId
+     * @param string $managerLinkId
+     *
+     * @return string The formatted customer_manager_link resource.
+     */
+    public static function customerManagerLinkName($customerId, $managerCustomerId, $managerLinkId)
+    {
+        return self::getCustomerManagerLinkNameTemplate()->render([
+            'customer_id' => $customerId,
+            'manager_customer_id' => $managerCustomerId,
+            'manager_link_id' => $managerLinkId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - customer: customers/{customer_id}
+     * - customerManagerLink: customers/{customer_id}/customerManagerLinks/{manager_customer_id}~{manager_link_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/CustomerServiceGapicClient.php
@@ -85,6 +85,8 @@ class CustomerServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $conversionActionNameTemplate;
+
     private static $customerNameTemplate;
 
     private static $pathTemplateMap;
@@ -108,6 +110,15 @@ class CustomerServiceGapicClient
         ];
     }
 
+    private static function getConversionActionNameTemplate()
+    {
+        if (self::$conversionActionNameTemplate == null) {
+            self::$conversionActionNameTemplate = new PathTemplate('customers/{customer_id}/conversionActions/{conversion_action_id}');
+        }
+
+        return self::$conversionActionNameTemplate;
+    }
+
     private static function getCustomerNameTemplate()
     {
         if (self::$customerNameTemplate == null) {
@@ -121,11 +132,29 @@ class CustomerServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'conversionAction' => self::getConversionActionNameTemplate(),
                 'customer' => self::getCustomerNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_action resource.
+     *
+     * @param string $customerId
+     * @param string $conversionActionId
+     *
+     * @return string The formatted conversion_action resource.
+     */
+    public static function conversionActionName($customerId, $conversionActionId)
+    {
+        return self::getConversionActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_action_id' => $conversionActionId,
+        ]);
     }
 
     /**
@@ -147,6 +176,7 @@ class CustomerServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
      * - customer: customers/{customer_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ExperimentArmServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ExperimentArmServiceGapicClient.php
@@ -80,6 +80,10 @@ class ExperimentArmServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
+    private static $experimentNameTemplate;
+
     private static $experimentArmNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +107,24 @@ class ExperimentArmServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
+    private static function getExperimentNameTemplate()
+    {
+        if (self::$experimentNameTemplate == null) {
+            self::$experimentNameTemplate = new PathTemplate('customers/{customer_id}/experiments/{trial_id}');
+        }
+
+        return self::$experimentNameTemplate;
+    }
+
     private static function getExperimentArmNameTemplate()
     {
         if (self::$experimentArmNameTemplate == null) {
@@ -116,11 +138,47 @@ class ExperimentArmServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
+                'experiment' => self::getExperimentNameTemplate(),
                 'experimentArm' => self::getExperimentArmNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a experiment
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $trialId
+     *
+     * @return string The formatted experiment resource.
+     */
+    public static function experimentName($customerId, $trialId)
+    {
+        return self::getExperimentNameTemplate()->render([
+            'customer_id' => $customerId,
+            'trial_id' => $trialId,
+        ]);
     }
 
     /**
@@ -146,6 +204,8 @@ class ExperimentArmServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - experiment: customers/{customer_id}/experiments/{trial_id}
      * - experimentArm: customers/{customer_id}/experimentArms/{trial_id}~{trial_arm_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ExtensionFeedItemServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ExtensionFeedItemServiceGapicClient.php
@@ -80,7 +80,15 @@ class ExtensionFeedItemServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
+    private static $assetNameTemplate;
+
+    private static $campaignNameTemplate;
+
     private static $extensionFeedItemNameTemplate;
+
+    private static $geoTargetConstantNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +111,33 @@ class ExtensionFeedItemServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getExtensionFeedItemNameTemplate()
     {
         if (self::$extensionFeedItemNameTemplate == null) {
@@ -112,15 +147,79 @@ class ExtensionFeedItemServiceGapicClient
         return self::$extensionFeedItemNameTemplate;
     }
 
+    private static function getGeoTargetConstantNameTemplate()
+    {
+        if (self::$geoTargetConstantNameTemplate == null) {
+            self::$geoTargetConstantNameTemplate = new PathTemplate('geoTargetConstants/{criterion_id}');
+        }
+
+        return self::$geoTargetConstantNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
+                'asset' => self::getAssetNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
                 'extensionFeedItem' => self::getExtensionFeedItemNameTemplate(),
+                'geoTargetConstant' => self::getGeoTargetConstantNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -141,10 +240,29 @@ class ExtensionFeedItemServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * geo_target_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted geo_target_constant resource.
+     */
+    public static function geoTargetConstantName($criterionId)
+    {
+        return self::getGeoTargetConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - extensionFeedItem: customers/{customer_id}/extensionFeedItems/{feed_item_id}
+     * - geoTargetConstant: geoTargetConstants/{criterion_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemServiceGapicClient.php
@@ -80,6 +80,8 @@ class FeedItemServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $feedNameTemplate;
+
     private static $feedItemNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class FeedItemServiceGapicClient
         ];
     }
 
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
     private static function getFeedItemNameTemplate()
     {
         if (self::$feedItemNameTemplate == null) {
@@ -116,11 +127,29 @@ class FeedItemServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'feed' => self::getFeedNameTemplate(),
                 'feedItem' => self::getFeedItemNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class FeedItemServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - feed: customers/{customer_id}/feeds/{feed_id}
      * - feedItem: customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemSetLinkServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemSetLinkServiceGapicClient.php
@@ -80,6 +80,10 @@ class FeedItemSetLinkServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $feedItemNameTemplate;
+
+    private static $feedItemSetNameTemplate;
+
     private static $feedItemSetLinkNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +107,24 @@ class FeedItemSetLinkServiceGapicClient
         ];
     }
 
+    private static function getFeedItemNameTemplate()
+    {
+        if (self::$feedItemNameTemplate == null) {
+            self::$feedItemNameTemplate = new PathTemplate('customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}');
+        }
+
+        return self::$feedItemNameTemplate;
+    }
+
+    private static function getFeedItemSetNameTemplate()
+    {
+        if (self::$feedItemSetNameTemplate == null) {
+            self::$feedItemSetNameTemplate = new PathTemplate('customers/{customer_id}/feedItemSets/{feed_id}~{feed_item_set_id}');
+        }
+
+        return self::$feedItemSetNameTemplate;
+    }
+
     private static function getFeedItemSetLinkNameTemplate()
     {
         if (self::$feedItemSetLinkNameTemplate == null) {
@@ -116,11 +138,51 @@ class FeedItemSetLinkServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'feedItem' => self::getFeedItemNameTemplate(),
+                'feedItemSet' => self::getFeedItemSetNameTemplate(),
                 'feedItemSetLink' => self::getFeedItemSetLinkNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed_item
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     *
+     * @return string The formatted feed_item resource.
+     */
+    public static function feedItemName($customerId, $feedId, $feedItemId)
+    {
+        return self::getFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * feed_item_set resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
+     *
+     * @return string The formatted feed_item_set resource.
+     */
+    public static function feedItemSetName($customerId, $feedId, $feedItemSetId)
+    {
+        return self::getFeedItemSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_set_id' => $feedItemSetId,
+        ]);
     }
 
     /**
@@ -148,6 +210,8 @@ class FeedItemSetLinkServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - feedItem: customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}
+     * - feedItemSet: customers/{customer_id}/feedItemSets/{feed_id}~{feed_item_set_id}
      * - feedItemSetLink: customers/{customer_id}/feedItemSetLinks/{feed_id}~{feed_item_set_id}~{feed_item_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemSetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemSetServiceGapicClient.php
@@ -80,6 +80,8 @@ class FeedItemSetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $feedNameTemplate;
+
     private static $feedItemSetNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class FeedItemSetServiceGapicClient
         ];
     }
 
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
     private static function getFeedItemSetNameTemplate()
     {
         if (self::$feedItemSetNameTemplate == null) {
@@ -116,11 +127,29 @@ class FeedItemSetServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'feed' => self::getFeedNameTemplate(),
                 'feedItemSet' => self::getFeedItemSetNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class FeedItemSetServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - feed: customers/{customer_id}/feeds/{feed_id}
      * - feedItemSet: customers/{customer_id}/feedItemSets/{feed_id}~{feed_item_set_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemTargetServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedItemTargetServiceGapicClient.php
@@ -80,7 +80,15 @@ class FeedItemTargetServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adGroupNameTemplate;
+
+    private static $campaignNameTemplate;
+
+    private static $feedItemNameTemplate;
+
     private static $feedItemTargetNameTemplate;
+
+    private static $geoTargetConstantNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +111,33 @@ class FeedItemTargetServiceGapicClient
         ];
     }
 
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
+    private static function getFeedItemNameTemplate()
+    {
+        if (self::$feedItemNameTemplate == null) {
+            self::$feedItemNameTemplate = new PathTemplate('customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}');
+        }
+
+        return self::$feedItemNameTemplate;
+    }
+
     private static function getFeedItemTargetNameTemplate()
     {
         if (self::$feedItemTargetNameTemplate == null) {
@@ -112,15 +147,81 @@ class FeedItemTargetServiceGapicClient
         return self::$feedItemTargetNameTemplate;
     }
 
+    private static function getGeoTargetConstantNameTemplate()
+    {
+        if (self::$geoTargetConstantNameTemplate == null) {
+            self::$geoTargetConstantNameTemplate = new PathTemplate('geoTargetConstants/{criterion_id}');
+        }
+
+        return self::$geoTargetConstantNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'adGroup' => self::getAdGroupNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
+                'feedItem' => self::getFeedItemNameTemplate(),
                 'feedItemTarget' => self::getFeedItemTargetNameTemplate(),
+                'geoTargetConstant' => self::getGeoTargetConstantNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed_item
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     *
+     * @return string The formatted feed_item resource.
+     */
+    public static function feedItemName($customerId, $feedId, $feedItemId)
+    {
+        return self::getFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_id' => $feedItemId,
+        ]);
     }
 
     /**
@@ -147,10 +248,29 @@ class FeedItemTargetServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * geo_target_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted geo_target_constant resource.
+     */
+    public static function geoTargetConstantName($criterionId)
+    {
+        return self::getGeoTargetConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - feedItem: customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}
      * - feedItemTarget: customers/{customer_id}/feedItemTargets/{feed_id}~{feed_item_id}~{feed_item_target_type}~{feed_item_target_id}
+     * - geoTargetConstant: geoTargetConstants/{criterion_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedMappingServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/FeedMappingServiceGapicClient.php
@@ -80,6 +80,8 @@ class FeedMappingServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $feedNameTemplate;
+
     private static $feedMappingNameTemplate;
 
     private static $pathTemplateMap;
@@ -103,6 +105,15 @@ class FeedMappingServiceGapicClient
         ];
     }
 
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
     private static function getFeedMappingNameTemplate()
     {
         if (self::$feedMappingNameTemplate == null) {
@@ -116,11 +127,29 @@ class FeedMappingServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'feed' => self::getFeedNameTemplate(),
                 'feedMapping' => self::getFeedMappingNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
     }
 
     /**
@@ -146,6 +175,7 @@ class FeedMappingServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - feed: customers/{customer_id}/feeds/{feed_id}
      * - feedMapping: customers/{customer_id}/feedMappings/{feed_id}~{feed_mapping_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/GoogleAdsServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/GoogleAdsServiceGapicClient.php
@@ -35,6 +35,7 @@ use Google\ApiCore\ApiException;
 use Google\ApiCore\Call;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -57,6 +58,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $googleAdsServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class GoogleAdsServiceGapicClient
 {
@@ -79,6 +85,166 @@ class GoogleAdsServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $accessibleBiddingStrategyNameTemplate;
+
+    private static $adNameTemplate;
+
+    private static $adGroupNameTemplate;
+
+    private static $adGroupAdNameTemplate;
+
+    private static $adGroupAdLabelNameTemplate;
+
+    private static $adGroupAssetNameTemplate;
+
+    private static $adGroupBidModifierNameTemplate;
+
+    private static $adGroupCriterionNameTemplate;
+
+    private static $adGroupCriterionCustomizerNameTemplate;
+
+    private static $adGroupCriterionLabelNameTemplate;
+
+    private static $adGroupCustomizerNameTemplate;
+
+    private static $adGroupExtensionSettingNameTemplate;
+
+    private static $adGroupFeedNameTemplate;
+
+    private static $adGroupLabelNameTemplate;
+
+    private static $adParameterNameTemplate;
+
+    private static $assetNameTemplate;
+
+    private static $assetGroupNameTemplate;
+
+    private static $assetGroupAssetNameTemplate;
+
+    private static $assetGroupListingGroupFilterNameTemplate;
+
+    private static $assetGroupSignalNameTemplate;
+
+    private static $assetSetNameTemplate;
+
+    private static $assetSetAssetNameTemplate;
+
+    private static $audienceNameTemplate;
+
+    private static $biddingDataExclusionNameTemplate;
+
+    private static $biddingSeasonalityAdjustmentNameTemplate;
+
+    private static $biddingStrategyNameTemplate;
+
+    private static $campaignNameTemplate;
+
+    private static $campaignAssetNameTemplate;
+
+    private static $campaignAssetSetNameTemplate;
+
+    private static $campaignBidModifierNameTemplate;
+
+    private static $campaignBudgetNameTemplate;
+
+    private static $campaignConversionGoalNameTemplate;
+
+    private static $campaignCriterionNameTemplate;
+
+    private static $campaignCustomizerNameTemplate;
+
+    private static $campaignDraftNameTemplate;
+
+    private static $campaignExtensionSettingNameTemplate;
+
+    private static $campaignFeedNameTemplate;
+
+    private static $campaignGroupNameTemplate;
+
+    private static $campaignLabelNameTemplate;
+
+    private static $campaignSharedSetNameTemplate;
+
+    private static $conversionActionNameTemplate;
+
+    private static $conversionCustomVariableNameTemplate;
+
+    private static $conversionGoalCampaignConfigNameTemplate;
+
+    private static $conversionValueRuleNameTemplate;
+
+    private static $conversionValueRuleSetNameTemplate;
+
+    private static $customConversionGoalNameTemplate;
+
+    private static $customerNameTemplate;
+
+    private static $customerAssetNameTemplate;
+
+    private static $customerConversionGoalNameTemplate;
+
+    private static $customerCustomizerNameTemplate;
+
+    private static $customerExtensionSettingNameTemplate;
+
+    private static $customerFeedNameTemplate;
+
+    private static $customerLabelNameTemplate;
+
+    private static $customerNegativeCriterionNameTemplate;
+
+    private static $customizerAttributeNameTemplate;
+
+    private static $experimentNameTemplate;
+
+    private static $experimentArmNameTemplate;
+
+    private static $extensionFeedItemNameTemplate;
+
+    private static $feedNameTemplate;
+
+    private static $feedItemNameTemplate;
+
+    private static $feedItemSetNameTemplate;
+
+    private static $feedItemSetLinkNameTemplate;
+
+    private static $feedItemTargetNameTemplate;
+
+    private static $feedMappingNameTemplate;
+
+    private static $geoTargetConstantNameTemplate;
+
+    private static $keywordPlanNameTemplate;
+
+    private static $keywordPlanAdGroupNameTemplate;
+
+    private static $keywordPlanAdGroupKeywordNameTemplate;
+
+    private static $keywordPlanCampaignNameTemplate;
+
+    private static $keywordPlanCampaignKeywordNameTemplate;
+
+    private static $labelNameTemplate;
+
+    private static $languageConstantNameTemplate;
+
+    private static $mediaFileNameTemplate;
+
+    private static $remarketingActionNameTemplate;
+
+    private static $sharedCriterionNameTemplate;
+
+    private static $sharedSetNameTemplate;
+
+    private static $smartCampaignSettingNameTemplate;
+
+    private static $userInterestNameTemplate;
+
+    private static $userListNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -96,6 +262,2355 @@ class GoogleAdsServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getAccessibleBiddingStrategyNameTemplate()
+    {
+        if (self::$accessibleBiddingStrategyNameTemplate == null) {
+            self::$accessibleBiddingStrategyNameTemplate = new PathTemplate('customers/{customer_id}/accessibleBiddingStrategies/{bidding_strategy_id}');
+        }
+
+        return self::$accessibleBiddingStrategyNameTemplate;
+    }
+
+    private static function getAdNameTemplate()
+    {
+        if (self::$adNameTemplate == null) {
+            self::$adNameTemplate = new PathTemplate('customers/{customer_id}/ads/{ad_id}');
+        }
+
+        return self::$adNameTemplate;
+    }
+
+    private static function getAdGroupNameTemplate()
+    {
+        if (self::$adGroupNameTemplate == null) {
+            self::$adGroupNameTemplate = new PathTemplate('customers/{customer_id}/adGroups/{ad_group_id}');
+        }
+
+        return self::$adGroupNameTemplate;
+    }
+
+    private static function getAdGroupAdNameTemplate()
+    {
+        if (self::$adGroupAdNameTemplate == null) {
+            self::$adGroupAdNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}');
+        }
+
+        return self::$adGroupAdNameTemplate;
+    }
+
+    private static function getAdGroupAdLabelNameTemplate()
+    {
+        if (self::$adGroupAdLabelNameTemplate == null) {
+            self::$adGroupAdLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}');
+        }
+
+        return self::$adGroupAdLabelNameTemplate;
+    }
+
+    private static function getAdGroupAssetNameTemplate()
+    {
+        if (self::$adGroupAssetNameTemplate == null) {
+            self::$adGroupAssetNameTemplate = new PathTemplate('customers/{customer_id}/adGroupAssets/{ad_group_id}~{asset_id}~{field_type}');
+        }
+
+        return self::$adGroupAssetNameTemplate;
+    }
+
+    private static function getAdGroupBidModifierNameTemplate()
+    {
+        if (self::$adGroupBidModifierNameTemplate == null) {
+            self::$adGroupBidModifierNameTemplate = new PathTemplate('customers/{customer_id}/adGroupBidModifiers/{ad_group_id}~{criterion_id}');
+        }
+
+        return self::$adGroupBidModifierNameTemplate;
+    }
+
+    private static function getAdGroupCriterionNameTemplate()
+    {
+        if (self::$adGroupCriterionNameTemplate == null) {
+            self::$adGroupCriterionNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}');
+        }
+
+        return self::$adGroupCriterionNameTemplate;
+    }
+
+    private static function getAdGroupCriterionCustomizerNameTemplate()
+    {
+        if (self::$adGroupCriterionCustomizerNameTemplate == null) {
+            self::$adGroupCriterionCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriterionCustomizers/{ad_group_id}~{criterion_id}~{customizer_attribute_id}');
+        }
+
+        return self::$adGroupCriterionCustomizerNameTemplate;
+    }
+
+    private static function getAdGroupCriterionLabelNameTemplate()
+    {
+        if (self::$adGroupCriterionLabelNameTemplate == null) {
+            self::$adGroupCriterionLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}');
+        }
+
+        return self::$adGroupCriterionLabelNameTemplate;
+    }
+
+    private static function getAdGroupCustomizerNameTemplate()
+    {
+        if (self::$adGroupCustomizerNameTemplate == null) {
+            self::$adGroupCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/adGroupCustomizers/{ad_group_id}~{customizer_attribute_id}');
+        }
+
+        return self::$adGroupCustomizerNameTemplate;
+    }
+
+    private static function getAdGroupExtensionSettingNameTemplate()
+    {
+        if (self::$adGroupExtensionSettingNameTemplate == null) {
+            self::$adGroupExtensionSettingNameTemplate = new PathTemplate('customers/{customer_id}/adGroupExtensionSettings/{ad_group_id}~{extension_type}');
+        }
+
+        return self::$adGroupExtensionSettingNameTemplate;
+    }
+
+    private static function getAdGroupFeedNameTemplate()
+    {
+        if (self::$adGroupFeedNameTemplate == null) {
+            self::$adGroupFeedNameTemplate = new PathTemplate('customers/{customer_id}/adGroupFeeds/{ad_group_id}~{feed_id}');
+        }
+
+        return self::$adGroupFeedNameTemplate;
+    }
+
+    private static function getAdGroupLabelNameTemplate()
+    {
+        if (self::$adGroupLabelNameTemplate == null) {
+            self::$adGroupLabelNameTemplate = new PathTemplate('customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}');
+        }
+
+        return self::$adGroupLabelNameTemplate;
+    }
+
+    private static function getAdParameterNameTemplate()
+    {
+        if (self::$adParameterNameTemplate == null) {
+            self::$adParameterNameTemplate = new PathTemplate('customers/{customer_id}/adParameters/{ad_group_id}~{criterion_id}~{parameter_index}');
+        }
+
+        return self::$adParameterNameTemplate;
+    }
+
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getAssetGroupNameTemplate()
+    {
+        if (self::$assetGroupNameTemplate == null) {
+            self::$assetGroupNameTemplate = new PathTemplate('customers/{customer_id}/assetGroups/{asset_group_id}');
+        }
+
+        return self::$assetGroupNameTemplate;
+    }
+
+    private static function getAssetGroupAssetNameTemplate()
+    {
+        if (self::$assetGroupAssetNameTemplate == null) {
+            self::$assetGroupAssetNameTemplate = new PathTemplate('customers/{customer_id}/assetGroupAssets/{asset_group_id}~{asset_id}~{field_type}');
+        }
+
+        return self::$assetGroupAssetNameTemplate;
+    }
+
+    private static function getAssetGroupListingGroupFilterNameTemplate()
+    {
+        if (self::$assetGroupListingGroupFilterNameTemplate == null) {
+            self::$assetGroupListingGroupFilterNameTemplate = new PathTemplate('customers/{customer_id}/assetGroupListingGroupFilters/{asset_group_id}~{listing_group_filter_id}');
+        }
+
+        return self::$assetGroupListingGroupFilterNameTemplate;
+    }
+
+    private static function getAssetGroupSignalNameTemplate()
+    {
+        if (self::$assetGroupSignalNameTemplate == null) {
+            self::$assetGroupSignalNameTemplate = new PathTemplate('customers/{customer_id}/assetGroupSignals/{asset_group_id}~{criterion_id}');
+        }
+
+        return self::$assetGroupSignalNameTemplate;
+    }
+
+    private static function getAssetSetNameTemplate()
+    {
+        if (self::$assetSetNameTemplate == null) {
+            self::$assetSetNameTemplate = new PathTemplate('customers/{customer_id}/assetSets/{asset_set_id}');
+        }
+
+        return self::$assetSetNameTemplate;
+    }
+
+    private static function getAssetSetAssetNameTemplate()
+    {
+        if (self::$assetSetAssetNameTemplate == null) {
+            self::$assetSetAssetNameTemplate = new PathTemplate('customers/{customer_id}/assetSetAssets/{asset_set_id}~{asset_id}');
+        }
+
+        return self::$assetSetAssetNameTemplate;
+    }
+
+    private static function getAudienceNameTemplate()
+    {
+        if (self::$audienceNameTemplate == null) {
+            self::$audienceNameTemplate = new PathTemplate('customers/{customer_id}/audiences/{audience_id}');
+        }
+
+        return self::$audienceNameTemplate;
+    }
+
+    private static function getBiddingDataExclusionNameTemplate()
+    {
+        if (self::$biddingDataExclusionNameTemplate == null) {
+            self::$biddingDataExclusionNameTemplate = new PathTemplate('customers/{customer_id}/biddingDataExclusions/{seasonality_event_id}');
+        }
+
+        return self::$biddingDataExclusionNameTemplate;
+    }
+
+    private static function getBiddingSeasonalityAdjustmentNameTemplate()
+    {
+        if (self::$biddingSeasonalityAdjustmentNameTemplate == null) {
+            self::$biddingSeasonalityAdjustmentNameTemplate = new PathTemplate('customers/{customer_id}/biddingSeasonalityAdjustments/{seasonality_event_id}');
+        }
+
+        return self::$biddingSeasonalityAdjustmentNameTemplate;
+    }
+
+    private static function getBiddingStrategyNameTemplate()
+    {
+        if (self::$biddingStrategyNameTemplate == null) {
+            self::$biddingStrategyNameTemplate = new PathTemplate('customers/{customer_id}/biddingStrategies/{bidding_strategy_id}');
+        }
+
+        return self::$biddingStrategyNameTemplate;
+    }
+
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
+    private static function getCampaignAssetNameTemplate()
+    {
+        if (self::$campaignAssetNameTemplate == null) {
+            self::$campaignAssetNameTemplate = new PathTemplate('customers/{customer_id}/campaignAssets/{campaign_id}~{asset_id}~{field_type}');
+        }
+
+        return self::$campaignAssetNameTemplate;
+    }
+
+    private static function getCampaignAssetSetNameTemplate()
+    {
+        if (self::$campaignAssetSetNameTemplate == null) {
+            self::$campaignAssetSetNameTemplate = new PathTemplate('customers/{customer_id}/campaignAssetSets/{campaign_id}~{asset_set_id}');
+        }
+
+        return self::$campaignAssetSetNameTemplate;
+    }
+
+    private static function getCampaignBidModifierNameTemplate()
+    {
+        if (self::$campaignBidModifierNameTemplate == null) {
+            self::$campaignBidModifierNameTemplate = new PathTemplate('customers/{customer_id}/campaignBidModifiers/{campaign_id}~{criterion_id}');
+        }
+
+        return self::$campaignBidModifierNameTemplate;
+    }
+
+    private static function getCampaignBudgetNameTemplate()
+    {
+        if (self::$campaignBudgetNameTemplate == null) {
+            self::$campaignBudgetNameTemplate = new PathTemplate('customers/{customer_id}/campaignBudgets/{campaign_budget_id}');
+        }
+
+        return self::$campaignBudgetNameTemplate;
+    }
+
+    private static function getCampaignConversionGoalNameTemplate()
+    {
+        if (self::$campaignConversionGoalNameTemplate == null) {
+            self::$campaignConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/campaignConversionGoals/{campaign_id}~{category}~{source}');
+        }
+
+        return self::$campaignConversionGoalNameTemplate;
+    }
+
+    private static function getCampaignCriterionNameTemplate()
+    {
+        if (self::$campaignCriterionNameTemplate == null) {
+            self::$campaignCriterionNameTemplate = new PathTemplate('customers/{customer_id}/campaignCriteria/{campaign_id}~{criterion_id}');
+        }
+
+        return self::$campaignCriterionNameTemplate;
+    }
+
+    private static function getCampaignCustomizerNameTemplate()
+    {
+        if (self::$campaignCustomizerNameTemplate == null) {
+            self::$campaignCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/campaignCustomizers/{campaign_id}~{customizer_attribute_id}');
+        }
+
+        return self::$campaignCustomizerNameTemplate;
+    }
+
+    private static function getCampaignDraftNameTemplate()
+    {
+        if (self::$campaignDraftNameTemplate == null) {
+            self::$campaignDraftNameTemplate = new PathTemplate('customers/{customer_id}/campaignDrafts/{base_campaign_id}~{draft_id}');
+        }
+
+        return self::$campaignDraftNameTemplate;
+    }
+
+    private static function getCampaignExtensionSettingNameTemplate()
+    {
+        if (self::$campaignExtensionSettingNameTemplate == null) {
+            self::$campaignExtensionSettingNameTemplate = new PathTemplate('customers/{customer_id}/campaignExtensionSettings/{campaign_id}~{extension_type}');
+        }
+
+        return self::$campaignExtensionSettingNameTemplate;
+    }
+
+    private static function getCampaignFeedNameTemplate()
+    {
+        if (self::$campaignFeedNameTemplate == null) {
+            self::$campaignFeedNameTemplate = new PathTemplate('customers/{customer_id}/campaignFeeds/{campaign_id}~{feed_id}');
+        }
+
+        return self::$campaignFeedNameTemplate;
+    }
+
+    private static function getCampaignGroupNameTemplate()
+    {
+        if (self::$campaignGroupNameTemplate == null) {
+            self::$campaignGroupNameTemplate = new PathTemplate('customers/{customer_id}/campaignGroups/{campaign_group_id}');
+        }
+
+        return self::$campaignGroupNameTemplate;
+    }
+
+    private static function getCampaignLabelNameTemplate()
+    {
+        if (self::$campaignLabelNameTemplate == null) {
+            self::$campaignLabelNameTemplate = new PathTemplate('customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}');
+        }
+
+        return self::$campaignLabelNameTemplate;
+    }
+
+    private static function getCampaignSharedSetNameTemplate()
+    {
+        if (self::$campaignSharedSetNameTemplate == null) {
+            self::$campaignSharedSetNameTemplate = new PathTemplate('customers/{customer_id}/campaignSharedSets/{campaign_id}~{shared_set_id}');
+        }
+
+        return self::$campaignSharedSetNameTemplate;
+    }
+
+    private static function getConversionActionNameTemplate()
+    {
+        if (self::$conversionActionNameTemplate == null) {
+            self::$conversionActionNameTemplate = new PathTemplate('customers/{customer_id}/conversionActions/{conversion_action_id}');
+        }
+
+        return self::$conversionActionNameTemplate;
+    }
+
+    private static function getConversionCustomVariableNameTemplate()
+    {
+        if (self::$conversionCustomVariableNameTemplate == null) {
+            self::$conversionCustomVariableNameTemplate = new PathTemplate('customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}');
+        }
+
+        return self::$conversionCustomVariableNameTemplate;
+    }
+
+    private static function getConversionGoalCampaignConfigNameTemplate()
+    {
+        if (self::$conversionGoalCampaignConfigNameTemplate == null) {
+            self::$conversionGoalCampaignConfigNameTemplate = new PathTemplate('customers/{customer_id}/conversionGoalCampaignConfigs/{campaign_id}');
+        }
+
+        return self::$conversionGoalCampaignConfigNameTemplate;
+    }
+
+    private static function getConversionValueRuleNameTemplate()
+    {
+        if (self::$conversionValueRuleNameTemplate == null) {
+            self::$conversionValueRuleNameTemplate = new PathTemplate('customers/{customer_id}/conversionValueRules/{conversion_value_rule_id}');
+        }
+
+        return self::$conversionValueRuleNameTemplate;
+    }
+
+    private static function getConversionValueRuleSetNameTemplate()
+    {
+        if (self::$conversionValueRuleSetNameTemplate == null) {
+            self::$conversionValueRuleSetNameTemplate = new PathTemplate('customers/{customer_id}/conversionValueRuleSets/{conversion_value_rule_set_id}');
+        }
+
+        return self::$conversionValueRuleSetNameTemplate;
+    }
+
+    private static function getCustomConversionGoalNameTemplate()
+    {
+        if (self::$customConversionGoalNameTemplate == null) {
+            self::$customConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/customConversionGoals/{goal_id}');
+        }
+
+        return self::$customConversionGoalNameTemplate;
+    }
+
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
+    private static function getCustomerAssetNameTemplate()
+    {
+        if (self::$customerAssetNameTemplate == null) {
+            self::$customerAssetNameTemplate = new PathTemplate('customers/{customer_id}/customerAssets/{asset_id}~{field_type}');
+        }
+
+        return self::$customerAssetNameTemplate;
+    }
+
+    private static function getCustomerConversionGoalNameTemplate()
+    {
+        if (self::$customerConversionGoalNameTemplate == null) {
+            self::$customerConversionGoalNameTemplate = new PathTemplate('customers/{customer_id}/customerConversionGoals/{category}~{source}');
+        }
+
+        return self::$customerConversionGoalNameTemplate;
+    }
+
+    private static function getCustomerCustomizerNameTemplate()
+    {
+        if (self::$customerCustomizerNameTemplate == null) {
+            self::$customerCustomizerNameTemplate = new PathTemplate('customers/{customer_id}/customerCustomizers/{customizer_attribute_id}');
+        }
+
+        return self::$customerCustomizerNameTemplate;
+    }
+
+    private static function getCustomerExtensionSettingNameTemplate()
+    {
+        if (self::$customerExtensionSettingNameTemplate == null) {
+            self::$customerExtensionSettingNameTemplate = new PathTemplate('customers/{customer_id}/customerExtensionSettings/{extension_type}');
+        }
+
+        return self::$customerExtensionSettingNameTemplate;
+    }
+
+    private static function getCustomerFeedNameTemplate()
+    {
+        if (self::$customerFeedNameTemplate == null) {
+            self::$customerFeedNameTemplate = new PathTemplate('customers/{customer_id}/customerFeeds/{feed_id}');
+        }
+
+        return self::$customerFeedNameTemplate;
+    }
+
+    private static function getCustomerLabelNameTemplate()
+    {
+        if (self::$customerLabelNameTemplate == null) {
+            self::$customerLabelNameTemplate = new PathTemplate('customers/{customer_id}/customerLabels/{label_id}');
+        }
+
+        return self::$customerLabelNameTemplate;
+    }
+
+    private static function getCustomerNegativeCriterionNameTemplate()
+    {
+        if (self::$customerNegativeCriterionNameTemplate == null) {
+            self::$customerNegativeCriterionNameTemplate = new PathTemplate('customers/{customer_id}/customerNegativeCriteria/{criterion_id}');
+        }
+
+        return self::$customerNegativeCriterionNameTemplate;
+    }
+
+    private static function getCustomizerAttributeNameTemplate()
+    {
+        if (self::$customizerAttributeNameTemplate == null) {
+            self::$customizerAttributeNameTemplate = new PathTemplate('customers/{customer_id}/customizerAttributes/{customizer_attribute_id}');
+        }
+
+        return self::$customizerAttributeNameTemplate;
+    }
+
+    private static function getExperimentNameTemplate()
+    {
+        if (self::$experimentNameTemplate == null) {
+            self::$experimentNameTemplate = new PathTemplate('customers/{customer_id}/experiments/{trial_id}');
+        }
+
+        return self::$experimentNameTemplate;
+    }
+
+    private static function getExperimentArmNameTemplate()
+    {
+        if (self::$experimentArmNameTemplate == null) {
+            self::$experimentArmNameTemplate = new PathTemplate('customers/{customer_id}/experimentArms/{trial_id}~{trial_arm_id}');
+        }
+
+        return self::$experimentArmNameTemplate;
+    }
+
+    private static function getExtensionFeedItemNameTemplate()
+    {
+        if (self::$extensionFeedItemNameTemplate == null) {
+            self::$extensionFeedItemNameTemplate = new PathTemplate('customers/{customer_id}/extensionFeedItems/{feed_item_id}');
+        }
+
+        return self::$extensionFeedItemNameTemplate;
+    }
+
+    private static function getFeedNameTemplate()
+    {
+        if (self::$feedNameTemplate == null) {
+            self::$feedNameTemplate = new PathTemplate('customers/{customer_id}/feeds/{feed_id}');
+        }
+
+        return self::$feedNameTemplate;
+    }
+
+    private static function getFeedItemNameTemplate()
+    {
+        if (self::$feedItemNameTemplate == null) {
+            self::$feedItemNameTemplate = new PathTemplate('customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}');
+        }
+
+        return self::$feedItemNameTemplate;
+    }
+
+    private static function getFeedItemSetNameTemplate()
+    {
+        if (self::$feedItemSetNameTemplate == null) {
+            self::$feedItemSetNameTemplate = new PathTemplate('customers/{customer_id}/feedItemSets/{feed_id}~{feed_item_set_id}');
+        }
+
+        return self::$feedItemSetNameTemplate;
+    }
+
+    private static function getFeedItemSetLinkNameTemplate()
+    {
+        if (self::$feedItemSetLinkNameTemplate == null) {
+            self::$feedItemSetLinkNameTemplate = new PathTemplate('customers/{customer_id}/feedItemSetLinks/{feed_id}~{feed_item_set_id}~{feed_item_id}');
+        }
+
+        return self::$feedItemSetLinkNameTemplate;
+    }
+
+    private static function getFeedItemTargetNameTemplate()
+    {
+        if (self::$feedItemTargetNameTemplate == null) {
+            self::$feedItemTargetNameTemplate = new PathTemplate('customers/{customer_id}/feedItemTargets/{feed_id}~{feed_item_id}~{feed_item_target_type}~{feed_item_target_id}');
+        }
+
+        return self::$feedItemTargetNameTemplate;
+    }
+
+    private static function getFeedMappingNameTemplate()
+    {
+        if (self::$feedMappingNameTemplate == null) {
+            self::$feedMappingNameTemplate = new PathTemplate('customers/{customer_id}/feedMappings/{feed_id}~{feed_mapping_id}');
+        }
+
+        return self::$feedMappingNameTemplate;
+    }
+
+    private static function getGeoTargetConstantNameTemplate()
+    {
+        if (self::$geoTargetConstantNameTemplate == null) {
+            self::$geoTargetConstantNameTemplate = new PathTemplate('geoTargetConstants/{criterion_id}');
+        }
+
+        return self::$geoTargetConstantNameTemplate;
+    }
+
+    private static function getKeywordPlanNameTemplate()
+    {
+        if (self::$keywordPlanNameTemplate == null) {
+            self::$keywordPlanNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlans/{keyword_plan_id}');
+        }
+
+        return self::$keywordPlanNameTemplate;
+    }
+
+    private static function getKeywordPlanAdGroupNameTemplate()
+    {
+        if (self::$keywordPlanAdGroupNameTemplate == null) {
+            self::$keywordPlanAdGroupNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanAdGroups/{keyword_plan_ad_group_id}');
+        }
+
+        return self::$keywordPlanAdGroupNameTemplate;
+    }
+
+    private static function getKeywordPlanAdGroupKeywordNameTemplate()
+    {
+        if (self::$keywordPlanAdGroupKeywordNameTemplate == null) {
+            self::$keywordPlanAdGroupKeywordNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanAdGroupKeywords/{keyword_plan_ad_group_keyword_id}');
+        }
+
+        return self::$keywordPlanAdGroupKeywordNameTemplate;
+    }
+
+    private static function getKeywordPlanCampaignNameTemplate()
+    {
+        if (self::$keywordPlanCampaignNameTemplate == null) {
+            self::$keywordPlanCampaignNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}');
+        }
+
+        return self::$keywordPlanCampaignNameTemplate;
+    }
+
+    private static function getKeywordPlanCampaignKeywordNameTemplate()
+    {
+        if (self::$keywordPlanCampaignKeywordNameTemplate == null) {
+            self::$keywordPlanCampaignKeywordNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanCampaignKeywords/{keyword_plan_campaign_keyword_id}');
+        }
+
+        return self::$keywordPlanCampaignKeywordNameTemplate;
+    }
+
+    private static function getLabelNameTemplate()
+    {
+        if (self::$labelNameTemplate == null) {
+            self::$labelNameTemplate = new PathTemplate('customers/{customer_id}/labels/{label_id}');
+        }
+
+        return self::$labelNameTemplate;
+    }
+
+    private static function getLanguageConstantNameTemplate()
+    {
+        if (self::$languageConstantNameTemplate == null) {
+            self::$languageConstantNameTemplate = new PathTemplate('languageConstants/{criterion_id}');
+        }
+
+        return self::$languageConstantNameTemplate;
+    }
+
+    private static function getMediaFileNameTemplate()
+    {
+        if (self::$mediaFileNameTemplate == null) {
+            self::$mediaFileNameTemplate = new PathTemplate('customers/{customer_id}/mediaFiles/{media_file_id}');
+        }
+
+        return self::$mediaFileNameTemplate;
+    }
+
+    private static function getRemarketingActionNameTemplate()
+    {
+        if (self::$remarketingActionNameTemplate == null) {
+            self::$remarketingActionNameTemplate = new PathTemplate('customers/{customer_id}/remarketingActions/{remarketing_action_id}');
+        }
+
+        return self::$remarketingActionNameTemplate;
+    }
+
+    private static function getSharedCriterionNameTemplate()
+    {
+        if (self::$sharedCriterionNameTemplate == null) {
+            self::$sharedCriterionNameTemplate = new PathTemplate('customers/{customer_id}/sharedCriteria/{shared_set_id}~{criterion_id}');
+        }
+
+        return self::$sharedCriterionNameTemplate;
+    }
+
+    private static function getSharedSetNameTemplate()
+    {
+        if (self::$sharedSetNameTemplate == null) {
+            self::$sharedSetNameTemplate = new PathTemplate('customers/{customer_id}/sharedSets/{shared_set_id}');
+        }
+
+        return self::$sharedSetNameTemplate;
+    }
+
+    private static function getSmartCampaignSettingNameTemplate()
+    {
+        if (self::$smartCampaignSettingNameTemplate == null) {
+            self::$smartCampaignSettingNameTemplate = new PathTemplate('customers/{customer_id}/smartCampaignSettings/{campaign_id}');
+        }
+
+        return self::$smartCampaignSettingNameTemplate;
+    }
+
+    private static function getUserInterestNameTemplate()
+    {
+        if (self::$userInterestNameTemplate == null) {
+            self::$userInterestNameTemplate = new PathTemplate('customers/{customer_id}/userInterests/{user_interest_id}');
+        }
+
+        return self::$userInterestNameTemplate;
+    }
+
+    private static function getUserListNameTemplate()
+    {
+        if (self::$userListNameTemplate == null) {
+            self::$userListNameTemplate = new PathTemplate('customers/{customer_id}/userLists/{user_list_id}');
+        }
+
+        return self::$userListNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'accessibleBiddingStrategy' => self::getAccessibleBiddingStrategyNameTemplate(),
+                'ad' => self::getAdNameTemplate(),
+                'adGroup' => self::getAdGroupNameTemplate(),
+                'adGroupAd' => self::getAdGroupAdNameTemplate(),
+                'adGroupAdLabel' => self::getAdGroupAdLabelNameTemplate(),
+                'adGroupAsset' => self::getAdGroupAssetNameTemplate(),
+                'adGroupBidModifier' => self::getAdGroupBidModifierNameTemplate(),
+                'adGroupCriterion' => self::getAdGroupCriterionNameTemplate(),
+                'adGroupCriterionCustomizer' => self::getAdGroupCriterionCustomizerNameTemplate(),
+                'adGroupCriterionLabel' => self::getAdGroupCriterionLabelNameTemplate(),
+                'adGroupCustomizer' => self::getAdGroupCustomizerNameTemplate(),
+                'adGroupExtensionSetting' => self::getAdGroupExtensionSettingNameTemplate(),
+                'adGroupFeed' => self::getAdGroupFeedNameTemplate(),
+                'adGroupLabel' => self::getAdGroupLabelNameTemplate(),
+                'adParameter' => self::getAdParameterNameTemplate(),
+                'asset' => self::getAssetNameTemplate(),
+                'assetGroup' => self::getAssetGroupNameTemplate(),
+                'assetGroupAsset' => self::getAssetGroupAssetNameTemplate(),
+                'assetGroupListingGroupFilter' => self::getAssetGroupListingGroupFilterNameTemplate(),
+                'assetGroupSignal' => self::getAssetGroupSignalNameTemplate(),
+                'assetSet' => self::getAssetSetNameTemplate(),
+                'assetSetAsset' => self::getAssetSetAssetNameTemplate(),
+                'audience' => self::getAudienceNameTemplate(),
+                'biddingDataExclusion' => self::getBiddingDataExclusionNameTemplate(),
+                'biddingSeasonalityAdjustment' => self::getBiddingSeasonalityAdjustmentNameTemplate(),
+                'biddingStrategy' => self::getBiddingStrategyNameTemplate(),
+                'campaign' => self::getCampaignNameTemplate(),
+                'campaignAsset' => self::getCampaignAssetNameTemplate(),
+                'campaignAssetSet' => self::getCampaignAssetSetNameTemplate(),
+                'campaignBidModifier' => self::getCampaignBidModifierNameTemplate(),
+                'campaignBudget' => self::getCampaignBudgetNameTemplate(),
+                'campaignConversionGoal' => self::getCampaignConversionGoalNameTemplate(),
+                'campaignCriterion' => self::getCampaignCriterionNameTemplate(),
+                'campaignCustomizer' => self::getCampaignCustomizerNameTemplate(),
+                'campaignDraft' => self::getCampaignDraftNameTemplate(),
+                'campaignExtensionSetting' => self::getCampaignExtensionSettingNameTemplate(),
+                'campaignFeed' => self::getCampaignFeedNameTemplate(),
+                'campaignGroup' => self::getCampaignGroupNameTemplate(),
+                'campaignLabel' => self::getCampaignLabelNameTemplate(),
+                'campaignSharedSet' => self::getCampaignSharedSetNameTemplate(),
+                'conversionAction' => self::getConversionActionNameTemplate(),
+                'conversionCustomVariable' => self::getConversionCustomVariableNameTemplate(),
+                'conversionGoalCampaignConfig' => self::getConversionGoalCampaignConfigNameTemplate(),
+                'conversionValueRule' => self::getConversionValueRuleNameTemplate(),
+                'conversionValueRuleSet' => self::getConversionValueRuleSetNameTemplate(),
+                'customConversionGoal' => self::getCustomConversionGoalNameTemplate(),
+                'customer' => self::getCustomerNameTemplate(),
+                'customerAsset' => self::getCustomerAssetNameTemplate(),
+                'customerConversionGoal' => self::getCustomerConversionGoalNameTemplate(),
+                'customerCustomizer' => self::getCustomerCustomizerNameTemplate(),
+                'customerExtensionSetting' => self::getCustomerExtensionSettingNameTemplate(),
+                'customerFeed' => self::getCustomerFeedNameTemplate(),
+                'customerLabel' => self::getCustomerLabelNameTemplate(),
+                'customerNegativeCriterion' => self::getCustomerNegativeCriterionNameTemplate(),
+                'customizerAttribute' => self::getCustomizerAttributeNameTemplate(),
+                'experiment' => self::getExperimentNameTemplate(),
+                'experimentArm' => self::getExperimentArmNameTemplate(),
+                'extensionFeedItem' => self::getExtensionFeedItemNameTemplate(),
+                'feed' => self::getFeedNameTemplate(),
+                'feedItem' => self::getFeedItemNameTemplate(),
+                'feedItemSet' => self::getFeedItemSetNameTemplate(),
+                'feedItemSetLink' => self::getFeedItemSetLinkNameTemplate(),
+                'feedItemTarget' => self::getFeedItemTargetNameTemplate(),
+                'feedMapping' => self::getFeedMappingNameTemplate(),
+                'geoTargetConstant' => self::getGeoTargetConstantNameTemplate(),
+                'keywordPlan' => self::getKeywordPlanNameTemplate(),
+                'keywordPlanAdGroup' => self::getKeywordPlanAdGroupNameTemplate(),
+                'keywordPlanAdGroupKeyword' => self::getKeywordPlanAdGroupKeywordNameTemplate(),
+                'keywordPlanCampaign' => self::getKeywordPlanCampaignNameTemplate(),
+                'keywordPlanCampaignKeyword' => self::getKeywordPlanCampaignKeywordNameTemplate(),
+                'label' => self::getLabelNameTemplate(),
+                'languageConstant' => self::getLanguageConstantNameTemplate(),
+                'mediaFile' => self::getMediaFileNameTemplate(),
+                'remarketingAction' => self::getRemarketingActionNameTemplate(),
+                'sharedCriterion' => self::getSharedCriterionNameTemplate(),
+                'sharedSet' => self::getSharedSetNameTemplate(),
+                'smartCampaignSetting' => self::getSmartCampaignSettingNameTemplate(),
+                'userInterest' => self::getUserInterestNameTemplate(),
+                'userList' => self::getUserListNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * accessible_bidding_strategy resource.
+     *
+     * @param string $customerId
+     * @param string $biddingStrategyId
+     *
+     * @return string The formatted accessible_bidding_strategy resource.
+     */
+    public static function accessibleBiddingStrategyName($customerId, $biddingStrategyId)
+    {
+        return self::getAccessibleBiddingStrategyNameTemplate()->render([
+            'customer_id' => $customerId,
+            'bidding_strategy_id' => $biddingStrategyId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad resource.
+     *
+     * @param string $customerId
+     * @param string $adId
+     *
+     * @return string The formatted ad resource.
+     */
+    public static function adName($customerId, $adId)
+    {
+        return self::getAdNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_id' => $adId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     *
+     * @return string The formatted ad_group resource.
+     */
+    public static function adGroupName($customerId, $adGroupId)
+    {
+        return self::getAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_group_ad
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     *
+     * @return string The formatted ad_group_ad resource.
+     */
+    public static function adGroupAdName($customerId, $adGroupId, $adId)
+    {
+        return self::getAdGroupAdNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'ad_id' => $adId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_ad_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $adId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_ad_label resource.
+     */
+    public static function adGroupAdLabelName($customerId, $adGroupId, $adId, $labelId)
+    {
+        return self::getAdGroupAdLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'ad_id' => $adId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_asset resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted ad_group_asset resource.
+     */
+    public static function adGroupAssetName($customerId, $adGroupId, $assetId, $fieldType)
+    {
+        return self::getAdGroupAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_bid_modifier resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted ad_group_bid_modifier resource.
+     */
+    public static function adGroupBidModifierName($customerId, $adGroupId, $criterionId)
+    {
+        return self::getAdGroupBidModifierNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted ad_group_criterion resource.
+     */
+    public static function adGroupCriterionName($customerId, $adGroupId, $criterionId)
+    {
+        return self::getAdGroupCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted ad_group_criterion_customizer resource.
+     */
+    public static function adGroupCriterionCustomizerName($customerId, $adGroupId, $criterionId, $customizerAttributeId)
+    {
+        return self::getAdGroupCriterionCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_criterion_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_criterion_label resource.
+     */
+    public static function adGroupCriterionLabelName($customerId, $adGroupId, $criterionId, $labelId)
+    {
+        return self::getAdGroupCriterionLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted ad_group_customizer resource.
+     */
+    public static function adGroupCustomizerName($customerId, $adGroupId, $customizerAttributeId)
+    {
+        return self::getAdGroupCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_extension_setting resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $extensionType
+     *
+     * @return string The formatted ad_group_extension_setting resource.
+     */
+    public static function adGroupExtensionSettingName($customerId, $adGroupId, $extensionType)
+    {
+        return self::getAdGroupExtensionSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'extension_type' => $extensionType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_feed resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $feedId
+     *
+     * @return string The formatted ad_group_feed resource.
+     */
+    public static function adGroupFeedName($customerId, $adGroupId, $feedId)
+    {
+        return self::getAdGroupFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * ad_group_label resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $labelId
+     *
+     * @return string The formatted ad_group_label resource.
+     */
+    public static function adGroupLabelName($customerId, $adGroupId, $labelId)
+    {
+        return self::getAdGroupLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad_parameter
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $adGroupId
+     * @param string $criterionId
+     * @param string $parameterIndex
+     *
+     * @return string The formatted ad_parameter resource.
+     */
+    public static function adParameterName($customerId, $adGroupId, $criterionId, $parameterIndex)
+    {
+        return self::getAdParameterNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_group_id' => $adGroupId,
+            'criterion_id' => $criterionId,
+            'parameter_index' => $parameterIndex,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_group
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     *
+     * @return string The formatted asset_group resource.
+     */
+    public static function assetGroupName($customerId, $assetGroupId)
+    {
+        return self::getAssetGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_group_asset resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted asset_group_asset resource.
+     */
+    public static function assetGroupAssetName($customerId, $assetGroupId, $assetId, $fieldType)
+    {
+        return self::getAssetGroupAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_group_listing_group_filter resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     * @param string $listingGroupFilterId
+     *
+     * @return string The formatted asset_group_listing_group_filter resource.
+     */
+    public static function assetGroupListingGroupFilterName($customerId, $assetGroupId, $listingGroupFilterId)
+    {
+        return self::getAssetGroupListingGroupFilterNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+            'listing_group_filter_id' => $listingGroupFilterId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_group_signal resource.
+     *
+     * @param string $customerId
+     * @param string $assetGroupId
+     * @param string $criterionId
+     *
+     * @return string The formatted asset_group_signal resource.
+     */
+    public static function assetGroupSignalName($customerId, $assetGroupId, $criterionId)
+    {
+        return self::getAssetGroupSignalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_group_id' => $assetGroupId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     *
+     * @return string The formatted asset_set resource.
+     */
+    public static function assetSetName($customerId, $assetSetId)
+    {
+        return self::getAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * asset_set_asset resource.
+     *
+     * @param string $customerId
+     * @param string $assetSetId
+     * @param string $assetId
+     *
+     * @return string The formatted asset_set_asset resource.
+     */
+    public static function assetSetAssetName($customerId, $assetSetId, $assetId)
+    {
+        return self::getAssetSetAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_set_id' => $assetSetId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a audience
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $audienceId
+     *
+     * @return string The formatted audience resource.
+     */
+    public static function audienceName($customerId, $audienceId)
+    {
+        return self::getAudienceNameTemplate()->render([
+            'customer_id' => $customerId,
+            'audience_id' => $audienceId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * bidding_data_exclusion resource.
+     *
+     * @param string $customerId
+     * @param string $seasonalityEventId
+     *
+     * @return string The formatted bidding_data_exclusion resource.
+     */
+    public static function biddingDataExclusionName($customerId, $seasonalityEventId)
+    {
+        return self::getBiddingDataExclusionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'seasonality_event_id' => $seasonalityEventId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * bidding_seasonality_adjustment resource.
+     *
+     * @param string $customerId
+     * @param string $seasonalityEventId
+     *
+     * @return string The formatted bidding_seasonality_adjustment resource.
+     */
+    public static function biddingSeasonalityAdjustmentName($customerId, $seasonalityEventId)
+    {
+        return self::getBiddingSeasonalityAdjustmentNameTemplate()->render([
+            'customer_id' => $customerId,
+            'seasonality_event_id' => $seasonalityEventId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * bidding_strategy resource.
+     *
+     * @param string $customerId
+     * @param string $biddingStrategyId
+     *
+     * @return string The formatted bidding_strategy resource.
+     */
+    public static function biddingStrategyName($customerId, $biddingStrategyId)
+    {
+        return self::getBiddingStrategyNameTemplate()->render([
+            'customer_id' => $customerId,
+            'bidding_strategy_id' => $biddingStrategyId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_asset resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted campaign_asset resource.
+     */
+    public static function campaignAssetName($customerId, $campaignId, $assetId, $fieldType)
+    {
+        return self::getCampaignAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_asset_set resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $assetSetId
+     *
+     * @return string The formatted campaign_asset_set resource.
+     */
+    public static function campaignAssetSetName($customerId, $campaignId, $assetSetId)
+    {
+        return self::getCampaignAssetSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'asset_set_id' => $assetSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_bid_modifier resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
+     *
+     * @return string The formatted campaign_bid_modifier resource.
+     */
+    public static function campaignBidModifierName($customerId, $campaignId, $criterionId)
+    {
+        return self::getCampaignBidModifierNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_budget resource.
+     *
+     * @param string $customerId
+     * @param string $campaignBudgetId
+     *
+     * @return string The formatted campaign_budget resource.
+     */
+    public static function campaignBudgetName($customerId, $campaignBudgetId)
+    {
+        return self::getCampaignBudgetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_budget_id' => $campaignBudgetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $category
+     * @param string $source
+     *
+     * @return string The formatted campaign_conversion_goal resource.
+     */
+    public static function campaignConversionGoalName($customerId, $campaignId, $category, $source)
+    {
+        return self::getCampaignConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'category' => $category,
+            'source' => $source,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $criterionId
+     *
+     * @return string The formatted campaign_criterion resource.
+     */
+    public static function campaignCriterionName($customerId, $campaignId, $criterionId)
+    {
+        return self::getCampaignCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted campaign_customizer resource.
+     */
+    public static function campaignCustomizerName($customerId, $campaignId, $customizerAttributeId)
+    {
+        return self::getCampaignCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_draft resource.
+     *
+     * @param string $customerId
+     * @param string $baseCampaignId
+     * @param string $draftId
+     *
+     * @return string The formatted campaign_draft resource.
+     */
+    public static function campaignDraftName($customerId, $baseCampaignId, $draftId)
+    {
+        return self::getCampaignDraftNameTemplate()->render([
+            'customer_id' => $customerId,
+            'base_campaign_id' => $baseCampaignId,
+            'draft_id' => $draftId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_extension_setting resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $extensionType
+     *
+     * @return string The formatted campaign_extension_setting resource.
+     */
+    public static function campaignExtensionSettingName($customerId, $campaignId, $extensionType)
+    {
+        return self::getCampaignExtensionSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'extension_type' => $extensionType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_feed resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $feedId
+     *
+     * @return string The formatted campaign_feed resource.
+     */
+    public static function campaignFeedName($customerId, $campaignId, $feedId)
+    {
+        return self::getCampaignFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_group resource.
+     *
+     * @param string $customerId
+     * @param string $campaignGroupId
+     *
+     * @return string The formatted campaign_group resource.
+     */
+    public static function campaignGroupName($customerId, $campaignGroupId)
+    {
+        return self::getCampaignGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_group_id' => $campaignGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_label resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $labelId
+     *
+     * @return string The formatted campaign_label resource.
+     */
+    public static function campaignLabelName($customerId, $campaignId, $labelId)
+    {
+        return self::getCampaignLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * campaign_shared_set resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     * @param string $sharedSetId
+     *
+     * @return string The formatted campaign_shared_set resource.
+     */
+    public static function campaignSharedSetName($customerId, $campaignId, $sharedSetId)
+    {
+        return self::getCampaignSharedSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+            'shared_set_id' => $sharedSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_action resource.
+     *
+     * @param string $customerId
+     * @param string $conversionActionId
+     *
+     * @return string The formatted conversion_action resource.
+     */
+    public static function conversionActionName($customerId, $conversionActionId)
+    {
+        return self::getConversionActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_action_id' => $conversionActionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_custom_variable resource.
+     *
+     * @param string $customerId
+     * @param string $conversionCustomVariableId
+     *
+     * @return string The formatted conversion_custom_variable resource.
+     */
+    public static function conversionCustomVariableName($customerId, $conversionCustomVariableId)
+    {
+        return self::getConversionCustomVariableNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_custom_variable_id' => $conversionCustomVariableId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_goal_campaign_config resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted conversion_goal_campaign_config resource.
+     */
+    public static function conversionGoalCampaignConfigName($customerId, $campaignId)
+    {
+        return self::getConversionGoalCampaignConfigNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_value_rule resource.
+     *
+     * @param string $customerId
+     * @param string $conversionValueRuleId
+     *
+     * @return string The formatted conversion_value_rule resource.
+     */
+    public static function conversionValueRuleName($customerId, $conversionValueRuleId)
+    {
+        return self::getConversionValueRuleNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_value_rule_id' => $conversionValueRuleId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_value_rule_set resource.
+     *
+     * @param string $customerId
+     * @param string $conversionValueRuleSetId
+     *
+     * @return string The formatted conversion_value_rule_set resource.
+     */
+    public static function conversionValueRuleSetName($customerId, $conversionValueRuleSetId)
+    {
+        return self::getConversionValueRuleSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_value_rule_set_id' => $conversionValueRuleSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * custom_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $goalId
+     *
+     * @return string The formatted custom_conversion_goal resource.
+     */
+    public static function customConversionGoalName($customerId, $goalId)
+    {
+        return self::getCustomConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'goal_id' => $goalId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_asset resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     * @param string $fieldType
+     *
+     * @return string The formatted customer_asset resource.
+     */
+    public static function customerAssetName($customerId, $assetId, $fieldType)
+    {
+        return self::getCustomerAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+            'field_type' => $fieldType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_conversion_goal resource.
+     *
+     * @param string $customerId
+     * @param string $category
+     * @param string $source
+     *
+     * @return string The formatted customer_conversion_goal resource.
+     */
+    public static function customerConversionGoalName($customerId, $category, $source)
+    {
+        return self::getCustomerConversionGoalNameTemplate()->render([
+            'customer_id' => $customerId,
+            'category' => $category,
+            'source' => $source,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_customizer resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customer_customizer resource.
+     */
+    public static function customerCustomizerName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomerCustomizerNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_extension_setting resource.
+     *
+     * @param string $customerId
+     * @param string $extensionType
+     *
+     * @return string The formatted customer_extension_setting resource.
+     */
+    public static function customerExtensionSettingName($customerId, $extensionType)
+    {
+        return self::getCustomerExtensionSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'extension_type' => $extensionType,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_feed resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted customer_feed resource.
+     */
+    public static function customerFeedName($customerId, $feedId)
+    {
+        return self::getCustomerFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_label resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted customer_label resource.
+     */
+    public static function customerLabelName($customerId, $labelId)
+    {
+        return self::getCustomerLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customer_negative_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $criterionId
+     *
+     * @return string The formatted customer_negative_criterion resource.
+     */
+    public static function customerNegativeCriterionName($customerId, $criterionId)
+    {
+        return self::getCustomerNegativeCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * customizer_attribute resource.
+     *
+     * @param string $customerId
+     * @param string $customizerAttributeId
+     *
+     * @return string The formatted customizer_attribute resource.
+     */
+    public static function customizerAttributeName($customerId, $customizerAttributeId)
+    {
+        return self::getCustomizerAttributeNameTemplate()->render([
+            'customer_id' => $customerId,
+            'customizer_attribute_id' => $customizerAttributeId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a experiment
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $trialId
+     *
+     * @return string The formatted experiment resource.
+     */
+    public static function experimentName($customerId, $trialId)
+    {
+        return self::getExperimentNameTemplate()->render([
+            'customer_id' => $customerId,
+            'trial_id' => $trialId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * experiment_arm resource.
+     *
+     * @param string $customerId
+     * @param string $trialId
+     * @param string $trialArmId
+     *
+     * @return string The formatted experiment_arm resource.
+     */
+    public static function experimentArmName($customerId, $trialId, $trialArmId)
+    {
+        return self::getExperimentArmNameTemplate()->render([
+            'customer_id' => $customerId,
+            'trial_id' => $trialId,
+            'trial_arm_id' => $trialArmId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * extension_feed_item resource.
+     *
+     * @param string $customerId
+     * @param string $feedItemId
+     *
+     * @return string The formatted extension_feed_item resource.
+     */
+    public static function extensionFeedItemName($customerId, $feedItemId)
+    {
+        return self::getExtensionFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     *
+     * @return string The formatted feed resource.
+     */
+    public static function feedName($customerId, $feedId)
+    {
+        return self::getFeedNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed_item
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     *
+     * @return string The formatted feed_item resource.
+     */
+    public static function feedItemName($customerId, $feedId, $feedItemId)
+    {
+        return self::getFeedItemNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * feed_item_set resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
+     *
+     * @return string The formatted feed_item_set resource.
+     */
+    public static function feedItemSetName($customerId, $feedId, $feedItemSetId)
+    {
+        return self::getFeedItemSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_set_id' => $feedItemSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * feed_item_set_link resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemSetId
+     * @param string $feedItemId
+     *
+     * @return string The formatted feed_item_set_link resource.
+     */
+    public static function feedItemSetLinkName($customerId, $feedId, $feedItemSetId, $feedItemId)
+    {
+        return self::getFeedItemSetLinkNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_set_id' => $feedItemSetId,
+            'feed_item_id' => $feedItemId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * feed_item_target resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedItemId
+     * @param string $feedItemTargetType
+     * @param string $feedItemTargetId
+     *
+     * @return string The formatted feed_item_target resource.
+     */
+    public static function feedItemTargetName($customerId, $feedId, $feedItemId, $feedItemTargetType, $feedItemTargetId)
+    {
+        return self::getFeedItemTargetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_item_id' => $feedItemId,
+            'feed_item_target_type' => $feedItemTargetType,
+            'feed_item_target_id' => $feedItemTargetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a feed_mapping
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $feedId
+     * @param string $feedMappingId
+     *
+     * @return string The formatted feed_mapping resource.
+     */
+    public static function feedMappingName($customerId, $feedId, $feedMappingId)
+    {
+        return self::getFeedMappingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'feed_id' => $feedId,
+            'feed_mapping_id' => $feedMappingId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * geo_target_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted geo_target_constant resource.
+     */
+    public static function geoTargetConstantName($criterionId)
+    {
+        return self::getGeoTargetConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a keyword_plan
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanId
+     *
+     * @return string The formatted keyword_plan resource.
+     */
+    public static function keywordPlanName($customerId, $keywordPlanId)
+    {
+        return self::getKeywordPlanNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_id' => $keywordPlanId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_ad_group resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupId
+     *
+     * @return string The formatted keyword_plan_ad_group resource.
+     */
+    public static function keywordPlanAdGroupName($customerId, $keywordPlanAdGroupId)
+    {
+        return self::getKeywordPlanAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_ad_group_id' => $keywordPlanAdGroupId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_ad_group_keyword resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupKeywordId
+     *
+     * @return string The formatted keyword_plan_ad_group_keyword resource.
+     */
+    public static function keywordPlanAdGroupKeywordName($customerId, $keywordPlanAdGroupKeywordId)
+    {
+        return self::getKeywordPlanAdGroupKeywordNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_ad_group_keyword_id' => $keywordPlanAdGroupKeywordId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_campaign resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanCampaignId
+     *
+     * @return string The formatted keyword_plan_campaign resource.
+     */
+    public static function keywordPlanCampaignName($customerId, $keywordPlanCampaignId)
+    {
+        return self::getKeywordPlanCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_campaign_id' => $keywordPlanCampaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_campaign_keyword resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanCampaignKeywordId
+     *
+     * @return string The formatted keyword_plan_campaign_keyword resource.
+     */
+    public static function keywordPlanCampaignKeywordName($customerId, $keywordPlanCampaignKeywordId)
+    {
+        return self::getKeywordPlanCampaignKeywordNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_campaign_keyword_id' => $keywordPlanCampaignKeywordId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a label
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $labelId
+     *
+     * @return string The formatted label resource.
+     */
+    public static function labelName($customerId, $labelId)
+    {
+        return self::getLabelNameTemplate()->render([
+            'customer_id' => $customerId,
+            'label_id' => $labelId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * language_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted language_constant resource.
+     */
+    public static function languageConstantName($criterionId)
+    {
+        return self::getLanguageConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a media_file
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $mediaFileId
+     *
+     * @return string The formatted media_file resource.
+     */
+    public static function mediaFileName($customerId, $mediaFileId)
+    {
+        return self::getMediaFileNameTemplate()->render([
+            'customer_id' => $customerId,
+            'media_file_id' => $mediaFileId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * remarketing_action resource.
+     *
+     * @param string $customerId
+     * @param string $remarketingActionId
+     *
+     * @return string The formatted remarketing_action resource.
+     */
+    public static function remarketingActionName($customerId, $remarketingActionId)
+    {
+        return self::getRemarketingActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'remarketing_action_id' => $remarketingActionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * shared_criterion resource.
+     *
+     * @param string $customerId
+     * @param string $sharedSetId
+     * @param string $criterionId
+     *
+     * @return string The formatted shared_criterion resource.
+     */
+    public static function sharedCriterionName($customerId, $sharedSetId, $criterionId)
+    {
+        return self::getSharedCriterionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'shared_set_id' => $sharedSetId,
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a shared_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $sharedSetId
+     *
+     * @return string The formatted shared_set resource.
+     */
+    public static function sharedSetName($customerId, $sharedSetId)
+    {
+        return self::getSharedSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'shared_set_id' => $sharedSetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * smart_campaign_setting resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted smart_campaign_setting resource.
+     */
+    public static function smartCampaignSettingName($customerId, $campaignId)
+    {
+        return self::getSmartCampaignSettingNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * user_interest resource.
+     *
+     * @param string $customerId
+     * @param string $userInterestId
+     *
+     * @return string The formatted user_interest resource.
+     */
+    public static function userInterestName($customerId, $userInterestId)
+    {
+        return self::getUserInterestNameTemplate()->render([
+            'customer_id' => $customerId,
+            'user_interest_id' => $userInterestId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a user_list
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $userListId
+     *
+     * @return string The formatted user_list resource.
+     */
+    public static function userListName($customerId, $userListId)
+    {
+        return self::getUserListNameTemplate()->render([
+            'customer_id' => $customerId,
+            'user_list_id' => $userListId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - accessibleBiddingStrategy: customers/{customer_id}/accessibleBiddingStrategies/{bidding_strategy_id}
+     * - ad: customers/{customer_id}/ads/{ad_id}
+     * - adGroup: customers/{customer_id}/adGroups/{ad_group_id}
+     * - adGroupAd: customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}
+     * - adGroupAdLabel: customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}
+     * - adGroupAsset: customers/{customer_id}/adGroupAssets/{ad_group_id}~{asset_id}~{field_type}
+     * - adGroupBidModifier: customers/{customer_id}/adGroupBidModifiers/{ad_group_id}~{criterion_id}
+     * - adGroupCriterion: customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}
+     * - adGroupCriterionCustomizer: customers/{customer_id}/adGroupCriterionCustomizers/{ad_group_id}~{criterion_id}~{customizer_attribute_id}
+     * - adGroupCriterionLabel: customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}
+     * - adGroupCustomizer: customers/{customer_id}/adGroupCustomizers/{ad_group_id}~{customizer_attribute_id}
+     * - adGroupExtensionSetting: customers/{customer_id}/adGroupExtensionSettings/{ad_group_id}~{extension_type}
+     * - adGroupFeed: customers/{customer_id}/adGroupFeeds/{ad_group_id}~{feed_id}
+     * - adGroupLabel: customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}
+     * - adParameter: customers/{customer_id}/adParameters/{ad_group_id}~{criterion_id}~{parameter_index}
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - assetGroup: customers/{customer_id}/assetGroups/{asset_group_id}
+     * - assetGroupAsset: customers/{customer_id}/assetGroupAssets/{asset_group_id}~{asset_id}~{field_type}
+     * - assetGroupListingGroupFilter: customers/{customer_id}/assetGroupListingGroupFilters/{asset_group_id}~{listing_group_filter_id}
+     * - assetGroupSignal: customers/{customer_id}/assetGroupSignals/{asset_group_id}~{criterion_id}
+     * - assetSet: customers/{customer_id}/assetSets/{asset_set_id}
+     * - assetSetAsset: customers/{customer_id}/assetSetAssets/{asset_set_id}~{asset_id}
+     * - audience: customers/{customer_id}/audiences/{audience_id}
+     * - biddingDataExclusion: customers/{customer_id}/biddingDataExclusions/{seasonality_event_id}
+     * - biddingSeasonalityAdjustment: customers/{customer_id}/biddingSeasonalityAdjustments/{seasonality_event_id}
+     * - biddingStrategy: customers/{customer_id}/biddingStrategies/{bidding_strategy_id}
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
+     * - campaignAsset: customers/{customer_id}/campaignAssets/{campaign_id}~{asset_id}~{field_type}
+     * - campaignAssetSet: customers/{customer_id}/campaignAssetSets/{campaign_id}~{asset_set_id}
+     * - campaignBidModifier: customers/{customer_id}/campaignBidModifiers/{campaign_id}~{criterion_id}
+     * - campaignBudget: customers/{customer_id}/campaignBudgets/{campaign_budget_id}
+     * - campaignConversionGoal: customers/{customer_id}/campaignConversionGoals/{campaign_id}~{category}~{source}
+     * - campaignCriterion: customers/{customer_id}/campaignCriteria/{campaign_id}~{criterion_id}
+     * - campaignCustomizer: customers/{customer_id}/campaignCustomizers/{campaign_id}~{customizer_attribute_id}
+     * - campaignDraft: customers/{customer_id}/campaignDrafts/{base_campaign_id}~{draft_id}
+     * - campaignExtensionSetting: customers/{customer_id}/campaignExtensionSettings/{campaign_id}~{extension_type}
+     * - campaignFeed: customers/{customer_id}/campaignFeeds/{campaign_id}~{feed_id}
+     * - campaignGroup: customers/{customer_id}/campaignGroups/{campaign_group_id}
+     * - campaignLabel: customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}
+     * - campaignSharedSet: customers/{customer_id}/campaignSharedSets/{campaign_id}~{shared_set_id}
+     * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
+     * - conversionCustomVariable: customers/{customer_id}/conversionCustomVariables/{conversion_custom_variable_id}
+     * - conversionGoalCampaignConfig: customers/{customer_id}/conversionGoalCampaignConfigs/{campaign_id}
+     * - conversionValueRule: customers/{customer_id}/conversionValueRules/{conversion_value_rule_id}
+     * - conversionValueRuleSet: customers/{customer_id}/conversionValueRuleSets/{conversion_value_rule_set_id}
+     * - customConversionGoal: customers/{customer_id}/customConversionGoals/{goal_id}
+     * - customer: customers/{customer_id}
+     * - customerAsset: customers/{customer_id}/customerAssets/{asset_id}~{field_type}
+     * - customerConversionGoal: customers/{customer_id}/customerConversionGoals/{category}~{source}
+     * - customerCustomizer: customers/{customer_id}/customerCustomizers/{customizer_attribute_id}
+     * - customerExtensionSetting: customers/{customer_id}/customerExtensionSettings/{extension_type}
+     * - customerFeed: customers/{customer_id}/customerFeeds/{feed_id}
+     * - customerLabel: customers/{customer_id}/customerLabels/{label_id}
+     * - customerNegativeCriterion: customers/{customer_id}/customerNegativeCriteria/{criterion_id}
+     * - customizerAttribute: customers/{customer_id}/customizerAttributes/{customizer_attribute_id}
+     * - experiment: customers/{customer_id}/experiments/{trial_id}
+     * - experimentArm: customers/{customer_id}/experimentArms/{trial_id}~{trial_arm_id}
+     * - extensionFeedItem: customers/{customer_id}/extensionFeedItems/{feed_item_id}
+     * - feed: customers/{customer_id}/feeds/{feed_id}
+     * - feedItem: customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}
+     * - feedItemSet: customers/{customer_id}/feedItemSets/{feed_id}~{feed_item_set_id}
+     * - feedItemSetLink: customers/{customer_id}/feedItemSetLinks/{feed_id}~{feed_item_set_id}~{feed_item_id}
+     * - feedItemTarget: customers/{customer_id}/feedItemTargets/{feed_id}~{feed_item_id}~{feed_item_target_type}~{feed_item_target_id}
+     * - feedMapping: customers/{customer_id}/feedMappings/{feed_id}~{feed_mapping_id}
+     * - geoTargetConstant: geoTargetConstants/{criterion_id}
+     * - keywordPlan: customers/{customer_id}/keywordPlans/{keyword_plan_id}
+     * - keywordPlanAdGroup: customers/{customer_id}/keywordPlanAdGroups/{keyword_plan_ad_group_id}
+     * - keywordPlanAdGroupKeyword: customers/{customer_id}/keywordPlanAdGroupKeywords/{keyword_plan_ad_group_keyword_id}
+     * - keywordPlanCampaign: customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}
+     * - keywordPlanCampaignKeyword: customers/{customer_id}/keywordPlanCampaignKeywords/{keyword_plan_campaign_keyword_id}
+     * - label: customers/{customer_id}/labels/{label_id}
+     * - languageConstant: languageConstants/{criterion_id}
+     * - mediaFile: customers/{customer_id}/mediaFiles/{media_file_id}
+     * - remarketingAction: customers/{customer_id}/remarketingActions/{remarketing_action_id}
+     * - sharedCriterion: customers/{customer_id}/sharedCriteria/{shared_set_id}~{criterion_id}
+     * - sharedSet: customers/{customer_id}/sharedSets/{shared_set_id}
+     * - smartCampaignSetting: customers/{customer_id}/smartCampaignSettings/{campaign_id}
+     * - userInterest: customers/{customer_id}/userInterests/{user_interest_id}
+     * - userList: customers/{customer_id}/userLists/{user_list_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanAdGroupKeywordServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanAdGroupKeywordServiceGapicClient.php
@@ -84,6 +84,8 @@ class KeywordPlanAdGroupKeywordServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $keywordPlanAdGroupNameTemplate;
+
     private static $keywordPlanAdGroupKeywordNameTemplate;
 
     private static $pathTemplateMap;
@@ -107,6 +109,15 @@ class KeywordPlanAdGroupKeywordServiceGapicClient
         ];
     }
 
+    private static function getKeywordPlanAdGroupNameTemplate()
+    {
+        if (self::$keywordPlanAdGroupNameTemplate == null) {
+            self::$keywordPlanAdGroupNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanAdGroups/{keyword_plan_ad_group_id}');
+        }
+
+        return self::$keywordPlanAdGroupNameTemplate;
+    }
+
     private static function getKeywordPlanAdGroupKeywordNameTemplate()
     {
         if (self::$keywordPlanAdGroupKeywordNameTemplate == null) {
@@ -120,11 +131,29 @@ class KeywordPlanAdGroupKeywordServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'keywordPlanAdGroup' => self::getKeywordPlanAdGroupNameTemplate(),
                 'keywordPlanAdGroupKeyword' => self::getKeywordPlanAdGroupKeywordNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_ad_group resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanAdGroupId
+     *
+     * @return string The formatted keyword_plan_ad_group resource.
+     */
+    public static function keywordPlanAdGroupName($customerId, $keywordPlanAdGroupId)
+    {
+        return self::getKeywordPlanAdGroupNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_ad_group_id' => $keywordPlanAdGroupId,
+        ]);
     }
 
     /**
@@ -148,6 +177,7 @@ class KeywordPlanAdGroupKeywordServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - keywordPlanAdGroup: customers/{customer_id}/keywordPlanAdGroups/{keyword_plan_ad_group_id}
      * - keywordPlanAdGroupKeyword: customers/{customer_id}/keywordPlanAdGroupKeywords/{keyword_plan_ad_group_keyword_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanAdGroupServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanAdGroupServiceGapicClient.php
@@ -82,6 +82,8 @@ class KeywordPlanAdGroupServiceGapicClient
 
     private static $keywordPlanAdGroupNameTemplate;
 
+    private static $keywordPlanCampaignNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class KeywordPlanAdGroupServiceGapicClient
         return self::$keywordPlanAdGroupNameTemplate;
     }
 
+    private static function getKeywordPlanCampaignNameTemplate()
+    {
+        if (self::$keywordPlanCampaignNameTemplate == null) {
+            self::$keywordPlanCampaignNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}');
+        }
+
+        return self::$keywordPlanCampaignNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'keywordPlanAdGroup' => self::getKeywordPlanAdGroupNameTemplate(),
+                'keywordPlanCampaign' => self::getKeywordPlanCampaignNameTemplate(),
             ];
         }
 
@@ -141,10 +153,28 @@ class KeywordPlanAdGroupServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_campaign resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanCampaignId
+     *
+     * @return string The formatted keyword_plan_campaign resource.
+     */
+    public static function keywordPlanCampaignName($customerId, $keywordPlanCampaignId)
+    {
+        return self::getKeywordPlanCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_campaign_id' => $keywordPlanCampaignId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - keywordPlanAdGroup: customers/{customer_id}/keywordPlanAdGroups/{keyword_plan_ad_group_id}
+     * - keywordPlanCampaign: customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanCampaignKeywordServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanCampaignKeywordServiceGapicClient.php
@@ -83,6 +83,8 @@ class KeywordPlanCampaignKeywordServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $keywordPlanCampaignNameTemplate;
+
     private static $keywordPlanCampaignKeywordNameTemplate;
 
     private static $pathTemplateMap;
@@ -106,6 +108,15 @@ class KeywordPlanCampaignKeywordServiceGapicClient
         ];
     }
 
+    private static function getKeywordPlanCampaignNameTemplate()
+    {
+        if (self::$keywordPlanCampaignNameTemplate == null) {
+            self::$keywordPlanCampaignNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}');
+        }
+
+        return self::$keywordPlanCampaignNameTemplate;
+    }
+
     private static function getKeywordPlanCampaignKeywordNameTemplate()
     {
         if (self::$keywordPlanCampaignKeywordNameTemplate == null) {
@@ -119,11 +130,29 @@ class KeywordPlanCampaignKeywordServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'keywordPlanCampaign' => self::getKeywordPlanCampaignNameTemplate(),
                 'keywordPlanCampaignKeyword' => self::getKeywordPlanCampaignKeywordNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * keyword_plan_campaign resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanCampaignId
+     *
+     * @return string The formatted keyword_plan_campaign resource.
+     */
+    public static function keywordPlanCampaignName($customerId, $keywordPlanCampaignId)
+    {
+        return self::getKeywordPlanCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_campaign_id' => $keywordPlanCampaignId,
+        ]);
     }
 
     /**
@@ -147,6 +176,7 @@ class KeywordPlanCampaignKeywordServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - keywordPlanCampaign: customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}
      * - keywordPlanCampaignKeyword: customers/{customer_id}/keywordPlanCampaignKeywords/{keyword_plan_campaign_keyword_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanCampaignServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/KeywordPlanCampaignServiceGapicClient.php
@@ -80,7 +80,13 @@ class KeywordPlanCampaignServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $geoTargetConstantNameTemplate;
+
+    private static $keywordPlanNameTemplate;
+
     private static $keywordPlanCampaignNameTemplate;
+
+    private static $languageConstantNameTemplate;
 
     private static $pathTemplateMap;
 
@@ -103,6 +109,24 @@ class KeywordPlanCampaignServiceGapicClient
         ];
     }
 
+    private static function getGeoTargetConstantNameTemplate()
+    {
+        if (self::$geoTargetConstantNameTemplate == null) {
+            self::$geoTargetConstantNameTemplate = new PathTemplate('geoTargetConstants/{criterion_id}');
+        }
+
+        return self::$geoTargetConstantNameTemplate;
+    }
+
+    private static function getKeywordPlanNameTemplate()
+    {
+        if (self::$keywordPlanNameTemplate == null) {
+            self::$keywordPlanNameTemplate = new PathTemplate('customers/{customer_id}/keywordPlans/{keyword_plan_id}');
+        }
+
+        return self::$keywordPlanNameTemplate;
+    }
+
     private static function getKeywordPlanCampaignNameTemplate()
     {
         if (self::$keywordPlanCampaignNameTemplate == null) {
@@ -112,15 +136,59 @@ class KeywordPlanCampaignServiceGapicClient
         return self::$keywordPlanCampaignNameTemplate;
     }
 
+    private static function getLanguageConstantNameTemplate()
+    {
+        if (self::$languageConstantNameTemplate == null) {
+            self::$languageConstantNameTemplate = new PathTemplate('languageConstants/{criterion_id}');
+        }
+
+        return self::$languageConstantNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'geoTargetConstant' => self::getGeoTargetConstantNameTemplate(),
+                'keywordPlan' => self::getKeywordPlanNameTemplate(),
                 'keywordPlanCampaign' => self::getKeywordPlanCampaignNameTemplate(),
+                'languageConstant' => self::getLanguageConstantNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * geo_target_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted geo_target_constant resource.
+     */
+    public static function geoTargetConstantName($criterionId)
+    {
+        return self::getGeoTargetConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a keyword_plan
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $keywordPlanId
+     *
+     * @return string The formatted keyword_plan resource.
+     */
+    public static function keywordPlanName($customerId, $keywordPlanId)
+    {
+        return self::getKeywordPlanNameTemplate()->render([
+            'customer_id' => $customerId,
+            'keyword_plan_id' => $keywordPlanId,
+        ]);
     }
 
     /**
@@ -141,10 +209,28 @@ class KeywordPlanCampaignServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * language_constant resource.
+     *
+     * @param string $criterionId
+     *
+     * @return string The formatted language_constant resource.
+     */
+    public static function languageConstantName($criterionId)
+    {
+        return self::getLanguageConstantNameTemplate()->render([
+            'criterion_id' => $criterionId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - geoTargetConstant: geoTargetConstants/{criterion_id}
+     * - keywordPlan: customers/{customer_id}/keywordPlans/{keyword_plan_id}
      * - keywordPlanCampaign: customers/{customer_id}/keywordPlanCampaigns/{keyword_plan_campaign_id}
+     * - languageConstant: languageConstants/{criterion_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/MediaFileServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/MediaFileServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\MutateMediaFilesResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $mediaFileServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class MediaFileServiceGapicClient
 {
@@ -74,6 +80,10 @@ class MediaFileServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $mediaFileNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +101,84 @@ class MediaFileServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getMediaFileNameTemplate()
+    {
+        if (self::$mediaFileNameTemplate == null) {
+            self::$mediaFileNameTemplate = new PathTemplate('customers/{customer_id}/mediaFiles/{media_file_id}');
+        }
+
+        return self::$mediaFileNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'mediaFile' => self::getMediaFileNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a media_file
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $mediaFileId
+     *
+     * @return string The formatted media_file resource.
+     */
+    public static function mediaFileName($customerId, $mediaFileId)
+    {
+        return self::getMediaFileNameTemplate()->render([
+            'customer_id' => $customerId,
+            'media_file_id' => $mediaFileId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - mediaFile: customers/{customer_id}/mediaFiles/{media_file_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/ProductLinkServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/ProductLinkServiceGapicClient.php
@@ -83,6 +83,8 @@ class ProductLinkServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $customerNameTemplate;
+
     private static $productLinkNameTemplate;
 
     private static $pathTemplateMap;
@@ -106,6 +108,15 @@ class ProductLinkServiceGapicClient
         ];
     }
 
+    private static function getCustomerNameTemplate()
+    {
+        if (self::$customerNameTemplate == null) {
+            self::$customerNameTemplate = new PathTemplate('customers/{customer_id}');
+        }
+
+        return self::$customerNameTemplate;
+    }
+
     private static function getProductLinkNameTemplate()
     {
         if (self::$productLinkNameTemplate == null) {
@@ -119,11 +130,27 @@ class ProductLinkServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'customer' => self::getCustomerNameTemplate(),
                 'productLink' => self::getProductLinkNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a customer
+     * resource.
+     *
+     * @param string $customerId
+     *
+     * @return string The formatted customer resource.
+     */
+    public static function customerName($customerId)
+    {
+        return self::getCustomerNameTemplate()->render([
+            'customer_id' => $customerId,
+        ]);
     }
 
     /**
@@ -147,6 +174,7 @@ class ProductLinkServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - customer: customers/{customer_id}
      * - productLink: customers/{customer_id}/productLinks/{product_link_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/RecommendationServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/RecommendationServiceGapicClient.php
@@ -83,6 +83,12 @@ class RecommendationServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $adNameTemplate;
+
+    private static $assetNameTemplate;
+
+    private static $conversionActionNameTemplate;
+
     private static $recommendationNameTemplate;
 
     private static $pathTemplateMap;
@@ -106,6 +112,33 @@ class RecommendationServiceGapicClient
         ];
     }
 
+    private static function getAdNameTemplate()
+    {
+        if (self::$adNameTemplate == null) {
+            self::$adNameTemplate = new PathTemplate('customers/{customer_id}/ads/{ad_id}');
+        }
+
+        return self::$adNameTemplate;
+    }
+
+    private static function getAssetNameTemplate()
+    {
+        if (self::$assetNameTemplate == null) {
+            self::$assetNameTemplate = new PathTemplate('customers/{customer_id}/assets/{asset_id}');
+        }
+
+        return self::$assetNameTemplate;
+    }
+
+    private static function getConversionActionNameTemplate()
+    {
+        if (self::$conversionActionNameTemplate == null) {
+            self::$conversionActionNameTemplate = new PathTemplate('customers/{customer_id}/conversionActions/{conversion_action_id}');
+        }
+
+        return self::$conversionActionNameTemplate;
+    }
+
     private static function getRecommendationNameTemplate()
     {
         if (self::$recommendationNameTemplate == null) {
@@ -119,11 +152,64 @@ class RecommendationServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'ad' => self::getAdNameTemplate(),
+                'asset' => self::getAssetNameTemplate(),
+                'conversionAction' => self::getConversionActionNameTemplate(),
                 'recommendation' => self::getRecommendationNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a ad resource.
+     *
+     * @param string $customerId
+     * @param string $adId
+     *
+     * @return string The formatted ad resource.
+     */
+    public static function adName($customerId, $adId)
+    {
+        return self::getAdNameTemplate()->render([
+            'customer_id' => $customerId,
+            'ad_id' => $adId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a asset
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $assetId
+     *
+     * @return string The formatted asset resource.
+     */
+    public static function assetName($customerId, $assetId)
+    {
+        return self::getAssetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'asset_id' => $assetId,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * conversion_action resource.
+     *
+     * @param string $customerId
+     * @param string $conversionActionId
+     *
+     * @return string The formatted conversion_action resource.
+     */
+    public static function conversionActionName($customerId, $conversionActionId)
+    {
+        return self::getConversionActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'conversion_action_id' => $conversionActionId,
+        ]);
     }
 
     /**
@@ -147,6 +233,9 @@ class RecommendationServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - ad: customers/{customer_id}/ads/{ad_id}
+     * - asset: customers/{customer_id}/assets/{asset_id}
+     * - conversionAction: customers/{customer_id}/conversionActions/{conversion_action_id}
      * - recommendation: customers/{customer_id}/recommendations/{recommendation_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/RemarketingActionServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/RemarketingActionServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\Ads\GoogleAds\V13\Services\RemarketingActionOperation;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -52,6 +53,11 @@ use Google\Auth\FetchAuthTokenInterface;
  *     $remarketingActionServiceClient->close();
  * }
  * ```
+ *
+ * Many parameters require resource names to be formatted in a particular way. To
+ * assist with these names, this class includes a format method for each type of
+ * name, and additionally a parseName method to extract the individual identifiers
+ * contained within formatted names that are returned by the API.
  */
 class RemarketingActionServiceGapicClient
 {
@@ -74,6 +80,10 @@ class RemarketingActionServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $remarketingActionNameTemplate;
+
+    private static $pathTemplateMap;
+
     private static function getClientDefaults()
     {
         return [
@@ -91,6 +101,84 @@ class RemarketingActionServiceGapicClient
                 ],
             ],
         ];
+    }
+
+    private static function getRemarketingActionNameTemplate()
+    {
+        if (self::$remarketingActionNameTemplate == null) {
+            self::$remarketingActionNameTemplate = new PathTemplate('customers/{customer_id}/remarketingActions/{remarketing_action_id}');
+        }
+
+        return self::$remarketingActionNameTemplate;
+    }
+
+    private static function getPathTemplateMap()
+    {
+        if (self::$pathTemplateMap == null) {
+            self::$pathTemplateMap = [
+                'remarketingAction' => self::getRemarketingActionNameTemplate(),
+            ];
+        }
+
+        return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * remarketing_action resource.
+     *
+     * @param string $customerId
+     * @param string $remarketingActionId
+     *
+     * @return string The formatted remarketing_action resource.
+     */
+    public static function remarketingActionName($customerId, $remarketingActionId)
+    {
+        return self::getRemarketingActionNameTemplate()->render([
+            'customer_id' => $customerId,
+            'remarketing_action_id' => $remarketingActionId,
+        ]);
+    }
+
+    /**
+     * Parses a formatted name string and returns an associative array of the components in the name.
+     * The following name formats are supported:
+     * Template: Pattern
+     * - remarketingAction: customers/{customer_id}/remarketingActions/{remarketing_action_id}
+     *
+     * The optional $template argument can be supplied to specify a particular pattern,
+     * and must match one of the templates listed above. If no $template argument is
+     * provided, or if the $template argument does not match one of the templates
+     * listed, then parseName will check each of the supported templates, and return
+     * the first match.
+     *
+     * @param string $formattedName The formatted name string
+     * @param string $template      Optional name of template to match
+     *
+     * @return array An associative array from name component IDs to component values.
+     *
+     * @throws ValidationException If $formattedName could not be matched.
+     */
+    public static function parseName($formattedName, $template = null)
+    {
+        $templateMap = self::getPathTemplateMap();
+        if ($template) {
+            if (!isset($templateMap[$template])) {
+                throw new ValidationException("Template name $template does not exist");
+            }
+
+            return $templateMap[$template]->match($formattedName);
+        }
+
+        foreach ($templateMap as $templateName => $pathTemplate) {
+            try {
+                return $pathTemplate->match($formattedName);
+            } catch (ValidationException $ex) {
+                // Swallow the exception to continue trying other path templates
+            }
+        }
+
+        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/SharedCriterionServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/SharedCriterionServiceGapicClient.php
@@ -82,6 +82,8 @@ class SharedCriterionServiceGapicClient
 
     private static $sharedCriterionNameTemplate;
 
+    private static $sharedSetNameTemplate;
+
     private static $pathTemplateMap;
 
     private static function getClientDefaults()
@@ -112,11 +114,21 @@ class SharedCriterionServiceGapicClient
         return self::$sharedCriterionNameTemplate;
     }
 
+    private static function getSharedSetNameTemplate()
+    {
+        if (self::$sharedSetNameTemplate == null) {
+            self::$sharedSetNameTemplate = new PathTemplate('customers/{customer_id}/sharedSets/{shared_set_id}');
+        }
+
+        return self::$sharedSetNameTemplate;
+    }
+
     private static function getPathTemplateMap()
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
                 'sharedCriterion' => self::getSharedCriterionNameTemplate(),
+                'sharedSet' => self::getSharedSetNameTemplate(),
             ];
         }
 
@@ -143,10 +155,28 @@ class SharedCriterionServiceGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a shared_set
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $sharedSetId
+     *
+     * @return string The formatted shared_set resource.
+     */
+    public static function sharedSetName($customerId, $sharedSetId)
+    {
+        return self::getSharedSetNameTemplate()->render([
+            'customer_id' => $customerId,
+            'shared_set_id' => $sharedSetId,
+        ]);
+    }
+
+    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
      * - sharedCriterion: customers/{customer_id}/sharedCriteria/{shared_set_id}~{criterion_id}
+     * - sharedSet: customers/{customer_id}/sharedSets/{shared_set_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,
      * and must match one of the templates listed above. If no $template argument is

--- a/src/Google/Ads/GoogleAds/V13/Services/Gapic/SmartCampaignSettingServiceGapicClient.php
+++ b/src/Google/Ads/GoogleAds/V13/Services/Gapic/SmartCampaignSettingServiceGapicClient.php
@@ -81,6 +81,8 @@ class SmartCampaignSettingServiceGapicClient
         'https://www.googleapis.com/auth/adwords',
     ];
 
+    private static $campaignNameTemplate;
+
     private static $smartCampaignSettingNameTemplate;
 
     private static $pathTemplateMap;
@@ -104,6 +106,15 @@ class SmartCampaignSettingServiceGapicClient
         ];
     }
 
+    private static function getCampaignNameTemplate()
+    {
+        if (self::$campaignNameTemplate == null) {
+            self::$campaignNameTemplate = new PathTemplate('customers/{customer_id}/campaigns/{campaign_id}');
+        }
+
+        return self::$campaignNameTemplate;
+    }
+
     private static function getSmartCampaignSettingNameTemplate()
     {
         if (self::$smartCampaignSettingNameTemplate == null) {
@@ -117,11 +128,29 @@ class SmartCampaignSettingServiceGapicClient
     {
         if (self::$pathTemplateMap == null) {
             self::$pathTemplateMap = [
+                'campaign' => self::getCampaignNameTemplate(),
                 'smartCampaignSetting' => self::getSmartCampaignSettingNameTemplate(),
             ];
         }
 
         return self::$pathTemplateMap;
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a campaign
+     * resource.
+     *
+     * @param string $customerId
+     * @param string $campaignId
+     *
+     * @return string The formatted campaign resource.
+     */
+    public static function campaignName($customerId, $campaignId)
+    {
+        return self::getCampaignNameTemplate()->render([
+            'customer_id' => $customerId,
+            'campaign_id' => $campaignId,
+        ]);
     }
 
     /**
@@ -145,6 +174,7 @@ class SmartCampaignSettingServiceGapicClient
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
+     * - campaign: customers/{customer_id}/campaigns/{campaign_id}
      * - smartCampaignSetting: customers/{customer_id}/smartCampaignSettings/{campaign_id}
      *
      * The optional $template argument can be supplied to specify a particular pattern,


### PR DESCRIPTION
**DO NOT MERGE**

This is for preemptive review only.

All changes unrelated to the update generator version were reverted e.g. `metadata` and non `Gapic` directory changes.

The primary change is the addition of resource name helpers that weren't previously in scope. This is a result of the fix for https://github.com/googleapis/gapic-generator-php/issues/453.