### PR TITLE
Removed the use of "useGapicV2Source" from all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,6 @@ For more information on how to configure a client when instantiating it, see the
 Once you have an instance of `GoogleAdsClient`, you can obtain a service client
 for a particular service using one of the `get...ServiceClient()` methods.
 
-The created service client can be either GAPIC (Generated API Client) v1 or v2 source code, based
-on the value of the `useGapicV2Source` configuration.
-See [GAPIC](https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic)
-and [Configuration fields](https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/configuration#config-field)
-for details.
-
 ## Client configuration
 
 See the [Configuration guide](https://developers.google.com/google-ads/api/docs/client-libs/php/configuration).

--- a/examples/AccountManagement/CreateCustomer.php
+++ b/examples/AccountManagement/CreateCustomer.php
@@ -57,12 +57,6 @@ class CreateCustomer
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AccountManagement/GetAccountHierarchy.php
+++ b/examples/AccountManagement/GetAccountHierarchy.php
@@ -85,12 +85,6 @@ class GetAccountHierarchy
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {
@@ -210,12 +204,6 @@ class GetAccountHierarchy
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
             ->withLoginCustomerId($loginCustomerId ?? $rootCustomerId)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         // Creates the Google Ads Service client.

--- a/examples/AccountManagement/GetChangeDetails.php
+++ b/examples/AccountManagement/GetChangeDetails.php
@@ -62,12 +62,6 @@ class GetChangeDetails
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AccountManagement/GetChangeSummary.php
+++ b/examples/AccountManagement/GetChangeSummary.php
@@ -57,12 +57,6 @@ class GetChangeSummary
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AccountManagement/InviteUserWithAccessRole.php
+++ b/examples/AccountManagement/InviteUserWithAccessRole.php
@@ -65,12 +65,6 @@ class InviteUserWithAccessRole
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AccountManagement/LinkManagerToClient.php
+++ b/examples/AccountManagement/LinkManagerToClient.php
@@ -288,12 +288,6 @@ class LinkManagerToClient
             ->withOAuth2Credential($oAuth2Credential)
             // Overrides the login customer ID with the given one.
             ->withLoginCustomerId($loginCustomerId)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
     }
 }

--- a/examples/AccountManagement/ListAccessibleCustomers.php
+++ b/examples/AccountManagement/ListAccessibleCustomers.php
@@ -48,12 +48,6 @@ class ListAccessibleCustomers
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AccountManagement/UpdateUserAccess.php
+++ b/examples/AccountManagement/UpdateUserAccess.php
@@ -68,12 +68,6 @@ class UpdateUserAccess
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AccountManagement/VerifyAdvertiserIdentity.php
+++ b/examples/AccountManagement/VerifyAdvertiserIdentity.php
@@ -59,12 +59,6 @@ class VerifyAdvertiserIdentity
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddAdCustomizer.php
+++ b/examples/AdvancedOperations/AddAdCustomizer.php
@@ -72,12 +72,6 @@ class AddAdCustomizer
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddAdGroupBidModifier.php
+++ b/examples/AdvancedOperations/AddAdGroupBidModifier.php
@@ -64,12 +64,6 @@ class AddAdGroupBidModifier
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddAppCampaign.php
+++ b/examples/AdvancedOperations/AddAppCampaign.php
@@ -92,12 +92,6 @@ class AddAppCampaign
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddBiddingDataExclusion.php
+++ b/examples/AdvancedOperations/AddBiddingDataExclusion.php
@@ -67,12 +67,6 @@ class AddBiddingDataExclusion
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddBiddingSeasonalityAdjustment.php
+++ b/examples/AdvancedOperations/AddBiddingSeasonalityAdjustment.php
@@ -69,12 +69,6 @@ class AddBiddingSeasonalityAdjustment
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddCallAd.php
+++ b/examples/AdvancedOperations/AddCallAd.php
@@ -75,12 +75,6 @@ class AddCallAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddDisplayUploadAd.php
+++ b/examples/AdvancedOperations/AddDisplayUploadAd.php
@@ -70,12 +70,6 @@ class AddDisplayUploadAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddDynamicPageFeedAsset.php
+++ b/examples/AdvancedOperations/AddDynamicPageFeedAsset.php
@@ -77,12 +77,6 @@ class AddDynamicPageFeedAsset
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddDynamicSearchAds.php
+++ b/examples/AdvancedOperations/AddDynamicSearchAds.php
@@ -87,12 +87,6 @@ class AddDynamicSearchAds
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddPerformanceMaxCampaign.php
+++ b/examples/AdvancedOperations/AddPerformanceMaxCampaign.php
@@ -115,12 +115,6 @@ class AddPerformanceMaxCampaign
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddResponsiveSearchAdWithAdCustomizer.php
+++ b/examples/AdvancedOperations/AddResponsiveSearchAdWithAdCustomizer.php
@@ -80,12 +80,6 @@ class AddResponsiveSearchAdWithAdCustomizer
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/AddSmartCampaign.php
+++ b/examples/AdvancedOperations/AddSmartCampaign.php
@@ -155,12 +155,6 @@ class AddSmartCampaign
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/CreateAndAttachSharedKeywordSet.php
+++ b/examples/AdvancedOperations/CreateAndAttachSharedKeywordSet.php
@@ -69,12 +69,6 @@ class CreateAndAttachSharedKeywordSet
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/FindAndRemoveCriteriaFromSharedSet.php
+++ b/examples/AdvancedOperations/FindAndRemoveCriteriaFromSharedSet.php
@@ -62,12 +62,6 @@ class FindAndRemoveCriteriaFromSharedSet
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/GetAdGroupBidModifiers.php
+++ b/examples/AdvancedOperations/GetAdGroupBidModifiers.php
@@ -58,12 +58,6 @@ class GetAdGroupBidModifiers
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/UseCrossAccountBiddingStrategy.php
+++ b/examples/AdvancedOperations/UseCrossAccountBiddingStrategy.php
@@ -73,12 +73,6 @@ class UseCrossAccountBiddingStrategy
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/AdvancedOperations/UsePortfolioBiddingStrategy.php
+++ b/examples/AdvancedOperations/UsePortfolioBiddingStrategy.php
@@ -74,12 +74,6 @@ class UsePortfolioBiddingStrategy
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Assets/AddCall.php
+++ b/examples/Assets/AddCall.php
@@ -76,12 +76,6 @@ class AddCall
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Assets/AddHotelCallout.php
+++ b/examples/Assets/AddHotelCallout.php
@@ -67,12 +67,6 @@ class AddHotelCallout
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Assets/AddLeadFormAsset.php
+++ b/examples/Assets/AddLeadFormAsset.php
@@ -72,12 +72,6 @@ class AddLeadFormAsset
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Assets/AddPrices.php
+++ b/examples/Assets/AddPrices.php
@@ -65,12 +65,6 @@ class AddPrices
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Assets/AddSiteLinks.php
+++ b/examples/Assets/AddSiteLinks.php
@@ -65,12 +65,6 @@ class AddSitelinks
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Authentication/google_ads_php.ini
+++ b/examples/Authentication/google_ads_php.ini
@@ -57,11 +57,3 @@ refreshToken = "INSERT_OAUTH2_REFRESH_TOKEN_HERE"
 ; production because they do not use encryption or authentication, they should only be used for
 ; testing. By default, it is set to true (secure).
 ; grpcChannelIsSecure = true
-
-[GAPIC]
-; Optional GAPIC (Generated API Client) generator settings.
-; Whether this library should use the new version of GAPIC generated source code (GAPIC v2).
-; GAPIC v2 is the preparation for supporting more advanced features in the future.
-; For now, GAPIC v2 source code has the same functionality as the existing source code.
-; By default, it is set to false.
-; useGapicV2Source = false

--- a/examples/BasicOperations/AddAdGroups.php
+++ b/examples/BasicOperations/AddAdGroups.php
@@ -59,12 +59,6 @@ class AddAdGroups
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/AddCampaigns.php
+++ b/examples/BasicOperations/AddCampaigns.php
@@ -64,12 +64,6 @@ class AddCampaigns
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/GetCampaigns.php
+++ b/examples/BasicOperations/GetCampaigns.php
@@ -55,12 +55,6 @@ class GetCampaigns
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/GetResponsiveSearchAds.php
+++ b/examples/BasicOperations/GetResponsiveSearchAds.php
@@ -63,12 +63,6 @@ class GetResponsiveSearchAds
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/PauseAd.php
+++ b/examples/BasicOperations/PauseAd.php
@@ -62,12 +62,6 @@ class PauseAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/RemoveCampaign.php
+++ b/examples/BasicOperations/RemoveCampaign.php
@@ -58,12 +58,6 @@ class RemoveCampaign
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/SearchForGoogleAdsFields.php
+++ b/examples/BasicOperations/SearchForGoogleAdsFields.php
@@ -59,12 +59,6 @@ class SearchForGoogleAdsFields
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/UpdateAdGroup.php
+++ b/examples/BasicOperations/UpdateAdGroup.php
@@ -63,12 +63,6 @@ class UpdateAdGroup
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/UpdateCampaign.php
+++ b/examples/BasicOperations/UpdateCampaign.php
@@ -61,12 +61,6 @@ class UpdateCampaign
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/BasicOperations/UpdateResponsiveSearchAd.php
+++ b/examples/BasicOperations/UpdateResponsiveSearchAd.php
@@ -64,12 +64,6 @@ class UpdateResponsiveSearchAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Billing/AddAccountBudgetProposal.php
+++ b/examples/Billing/AddAccountBudgetProposal.php
@@ -61,12 +61,6 @@ class AddAccountBudgetProposal
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Billing/AddBillingSetup.php
+++ b/examples/Billing/AddBillingSetup.php
@@ -84,12 +84,6 @@ class AddBillingSetup
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Billing/GetInvoices.php
+++ b/examples/Billing/GetInvoices.php
@@ -62,12 +62,6 @@ class GetInvoices
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/CampaignManagement/AddCampaignLabels.php
+++ b/examples/CampaignManagement/AddCampaignLabels.php
@@ -60,12 +60,6 @@ class AddCampaignLabels
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
+++ b/examples/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
@@ -100,12 +100,6 @@ class AddCompleteCampaignsUsingBatchJob
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/CampaignManagement/CreateExperiment.php
+++ b/examples/CampaignManagement/CreateExperiment.php
@@ -72,12 +72,6 @@ class CreateExperiment
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/CampaignManagement/GetAllDisapprovedAds.php
+++ b/examples/CampaignManagement/GetAllDisapprovedAds.php
@@ -59,12 +59,6 @@ class GetAllDisapprovedAds
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/CampaignManagement/SetAdParameters.php
+++ b/examples/CampaignManagement/SetAdParameters.php
@@ -59,12 +59,6 @@ class SetAdParameters
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/CampaignManagement/UpdateCampaignCriterionBidModifier.php
+++ b/examples/CampaignManagement/UpdateCampaignCriterionBidModifier.php
@@ -64,12 +64,6 @@ class UpdateCampaignCriterionBidModifier
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/CampaignManagement/ValidateAd.php
+++ b/examples/CampaignManagement/ValidateAd.php
@@ -68,12 +68,6 @@ class ValidateAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ErrorHandling/HandleKeywordPolicyViolations.php
+++ b/examples/ErrorHandling/HandleKeywordPolicyViolations.php
@@ -74,12 +74,6 @@ class HandleKeywordPolicyViolations
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ErrorHandling/HandlePartialFailure.php
+++ b/examples/ErrorHandling/HandlePartialFailure.php
@@ -71,12 +71,6 @@ class HandlePartialFailure
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ErrorHandling/HandleRateExceededError.php
+++ b/examples/ErrorHandling/HandleRateExceededError.php
@@ -78,12 +78,6 @@ class HandleRateExceededError
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ErrorHandling/HandleResponsiveSearchAdPolicyViolations.php
+++ b/examples/ErrorHandling/HandleResponsiveSearchAdPolicyViolations.php
@@ -69,12 +69,6 @@ class HandleResponsiveSearchAdPolicyViolations
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Feeds/CreateFeedItemSet.php
+++ b/examples/Feeds/CreateFeedItemSet.php
@@ -61,12 +61,6 @@ class CreateFeedItemSet
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Feeds/GetFeedItemsOfFeedItemSet.php
+++ b/examples/Feeds/GetFeedItemsOfFeedItemSet.php
@@ -63,12 +63,6 @@ class GetFeedItemsOfFeedItemSet
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Feeds/LinkFeedItemSet.php
+++ b/examples/Feeds/LinkFeedItemSet.php
@@ -64,12 +64,6 @@ class LinkFeedItemSet
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Feeds/RemoveFeedItems.php
+++ b/examples/Feeds/RemoveFeedItems.php
@@ -59,12 +59,6 @@ class RemoveFeedItems
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Misc/CampaignReportToCsv.php
+++ b/examples/Misc/CampaignReportToCsv.php
@@ -60,12 +60,6 @@ class CampaignReportToCsv
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Misc/SetCustomClientTimeouts.php
+++ b/examples/Misc/SetCustomClientTimeouts.php
@@ -64,12 +64,6 @@ class SetCustomClientTimeouts
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Misc/UploadImageAsset.php
+++ b/examples/Misc/UploadImageAsset.php
@@ -58,12 +58,6 @@ class UploadImageAsset
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Planning/ForecastReach.php
+++ b/examples/Planning/ForecastReach.php
@@ -75,12 +75,6 @@ class ForecastReach
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Planning/GenerateForecastMetrics.php
+++ b/examples/Planning/GenerateForecastMetrics.php
@@ -67,12 +67,6 @@ class GenerateForecastMetrics
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Planning/GenerateHistoricalMetrics.php
+++ b/examples/Planning/GenerateHistoricalMetrics.php
@@ -62,12 +62,6 @@ class GenerateHistoricalMetrics
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Planning/GenerateKeywordIdeas.php
+++ b/examples/Planning/GenerateKeywordIdeas.php
@@ -77,12 +77,6 @@ class GenerateKeywordIdeas
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Planning/GetAdGroupCriterionCpcBidSimulations.php
+++ b/examples/Planning/GetAdGroupCriterionCpcBidSimulations.php
@@ -60,12 +60,6 @@ class GetAdGroupCriterionCpcBidSimulations
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Recommendations/DetectAndApplyRecommendations.php
+++ b/examples/Recommendations/DetectAndApplyRecommendations.php
@@ -71,12 +71,6 @@ class DetectAndApplyRecommendations
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Recommendations/DismissRecommendation.php
+++ b/examples/Recommendations/DismissRecommendation.php
@@ -61,12 +61,6 @@ class DismissRecommendation
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddConversionAction.php
+++ b/examples/Remarketing/AddConversionAction.php
@@ -59,12 +59,6 @@ class AddConversionAction
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddConversionBasedUserList.php
+++ b/examples/Remarketing/AddConversionBasedUserList.php
@@ -64,12 +64,6 @@ class AddConversionBasedUserList
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddCustomAudience.php
+++ b/examples/Remarketing/AddCustomAudience.php
@@ -63,12 +63,6 @@ class AddCustomAudience
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddCustomerMatchUserList.php
+++ b/examples/Remarketing/AddCustomerMatchUserList.php
@@ -115,12 +115,6 @@ class AddCustomerMatchUserList
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddDynamicRemarketingAsset.php
+++ b/examples/Remarketing/AddDynamicRemarketingAsset.php
@@ -69,12 +69,6 @@ class AddDynamicRemarketingAsset
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddFlexibleRuleUserList.php
+++ b/examples/Remarketing/AddFlexibleRuleUserList.php
@@ -70,12 +70,6 @@ class AddFlexibleRuleUserList
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddLogicalUserList.php
+++ b/examples/Remarketing/AddLogicalUserList.php
@@ -66,12 +66,6 @@ class AddLogicalUserList
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/AddMerchantCenterDynamicRemarketingCampaign.php
+++ b/examples/Remarketing/AddMerchantCenterDynamicRemarketingCampaign.php
@@ -92,12 +92,6 @@ class AddMerchantCenterDynamicRemarketingCampaign
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/SetUpAdvancedRemarketing.php
+++ b/examples/Remarketing/SetUpAdvancedRemarketing.php
@@ -74,12 +74,6 @@ class SetUpAdvancedRemarketing
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/SetUpRemarketing.php
+++ b/examples/Remarketing/SetUpRemarketing.php
@@ -97,12 +97,6 @@ class SetUpRemarketing
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/UpdateAudienceTargetRestriction.php
+++ b/examples/Remarketing/UpdateAudienceTargetRestriction.php
@@ -65,12 +65,6 @@ class UpdateAudienceTargetRestriction
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/UploadCallConversion.php
+++ b/examples/Remarketing/UploadCallConversion.php
@@ -80,12 +80,6 @@ class UploadCallConversion
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/UploadConversionAdjustment.php
+++ b/examples/Remarketing/UploadConversionAdjustment.php
@@ -78,12 +78,6 @@ class UploadConversionAdjustment
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/UploadEnhancedConversionsForLeads.php
+++ b/examples/Remarketing/UploadEnhancedConversionsForLeads.php
@@ -84,12 +84,6 @@ class UploadEnhancedConversionsForLeads
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/UploadEnhancedConversionsForWeb.php
+++ b/examples/Remarketing/UploadEnhancedConversionsForWeb.php
@@ -78,12 +78,6 @@ class UploadEnhancedConversionsForWeb
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/UploadOfflineConversion.php
+++ b/examples/Remarketing/UploadOfflineConversion.php
@@ -94,12 +94,6 @@ class UploadOfflineConversion
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Remarketing/UploadStoreSalesTransactions.php
+++ b/examples/Remarketing/UploadStoreSalesTransactions.php
@@ -160,12 +160,6 @@ class UploadStoreSalesTransactions
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ShoppingAds/AddListingScope.php
+++ b/examples/ShoppingAds/AddListingScope.php
@@ -77,12 +77,6 @@ class AddListingScope
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ShoppingAds/AddPerformanceMaxProductListingGroupTree.php
+++ b/examples/ShoppingAds/AddPerformanceMaxProductListingGroupTree.php
@@ -90,12 +90,6 @@ class AddPerformanceMaxProductListingGroupTree
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ShoppingAds/AddPerformanceMaxRetailCampaign.php
+++ b/examples/ShoppingAds/AddPerformanceMaxRetailCampaign.php
@@ -136,12 +136,6 @@ class AddPerformanceMaxRetailCampaign
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ShoppingAds/AddShoppingProductAd.php
+++ b/examples/ShoppingAds/AddShoppingProductAd.php
@@ -89,12 +89,6 @@ class AddShoppingProductAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ShoppingAds/AddShoppingProductListingGroupTree.php
+++ b/examples/ShoppingAds/AddShoppingProductListingGroupTree.php
@@ -80,12 +80,6 @@ class AddShoppingProductListingGroupTree
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/ShoppingAds/GetProductCategoryConstants.php
+++ b/examples/ShoppingAds/GetProductCategoryConstants.php
@@ -55,12 +55,6 @@ class GetProductCategoryConstants
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Targeting/AddCampaignTargetingCriteria.php
+++ b/examples/Targeting/AddCampaignTargetingCriteria.php
@@ -73,12 +73,6 @@ class AddCampaignTargetingCriteria
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Targeting/AddCustomerNegativeCriteria.php
+++ b/examples/Targeting/AddCustomerNegativeCriteria.php
@@ -59,12 +59,6 @@ class AddCustomerNegativeCriteria
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Targeting/AddDemographicTargetingCriteria.php
+++ b/examples/Targeting/AddDemographicTargetingCriteria.php
@@ -63,12 +63,6 @@ class AddDemographicTargetingCriteria
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Targeting/GetGeoTargetConstantsByNames.php
+++ b/examples/Targeting/GetGeoTargetConstantsByNames.php
@@ -66,12 +66,6 @@ class GetGeoTargetConstantsByNames
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Travel/AddHotelAd.php
+++ b/examples/Travel/AddHotelAd.php
@@ -90,12 +90,6 @@ class AddHotelAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Travel/AddHotelAdGroupBidModifiers.php
+++ b/examples/Travel/AddHotelAdGroupBidModifiers.php
@@ -63,12 +63,6 @@ class AddHotelAdGroupBidModifiers
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Travel/AddHotelListingGroupTree.php
+++ b/examples/Travel/AddHotelListingGroupTree.php
@@ -95,12 +95,6 @@ class AddHotelListingGroupTree
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Travel/AddPerformanceMaxForTravelGoalsCampaign.php
+++ b/examples/Travel/AddPerformanceMaxForTravelGoalsCampaign.php
@@ -160,12 +160,6 @@ class AddPerformanceMaxForTravelGoalsCampaign
         $googleAdsClient = (new GoogleAdsClientBuilder())
             ->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Travel/AddThingsToDoAd.php
+++ b/examples/Travel/AddThingsToDoAd.php
@@ -83,12 +83,6 @@ class AddThingsToDoAd
         // OAuth2 credentials above.
         $googleAdsClient = (new GoogleAdsClientBuilder())->fromFile()
             ->withOAuth2Credential($oAuth2Credential)
-            // We set this value to true to show how to use GAPIC v2 source code. You can remove the
-            // below line if you wish to use the old-style source code. Note that in that case, you
-            // probably need to modify some parts of the code below to make it work.
-            // For more information, see
-            // https://developers.devsite.corp.google.com/google-ads/api/docs/client-libs/php/gapic.
-            ->usingGapicV2Source(true)
             ->build();
 
         try {

--- a/examples/Utils/Feeds.php
+++ b/examples/Utils/Feeds.php
@@ -50,9 +50,8 @@ final class Feeds
         $query = "SELECT feed_item.attribute_values FROM feed_item"
             . " WHERE feed_item.resource_name = '$feedItemResourceName'";
         // Issues a search request.
-        $response = ($googleAdsClient->useGapicV2Source())
-            ? $googleAdsServiceClient->search(SearchGoogleAdsRequest::build($customerId, $query))
-            : $googleAdsServiceClient->search($customerId, $query);
+        $response =
+            $googleAdsServiceClient->search(SearchGoogleAdsRequest::build($customerId, $query));
 
         // Returns the feed item attribute values, which belongs to the first item. We can ensure
         // it belongs to the first one because we specified the feed item resource name in the
@@ -187,9 +186,8 @@ final class Feeds
         // Constructs the query to get the feed attributes for the specified feed resource name.
         $query = "SELECT feed.attributes FROM feed WHERE feed.resource_name = '$feedResourceName'";
         // Issues a search request.
-        $response = ($googleAdsClient->useGapicV2Source())
-            ? $googleAdsServiceClient->search(SearchGoogleAdsRequest::build($customerId, $query))
-            : $googleAdsServiceClient->search($customerId, $query);
+        $response =
+            $googleAdsServiceClient->search(SearchGoogleAdsRequest::build($customerId, $query));
 
         // Gets the first result because we only need the single feed we created previously.
         /** @var GoogleAdsRow $googleAdsRow */

--- a/src/Google/Ads/GoogleAds/Lib/ConfigurationTrait.php
+++ b/src/Google/Ads/GoogleAds/Lib/ConfigurationTrait.php
@@ -39,7 +39,6 @@ trait ConfigurationTrait
     private $proxy;
     private $transport;
     private $grpcChannelIsSecure;
-    private $useGapicV2Source;
 
     // The following configuration settings are based on complex objects. They cannot be set in
     // configuration files like the others but only dynamically.
@@ -167,16 +166,6 @@ trait ConfigurationTrait
     public function getGrpcChannelCredential()
     {
         return $this->grpcChannelCredential;
-    }
-
-    /**
-     * Returns true when this library is set to use GAPIC v2 source.
-     *
-     * @return bool
-     */
-    public function useGapicV2Source()
-    {
-        return $this->useGapicV2Source;
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/Lib/V16/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V16/GoogleAdsClient.php
@@ -50,7 +50,6 @@ class GoogleAdsClient
         $this->transport = $builder->getTransport();
         $this->grpcChannelIsSecure = $builder->getGrpcChannelIsSecure();
         $this->grpcChannelCredential = $builder->getGrpcChannelCredential();
-        $this->useGapicV2Source = $builder->useGapicV2Source();
         $this->unaryMiddlewares = $builder->getUnaryMiddlewares();
         $this->streamingMiddlewares = $builder->getStreamingMiddlewares();
         $this->grpcInterceptors = $builder->getGrpcInterceptors();

--- a/src/Google/Ads/GoogleAds/Lib/V16/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V16/GoogleAdsClientBuilder.php
@@ -46,7 +46,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     private const DEFAULT_LOGGER_CHANNEL = 'google-ads';
     private const DEFAULT_GRPC_CHANNEL_IS_SECURE = true;
     private const DEFAULT_USE_CLOUD_ORG_FOR_API_ACCESS = false;
-    private const DEFAULT_USE_GAPIC_V2_SOURCE = false;
 
     private $loggerFactory;
 
@@ -62,7 +61,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     private $transport;
     private $grpcChannelIsSecure;
     private $grpcChannelCredential;
-    private $useGapicV2Source;
     private $unaryMiddlewares = [];
     private $streamingMiddlewares = [];
     private $grpcInterceptors = [];
@@ -126,19 +124,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
                     // Defaults when value is not a valid boolean.
                     [
                         'options' => ['default' => self::DEFAULT_GRPC_CHANNEL_IS_SECURE],
-                        'flags' => FILTER_NULL_ON_FAILURE
-                    ]
-                );
-        $this->useGapicV2Source =
-            is_null($configuration->getConfiguration('useGapicV2Source', 'GAPIC'))
-            || $configuration->getConfiguration('useGapicV2Source', 'GAPIC') === ""
-                ? self::DEFAULT_USE_GAPIC_V2_SOURCE
-                : filter_var(
-                    $configuration->getConfiguration('useGapicV2Source', 'GAPIC'),
-                    FILTER_VALIDATE_BOOLEAN,
-                    // Defaults when value is not a valid boolean.
-                    [
-                        'options' => ['default' => self::DEFAULT_USE_GAPIC_V2_SOURCE],
                         'flags' => FILTER_NULL_ON_FAILURE
                     ]
                 );
@@ -320,18 +305,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     public function withGrpcChannelCredential(ChannelCredentials $grpcChannelCredential)
     {
         $this->grpcChannelCredential = $grpcChannelCredential;
-        return $this;
-    }
-
-    /**
-     * Sets whether this library should use GAPIC v2 source code or not.
-     *
-     * @param bool $useGapicV2Source
-     * @return self this builder
-     */
-    public function usingGapicV2Source(bool $useGapicV2Source)
-    {
-        $this->useGapicV2Source = $useGapicV2Source;
         return $this;
     }
 
@@ -636,16 +609,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     public function getGrpcChannelCredential()
     {
         return $this->grpcChannelCredential;
-    }
-
-    /**
-     * Returns true when this library is set to use GAPIC v2 source.
-     *
-     * @return bool
-     */
-    public function useGapicV2Source()
-    {
-        return $this->useGapicV2Source;
     }
 
     /**

--- a/src/Google/Ads/GoogleAds/Lib/V17/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAds/Lib/V17/GoogleAdsClient.php
@@ -50,7 +50,6 @@ class GoogleAdsClient
         $this->transport = $builder->getTransport();
         $this->grpcChannelIsSecure = $builder->getGrpcChannelIsSecure();
         $this->grpcChannelCredential = $builder->getGrpcChannelCredential();
-        $this->useGapicV2Source = $builder->useGapicV2Source();
         $this->unaryMiddlewares = $builder->getUnaryMiddlewares();
         $this->streamingMiddlewares = $builder->getStreamingMiddlewares();
         $this->grpcInterceptors = $builder->getGrpcInterceptors();

--- a/src/Google/Ads/GoogleAds/Lib/V17/GoogleAdsClientBuilder.php
+++ b/src/Google/Ads/GoogleAds/Lib/V17/GoogleAdsClientBuilder.php
@@ -46,7 +46,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     private const DEFAULT_LOGGER_CHANNEL = 'google-ads';
     private const DEFAULT_GRPC_CHANNEL_IS_SECURE = true;
     private const DEFAULT_USE_CLOUD_ORG_FOR_API_ACCESS = false;
-    private const DEFAULT_USE_GAPIC_V2_SOURCE = false;
 
     private $loggerFactory;
 
@@ -62,7 +61,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     private $transport;
     private $grpcChannelIsSecure;
     private $grpcChannelCredential;
-    private $useGapicV2Source;
     private $unaryMiddlewares = [];
     private $streamingMiddlewares = [];
     private $grpcInterceptors = [];
@@ -126,19 +124,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
                     // Defaults when value is not a valid boolean.
                     [
                         'options' => ['default' => self::DEFAULT_GRPC_CHANNEL_IS_SECURE],
-                        'flags' => FILTER_NULL_ON_FAILURE
-                    ]
-                );
-        $this->useGapicV2Source =
-            is_null($configuration->getConfiguration('useGapicV2Source', 'GAPIC'))
-            || $configuration->getConfiguration('useGapicV2Source', 'GAPIC') === ""
-                ? self::DEFAULT_USE_GAPIC_V2_SOURCE
-                : filter_var(
-                    $configuration->getConfiguration('useGapicV2Source', 'GAPIC'),
-                    FILTER_VALIDATE_BOOLEAN,
-                    // Defaults when value is not a valid boolean.
-                    [
-                        'options' => ['default' => self::DEFAULT_USE_GAPIC_V2_SOURCE],
                         'flags' => FILTER_NULL_ON_FAILURE
                     ]
                 );
@@ -320,18 +305,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     public function withGrpcChannelCredential(ChannelCredentials $grpcChannelCredential)
     {
         $this->grpcChannelCredential = $grpcChannelCredential;
-        return $this;
-    }
-
-    /**
-     * Sets whether this library should use GAPIC v2 source code or not.
-     *
-     * @param bool $useGapicV2Source
-     * @return self this builder
-     */
-    public function usingGapicV2Source(bool $useGapicV2Source)
-    {
-        $this->useGapicV2Source = $useGapicV2Source;
         return $this;
     }
 
@@ -636,16 +609,6 @@ final class GoogleAdsClientBuilder extends AbstractGoogleAdsBuilder
     public function getGrpcChannelCredential()
     {
         return $this->grpcChannelCredential;
-    }
-
-    /**
-     * Returns true when this library is set to use GAPIC v2 source.
-     *
-     * @return bool
-     */
-    public function useGapicV2Source()
-    {
-        return $this->useGapicV2Source;
     }
 
     /**

--- a/tests/Google/Ads/GoogleAds/Lib/ConfigurationTraitInserted.php
+++ b/tests/Google/Ads/GoogleAds/Lib/ConfigurationTraitInserted.php
@@ -46,7 +46,6 @@ class ConfigurationTraitInserted
      * @param string $logLevel
      * @param string $proxy
      * @param string $transport
-     * @param bool $useGapicV2Source
      */
     public function __construct(
         string $developerToken,
@@ -57,8 +56,7 @@ class ConfigurationTraitInserted
         LoggerInterface $logger,
         string $logLevel,
         string $proxy,
-        string $transport,
-        bool $useGapicV2Source
+        string $transport
     ) {
         $this->developerToken = $developerToken;
         $this->loginCustomerId = $loginCustomerId;
@@ -69,6 +67,5 @@ class ConfigurationTraitInserted
         $this->logLevel = $logLevel;
         $this->proxy = $proxy;
         $this->transport = $transport;
-        $this->useGapicV2Source = $useGapicV2Source;
     }
 }

--- a/tests/Google/Ads/GoogleAds/Lib/ConfigurationTraitTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/ConfigurationTraitTest.php
@@ -59,8 +59,7 @@ class ConfigurationTraitTest extends TestCase
             $this->loggerMock,
             LogLevel::INFO,
             'localhost',
-            'grpc',
-            true
+            'grpc'
         );
     }
 
