### PR TITLE
Remove the reference for setting Customer Match membership to no expiration

### DIFF
--- a/examples/Remarketing/AddCustomerMatchUserList.php
+++ b/examples/Remarketing/AddCustomerMatchUserList.php
@@ -225,8 +225,8 @@ class AddCustomerMatchUserList
             'name' => 'Customer Match list #' . Helper::getPrintableDatetime(),
             'description' => 'A list of customers that originated from email '
                 . 'and physical addresses',
-            // Customer Match user lists can use a membership life span of 10000 to
-            // indicate unlimited; otherwise normal values apply.
+            // Membership life span must be between 0 and 540 days inclusive. See:
+            // https://developers.google.com/google-ads/api/reference/rpc/latest/UserList#membership_life_span
             // Sets the membership life span to 30 days.
             'membership_life_span' => 30,
             'crm_based_user_list' => new CrmBasedUserListInfo([


### PR DESCRIPTION
As announced in [this blog post](https://ads-developers.googleblog.com/2025/02/update-to-customer-match-membership.html), we will soon disallow setting `membership_life_span` to no expiration.

Updated the comment to reflect this change.