### PR TITLE
Fixed the case when system package grpc version not found

### DIFF
--- a/src/Google/Ads/GoogleAds/Util/Dependencies.php
+++ b/src/Google/Ads/GoogleAds/Util/Dependencies.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2023 Google LLC
  *

--- a/src/Google/Ads/GoogleAds/Util/Dependencies.php
+++ b/src/Google/Ads/GoogleAds/Util/Dependencies.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Util;
+
+/**
+ * Utilities for dependencies of the Google Ads API PHP client library.
+ */
+class Dependencies
+{
+    /**
+     * Gets the grpc version installed by Composer from the specified file (default to
+     *  `composer.lock`. Returns null if that information cannot be found by any causes.
+     *
+     * @param string $fileName the file name to extract the grpc version from
+     * @return null|string the grpc version installed by Composer
+     */
+    public function getGrpcComposerVersion(string $fileName = 'composer.lock'): ?string
+    {
+        if (!file_exists($fileName)) {
+            return null;
+        }
+        $composerLockFileContents = file_get_contents($fileName);
+        if (empty($composerLockFileContents)) {
+            return null;
+        }
+
+        $composerLockJson = json_decode($composerLockFileContents, true);
+        if (!array_key_exists('packages', $composerLockJson)) {
+            return null;
+        }
+
+        $grpcComposerVersion = null;
+        foreach ($composerLockJson['packages'] as $package) {
+            if ($package['name'] === 'grpc/grpc') {
+                return $package['version'];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets the grpc version installed on as a system package, e.g., by PECL.
+     * Returns null if that information cannot be found by any causes.
+     *
+     * @return null|string the grpc version installed as a system package
+     */
+    public function getGrpcSystemPackageVersion(): ?string
+    {
+        $grpcVersion = phpversion('grpc');
+        return $grpcVersion ?? null;
+    }
+}

--- a/tests/Google/Ads/GoogleAds/Lib/V14/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V14/GoogleAdsClientBuilderTest.php
@@ -22,6 +22,7 @@ use Google\Ads\GoogleAds\Lib\Configuration;
 use Google\Ads\GoogleAds\Lib\ConfigurationLoader;
 use Google\Ads\GoogleAds\Lib\ConfigurationLoaderTestProvider;
 use Google\Ads\GoogleAds\Lib\GoogleAdsBuilder;
+use Google\Ads\GoogleAds\Util\Dependencies;
 use Google\Ads\GoogleAds\Util\EnvironmentalVariables;
 use Google\Auth\FetchAuthTokenInterface;
 use Grpc\ChannelCredentials;
@@ -30,6 +31,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use UnexpectedValueException;
 
 /**
  * Unit tests for `GoogleAdsClientBuilder`.
@@ -544,5 +546,89 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->build();
 
         $this->assertSame(LogLevel::DEBUG, $googleAdsClient->getLogLevel());
+    }
+
+    public function testBuildWithSystemPackageGrpcVersionGreaterThanComposerGrpcVersion()
+    {
+        $dependenciesMock = $this->getMockBuilder(Dependencies::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dependenciesMock->method('getGrpcComposerVersion')->willReturn('1.1');
+        $dependenciesMock->method('getGrpcSystemPackageVersion')->willReturn('1.1.5');
+        /** @var Dependencies $dependenciesMock */
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->withDependencies($dependenciesMock)
+            ->build();
+        $this->assertInstanceOf(GoogleAdsClient::class, $googleAdsClient);
+        $this->assertEquals(self::$DEVELOPER_TOKEN, $googleAdsClient->getDeveloperToken());
+    }
+
+    public function testBuildWithSystemPackageGrpcVersionNotFound()
+    {
+        $dependenciesMock = $this->getMockBuilder(Dependencies::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dependenciesMock->method('getGrpcComposerVersion')->willReturn('1.1');
+        $dependenciesMock->method('getGrpcSystemPackageVersion')->willReturn(null);
+        /** @var Dependencies $dependenciesMock */
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->withDependencies($dependenciesMock)
+            ->build();
+        $this->assertInstanceOf(GoogleAdsClient::class, $googleAdsClient);
+        $this->assertEquals(self::$DEVELOPER_TOKEN, $googleAdsClient->getDeveloperToken());
+    }
+
+    public function testBuildWithComposerGrpcVersionNotFound()
+    {
+        $dependenciesMock = $this->getMockBuilder(Dependencies::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dependenciesMock->method('getGrpcComposerVersion')->willReturn(null);
+        $dependenciesMock->method('getGrpcSystemPackageVersion')->willReturn('2.3');
+        /** @var Dependencies $dependenciesMock */
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->withDependencies($dependenciesMock)
+            ->build();
+        $this->assertInstanceOf(GoogleAdsClient::class, $googleAdsClient);
+        $this->assertEquals(self::$DEVELOPER_TOKEN, $googleAdsClient->getDeveloperToken());
+    }
+
+    public function testBuildWithBothComposerAndSystemPackageGrpcVersionsNotFound()
+    {
+        $dependenciesMock = $this->getMockBuilder(Dependencies::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dependenciesMock->method('getGrpcComposerVersion')->willReturn(null);
+        $dependenciesMock->method('getGrpcSystemPackageVersion')->willReturn(null);
+        /** @var Dependencies $dependenciesMock */
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->withDependencies($dependenciesMock)
+            ->build();
+        $this->assertInstanceOf(GoogleAdsClient::class, $googleAdsClient);
+        $this->assertEquals(self::$DEVELOPER_TOKEN, $googleAdsClient->getDeveloperToken());
+    }
+
+    public function testBuildFailsWithSystemPackageGrpcVersionSmallerThanComposerGrpcVersion()
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $dependenciesMock = $this->getMockBuilder(Dependencies::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dependenciesMock->method('getGrpcComposerVersion')->willReturn('2');
+        $dependenciesMock->method('getGrpcSystemPackageVersion')->willReturn('1.1.5');
+        /** @var Dependencies $dependenciesMock */
+        $googleAdsClient = $this->googleAdsClientBuilder
+            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
+            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
+            ->withDependencies($dependenciesMock)
+            ->build();
     }
 }

--- a/tests/Google/Ads/GoogleAds/Util/DependenciesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/DependenciesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Google/Ads/GoogleAds/Util/DependenciesTest.php
+++ b/tests/Google/Ads/GoogleAds/Util/DependenciesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Util;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for `Dependencies`.
+ *
+ * @covers \Google\Ads\GoogleAds\Util\Dependencies
+ * @small
+ */
+class DependenciesTest extends TestCase
+{
+    /** @var Dependencies $dependencies */
+    private $dependencies;
+    /** @var string $composerLockFilePath */
+    private $composerLockFilePath;
+    /** @var string $composerLockWithoutGrpcFilePath */
+    private $composerLockWithoutGrpcFilePath;
+
+    /**
+     * @see \PHPUnit\Framework\TestCase::setUp()
+     */
+    protected function setUp(): void
+    {
+        $this->dependencies = new Dependencies();
+        $this->composerLockFilePath = DependenciesTestProvider::getFakeComposerLockFilePath();
+        $this->composerLockWithoutGrpcFilePath =
+            DependenciesTestProvider::getFakeComposerLockWithoutGrpcFilePath();
+    }
+
+
+    public function testGetGrpcComposerVersion()
+    {
+        $this->assertEquals(
+            '1.52.0',
+            $this->dependencies->getGrpcComposerVersion($this->composerLockFilePath)
+        );
+    }
+
+    public function testGetGrpcComposerVersionNotFound()
+    {
+        $this->assertNull(
+            $this->dependencies->getGrpcComposerVersion($this->composerLockWithoutGrpcFilePath)
+        );
+    }
+}

--- a/tests/Google/Ads/GoogleAds/Util/DependenciesTestProvider.php
+++ b/tests/Google/Ads/GoogleAds/Util/DependenciesTestProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Ads\GoogleAds\Util;
+
+/**
+ * Provides testing data for the `DependenciesTest`.
+ *
+ * @see \Google\Ads\GoogleAds\Util\DependenciesTest
+ */
+class DependenciesTestProvider
+{
+    /**
+     * Gets the file path to a fake composer.lock file.
+     *
+     * @return string
+     */
+    public static function getFakeComposerLockFilePath()
+    {
+        return dirname(__FILE__) . DIRECTORY_SEPARATOR . 'fake-composer.lock';
+    }
+
+    /**
+     * Gets the file path to a fake composer.lock file containing no grpc.
+     *
+     * @return string
+     */
+    public static function getFakeComposerLockWithoutGrpcFilePath()
+    {
+        return dirname(__FILE__) . DIRECTORY_SEPARATOR . 'fake-composer-no-grpc.lock';
+    }
+}

--- a/tests/Google/Ads/GoogleAds/Util/DependenciesTestProvider.php
+++ b/tests/Google/Ads/GoogleAds/Util/DependenciesTestProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Google/Ads/GoogleAds/Util/fake-composer-no-grpc.lock
+++ b/tests/Google/Ads/GoogleAds/Util/fake-composer-no-grpc.lock
@@ -1,0 +1,68 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1234567890",
+    "packages": [
+        {
+            "name": "google/protobuf",
+            "version": "v3.22.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "0edeee0cc2e2991706e16ab60c7d224e5c0241ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/0edeee0cc2e2991706e16ab60c7d224e5c0241ba",
+                "reference": "0edeee0cc2e2991706e16ab60c7d224e5c0241ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=5.0.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "support": {
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.22.3"
+            },
+            "time": "2023-04-12T23:38:34+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.0"
+    },
+    "platform-dev": {
+        "ext-bcmath": "*",
+        "ext-grpc": "*",
+        "ext-protobuf": "*"
+    },
+    "plugin-api-version": "2.0.0"
+}

--- a/tests/Google/Ads/GoogleAds/Util/fake-composer.lock
+++ b/tests/Google/Ads/GoogleAds/Util/fake-composer.lock
@@ -1,0 +1,68 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1234567890",
+    "packages": [
+        {
+            "name": "grpc/grpc",
+            "version": "1.52.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grpc/grpc-php.git",
+                "reference": "98394cd601a587ca68294e6209bd713856969105"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/98394cd601a587ca68294e6209bd713856969105",
+                "reference": "98394cd601a587ca68294e6209bd713856969105",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "google/auth": "^v1.3.0"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, install the protobuf C extension.",
+                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\": "src/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC library for PHP",
+            "homepage": "https://grpc.io",
+            "keywords": [
+                "rpc"
+            ],
+            "support": {
+                "source": "https://github.com/grpc/grpc-php/tree/v1.52.0"
+            },
+            "time": "2023-02-25T05:20:08+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.0"
+    },
+    "platform-dev": {
+        "ext-bcmath": "*",
+        "ext-grpc": "*",
+        "ext-protobuf": "*"
+    },
+    "plugin-api-version": "2.0.0"
+}


### PR DESCRIPTION
Also, added unit tests for the check added in #922.

To do so, I separated the version fetching logic into a class named `Dependencies`, so we can do dependency injection to `GoogleAdsClientBuilder`.