@@ -110,10 +109,5 @@ class ConfigurationTraitTest extends TestCase
     public function testGetTransport()
     {
         $this->assertEquals('grpc', $this->configurationTraitInserted->getTransport());
-    }
-
-    public function testUseGapicV2Source()
-    {
-        $this->assertTrue($this->configurationTraitInserted->useGapicV2Source());
     }
 }

--- a/tests/Google/Ads/GoogleAds/Lib/V16/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V16/GoogleAdsClientBuilderTest.php
@@ -82,8 +82,7 @@ class GoogleAdsClientBuilderTest extends TestCase
             ['endpoint', 'GOOGLE_ADS', 'https://abc.xyz:443'],
             ['proxy', 'CONNECTION', 'https://localhost:8080'],
             ['transport', 'CONNECTION', 'grpc'],
-            ['grpcChannelIsSecure', 'CONNECTION', 'true'],
-            ['useGapicV2Source', 'GAPIC', 'true']
+            ['grpcChannelIsSecure', 'CONNECTION', 'true']
         ];
         $configurationMock = $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
@@ -107,7 +106,6 @@ class GoogleAdsClientBuilderTest extends TestCase
         $this->assertSame('grpc', $googleAdsClient->getTransport());
         $this->assertTrue($googleAdsClient->getGrpcChannelIsSecure());
         $this->assertSame($this->loggerMock, $googleAdsClient->getLogger());
