### PR TITLE
Update AddCampaigns.php

### DIFF
--- a/examples/BasicOperations/AddCampaigns.php
+++ b/examples/BasicOperations/AddCampaigns.php
@@ -39,6 +39,7 @@ use Google\Ads\GoogleAds\V14\Resources\CampaignBudget;
 use Google\Ads\GoogleAds\V14\Services\CampaignBudgetOperation;
 use Google\Ads\GoogleAds\V14\Services\CampaignOperation;
 use Google\Ads\GoogleAds\V14\Services\MutateCampaignsRequest;
+use Google\Ads\GoogleAds\V14\Services\MutateCampaignBudgetsRequest;
 use Google\ApiCore\ApiException;
 
 /** This example adds new campaigns to an account. */
@@ -190,8 +191,7 @@ class AddCampaigns
         // Issues a mutate request.
         $campaignBudgetServiceClient = $googleAdsClient->getCampaignBudgetServiceClient();
         $response = $campaignBudgetServiceClient->mutateCampaignBudgets(
-            $customerId,
-            [$campaignBudgetOperation]
+            MutateCampaignBudgetsRequest::build($customerId, [$campaignBudgetOperation])
         );
 
         /** @var CampaignBudget $addedBudget */


### PR DESCRIPTION
Fixed error:

``
PHP Fatal error:  Uncaught TypeError: Google\Ads\GoogleAds\V14\Services\Client\BaseClient\CampaignBudgetServiceBaseClient::mutateCampaignBudgets(): Argument #1 ($request) must be of type Google\Ads\GoogleAds\V14\Services\MutateCampaignBudgetsRequest, int given, called in /home/mejores/google-ads-php/examples/BasicOperations/AddCampaigns.php on line 192 and defined in /home/mejores/google-ads-php/src/Google/Ads/GoogleAds/V14/Services/Client/BaseClient/CampaignBudgetServiceBaseClient.php:252 ``