### PR TITLE
Return an empty object in interceptor tests.

### DIFF
--- a/tests/Google/Ads/GoogleAds/Lib/V13/GoogleAdsFailuresInterceptorTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V13/GoogleAdsFailuresInterceptorTest.php
@@ -38,7 +38,8 @@ class GoogleAdsFailuresInterceptorTest extends TestCase
                 new SearchGoogleAdsRequest(),
                 ['PagedListResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );

--- a/tests/Google/Ads/GoogleAds/Lib/V13/GoogleAdsLoggingInterceptorTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V13/GoogleAdsLoggingInterceptorTest.php
@@ -66,7 +66,8 @@ class GoogleAdsLoggingInterceptorTest extends TestCase
                 new SearchGoogleAdsRequest(),
                 ['PagedListResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );
@@ -81,7 +82,8 @@ class GoogleAdsLoggingInterceptorTest extends TestCase
                 new SearchGoogleAdsStreamRequest(),
                 ['SearchGoogleAdsStreamResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );

--- a/tests/Google/Ads/GoogleAds/Lib/V14/GoogleAdsFailuresInterceptorTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V14/GoogleAdsFailuresInterceptorTest.php
@@ -38,7 +38,8 @@ class GoogleAdsFailuresInterceptorTest extends TestCase
                 new SearchGoogleAdsRequest(),
                 ['PagedListResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );

--- a/tests/Google/Ads/GoogleAds/Lib/V14/GoogleAdsLoggingInterceptorTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V14/GoogleAdsLoggingInterceptorTest.php
@@ -66,7 +66,8 @@ class GoogleAdsLoggingInterceptorTest extends TestCase
                 new SearchGoogleAdsRequest(),
                 ['PagedListResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );
@@ -81,7 +82,8 @@ class GoogleAdsLoggingInterceptorTest extends TestCase
                 new SearchGoogleAdsStreamRequest(),
                 ['SearchGoogleAdsStreamResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );

--- a/tests/Google/Ads/GoogleAds/Lib/V15/GoogleAdsFailuresInterceptorTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V15/GoogleAdsFailuresInterceptorTest.php
@@ -38,7 +38,8 @@ class GoogleAdsFailuresInterceptorTest extends TestCase
                 new SearchGoogleAdsRequest(),
                 ['PagedListResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );

--- a/tests/Google/Ads/GoogleAds/Lib/V15/GoogleAdsLoggingInterceptorTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V15/GoogleAdsLoggingInterceptorTest.php
@@ -66,7 +66,8 @@ class GoogleAdsLoggingInterceptorTest extends TestCase
                 new SearchGoogleAdsRequest(),
                 ['PagedListResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );
@@ -81,7 +82,8 @@ class GoogleAdsLoggingInterceptorTest extends TestCase
                 new SearchGoogleAdsStreamRequest(),
                 ['SearchGoogleAdsStreamResponse', 'decode'],
                 function ($method, $argument, $deserialize, $metadata, $options) {
-                    // The function body is not needed for testing.
+                    // The gax-php ForwardingCall now requires a non-null object to be returned.
+                    return new \stdClass();
                 }
             )
         );


### PR DESCRIPTION
[ForwardingCall's `$innerCall`](https://github.com/googleapis/gax-php/compare/v1.19.1...v1.26.2#diff-f0c512b4727b9bd6878bfd6bdad1c5e43dc0b2142647b06f4ffa8d21af8ac905) now has `object` type, so we need to return something in tests to prevent failures.