-        $this->assertTrue($googleAdsClient->useGapicV2Source());
     }
 
     /**
@@ -319,7 +317,6 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->withLoginCustomerId(self::$LOGIN_CUSTOMER_ID)
             ->withEndpoint('abc.xyz.com')
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
-            ->usingGapicV2Source(false)
             ->build();
 
         $this->assertSame(self::$DEVELOPER_TOKEN, $googleAdsClient->getDeveloperToken());
@@ -330,7 +327,6 @@ class GoogleAdsClientBuilderTest extends TestCase
             FetchAuthTokenInterface::class,
             $googleAdsClient->getOAuth2Credential()
         );
-        $this->assertFalse($googleAdsClient->useGapicV2Source());
     }
 
     public function testBuildDefaults()
@@ -651,17 +647,6 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
             ->withDependencies($dependenciesMock)
             ->build();
-    }
-
-    public function testBuildUsingGapicV2Source()
-    {
-        $googleAdsClient = $this->googleAdsClientBuilder
-            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
-            ->usingGapicV2Source(true)
-            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
-            ->build();
-
-        $this->assertTrue($googleAdsClient->useGapicV2Source());
     }
 
     public function testBuildUsingCloudOrgForApiAccess()

--- a/tests/Google/Ads/GoogleAds/Lib/V17/GoogleAdsClientBuilderTest.php
+++ b/tests/Google/Ads/GoogleAds/Lib/V17/GoogleAdsClientBuilderTest.php
@@ -82,8 +82,7 @@ class GoogleAdsClientBuilderTest extends TestCase
             ['endpoint', 'GOOGLE_ADS', 'https://abc.xyz:443'],
             ['proxy', 'CONNECTION', 'https://localhost:8080'],
             ['transport', 'CONNECTION', 'grpc'],
-            ['grpcChannelIsSecure', 'CONNECTION', 'true'],
-            ['useGapicV2Source', 'GAPIC', 'true']
+            ['grpcChannelIsSecure', 'CONNECTION', 'true']
         ];
         $configurationMock = $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
@@ -107,7 +106,6 @@ class GoogleAdsClientBuilderTest extends TestCase
         $this->assertSame('grpc', $googleAdsClient->getTransport());
         $this->assertTrue($googleAdsClient->getGrpcChannelIsSecure());
         $this->assertSame($this->loggerMock, $googleAdsClient->getLogger());
-        $this->assertTrue($googleAdsClient->useGapicV2Source());
     }
 
     /**
@@ -319,7 +317,6 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->withLoginCustomerId(self::$LOGIN_CUSTOMER_ID)
             ->withEndpoint('abc.xyz.com')
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
-            ->usingGapicV2Source(false)
             ->build();
 
         $this->assertSame(self::$DEVELOPER_TOKEN, $googleAdsClient->getDeveloperToken());
@@ -330,7 +327,6 @@ class GoogleAdsClientBuilderTest extends TestCase
             FetchAuthTokenInterface::class,
             $googleAdsClient->getOAuth2Credential()
         );
-        $this->assertFalse($googleAdsClient->useGapicV2Source());
     }
 
     public function testBuildDefaults()
@@ -651,17 +647,6 @@ class GoogleAdsClientBuilderTest extends TestCase
             ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
             ->withDependencies($dependenciesMock)
             ->build();
-    }
-
-    public function testBuildUsingGapicV2Source()
-    {
-        $googleAdsClient = $this->googleAdsClientBuilder
-            ->withDeveloperToken(self::$DEVELOPER_TOKEN)
-            ->usingGapicV2Source(true)
-            ->withOAuth2Credential($this->fetchAuthTokenInterfaceMock)
-            ->build();
-
-        $this->assertTrue($googleAdsClient->useGapicV2Source());
     }
 
     public function testBuildUsingCloudOrgForApiAccess()


### PR DESCRIPTION
All generated clients since v16 now use GAPIC v2.