### PR TITLE
Remove unused exception variables.

### DIFF
--- a/examples/Extensions/AddBusinessProfileLocationExtensions.php
+++ b/examples/Extensions/AddBusinessProfileLocationExtensions.php
@@ -287,7 +287,7 @@ class AddBusinessProfileLocationExtensions
                     $addedCustomerFeed->getResults()[0]->getResourceName(),
                     PHP_EOL
                 );
-            } catch (GoogleAdsException $googleAdsException) {
+            } catch (GoogleAdsException) {
                 // Waits using exponential backoff policy.
                 $sleepSeconds = self::POLL_FREQUENCY_SECONDS * pow(2, $numberOfAttempts);
                 // Exits the loop early if $sleepSeconds grows too large in the event that

--- a/src/Google/Ads/GoogleAds/Lib/ConfigurationLoader.php
+++ b/src/Google/Ads/GoogleAds/Lib/ConfigurationLoader.php
@@ -68,7 +68,7 @@ final class ConfigurationLoader
                         )
                     );
                 }
-            } catch (UnexpectedValueException $e) {
+            } catch (UnexpectedValueException) {
                 throw new InvalidArgumentException(
                     sprintf(
                         "Config file not found as specified: '%s'. Home "


### PR DESCRIPTION
PHP 8 supports the catch statement without a variable, so I removed the unused variables in examples/ and src/.

Bug: N/A
Golden CLs: N/A

