### PR TITLE
PHP 8.4: Fix nullable is deprecated

### DIFF
--- a/src/Google/Ads/GoogleAds/Lib/GoogleAdsMiddlewareAbstract.php
+++ b/src/Google/Ads/GoogleAds/Lib/GoogleAdsMiddlewareAbstract.php
@@ -35,7 +35,7 @@ abstract class GoogleAdsMiddlewareAbstract
      *
      * @param callable|null $nextHandler the next handler
      */
-    public function __construct(callable $nextHandler = null)
+    public function __construct(?callable $nextHandler = null)
     {
         $this->nextHandler = $nextHandler;
     }

--- a/src/Google/Ads/GoogleAds/Lib/InsecureCredentialsWrapper.php
+++ b/src/Google/Ads/GoogleAds/Lib/InsecureCredentialsWrapper.php
@@ -36,7 +36,7 @@ class InsecureCredentialsWrapper extends CredentialsWrapper
      */
     public function __construct(
         FetchAuthTokenInterface $credentialsFetcher,
-        callable $authHttpHandler = null
+        ?callable $authHttpHandler = null
     ) {
         parent::__construct($credentialsFetcher, $authHttpHandler);
     }

--- a/src/Google/Ads/GoogleAds/Lib/V19/ServerStreamingGoogleAdsExceptionMiddleware.php
+++ b/src/Google/Ads/GoogleAds/Lib/V19/ServerStreamingGoogleAdsExceptionMiddleware.php
@@ -38,8 +38,8 @@ class ServerStreamingGoogleAdsExceptionMiddleware extends GoogleAdsMiddlewareAbs
      * @param StatusMetadataExtractor|null $statusMetadataExtractor
      */
     public function __construct(
-        callable $nextHandler = null,
-        StatusMetadataExtractor $statusMetadataExtractor = null
+        ?callable $nextHandler = null,
+        ?StatusMetadataExtractor $statusMetadataExtractor = null
     ) {
         parent::__construct($nextHandler);
         $this->statusMetadataExtractor = $statusMetadataExtractor ?: new StatusMetadataExtractor();

--- a/src/Google/Ads/GoogleAds/Lib/V19/UnaryGoogleAdsExceptionMiddleware.php
+++ b/src/Google/Ads/GoogleAds/Lib/V19/UnaryGoogleAdsExceptionMiddleware.php
@@ -39,8 +39,8 @@ class UnaryGoogleAdsExceptionMiddleware extends GoogleAdsMiddlewareAbstract
      * @param StatusMetadataExtractor|null $statusMetadataExtractor
      */
     public function __construct(
-        callable $nextHandler = null,
-        StatusMetadataExtractor $statusMetadataExtractor = null
+        ?callable $nextHandler = null,
+        ?StatusMetadataExtractor $statusMetadataExtractor = null
     ) {
         parent::__construct($nextHandler);
         $this->statusMetadataExtractor = $statusMetadataExtractor ?: new StatusMetadataExtractor();

--- a/src/Google/Ads/GoogleAds/Lib/V19/UnaryGoogleAdsResponseMetadataCallable.php
+++ b/src/Google/Ads/GoogleAds/Lib/V19/UnaryGoogleAdsResponseMetadataCallable.php
@@ -33,7 +33,7 @@ class UnaryGoogleAdsResponseMetadataCallable extends GoogleAdsMiddlewareAbstract
 
     private $adsClient;
 
-    public function __construct(callable $nextHandler = null, $adsClient = null)
+    public function __construct(?callable $nextHandler = null, $adsClient = null)
     {
         $this->adsClient = $adsClient;
         parent::__construct($nextHandler);

--- a/src/Google/Ads/GoogleAds/Lib/V20/ServerStreamingGoogleAdsExceptionMiddleware.php
+++ b/src/Google/Ads/GoogleAds/Lib/V20/ServerStreamingGoogleAdsExceptionMiddleware.php
@@ -38,8 +38,8 @@ class ServerStreamingGoogleAdsExceptionMiddleware extends GoogleAdsMiddlewareAbs
      * @param StatusMetadataExtractor|null $statusMetadataExtractor
      */
     public function __construct(
-        callable $nextHandler = null,
-        StatusMetadataExtractor $statusMetadataExtractor = null
+        ?callable $nextHandler = null,
+        ?StatusMetadataExtractor $statusMetadataExtractor = null
     ) {
         parent::__construct($nextHandler);
         $this->statusMetadataExtractor = $statusMetadataExtractor ?: new StatusMetadataExtractor();

--- a/src/Google/Ads/GoogleAds/Lib/V20/UnaryGoogleAdsExceptionMiddleware.php
+++ b/src/Google/Ads/GoogleAds/Lib/V20/UnaryGoogleAdsExceptionMiddleware.php
@@ -39,8 +39,8 @@ class UnaryGoogleAdsExceptionMiddleware extends GoogleAdsMiddlewareAbstract
      * @param StatusMetadataExtractor|null $statusMetadataExtractor
      */
     public function __construct(
-        callable $nextHandler = null,
-        StatusMetadataExtractor $statusMetadataExtractor = null
+        ?callable $nextHandler = null,
+        ?StatusMetadataExtractor $statusMetadataExtractor = null
     ) {
         parent::__construct($nextHandler);
         $this->statusMetadataExtractor = $statusMetadataExtractor ?: new StatusMetadataExtractor();

--- a/src/Google/Ads/GoogleAds/Lib/V20/UnaryGoogleAdsResponseMetadataCallable.php
+++ b/src/Google/Ads/GoogleAds/Lib/V20/UnaryGoogleAdsResponseMetadataCallable.php
@@ -33,7 +33,7 @@ class UnaryGoogleAdsResponseMetadataCallable extends GoogleAdsMiddlewareAbstract
 
     private $adsClient;
 
-    public function __construct(callable $nextHandler = null, $adsClient = null)
+    public function __construct(?callable $nextHandler = null, $adsClient = null)
     {
         $this->adsClient = $adsClient;
         parent::__construct($nextHandler);

--- a/src/Google/Ads/GoogleAds/Lib/V21/ServerStreamingGoogleAdsExceptionMiddleware.php
+++ b/src/Google/Ads/GoogleAds/Lib/V21/ServerStreamingGoogleAdsExceptionMiddleware.php
@@ -38,8 +38,8 @@ class ServerStreamingGoogleAdsExceptionMiddleware extends GoogleAdsMiddlewareAbs
      * @param StatusMetadataExtractor|null $statusMetadataExtractor
      */
     public function __construct(
-        callable $nextHandler = null,
-        StatusMetadataExtractor $statusMetadataExtractor = null
+        ?callable $nextHandler = null,
+        ?StatusMetadataExtractor $statusMetadataExtractor = null
     ) {
         parent::__construct($nextHandler);
         $this->statusMetadataExtractor = $statusMetadataExtractor ?: new StatusMetadataExtractor();

--- a/src/Google/Ads/GoogleAds/Lib/V21/UnaryGoogleAdsExceptionMiddleware.php
+++ b/src/Google/Ads/GoogleAds/Lib/V21/UnaryGoogleAdsExceptionMiddleware.php
@@ -39,8 +39,8 @@ class UnaryGoogleAdsExceptionMiddleware extends GoogleAdsMiddlewareAbstract
      * @param StatusMetadataExtractor|null $statusMetadataExtractor
      */
     public function __construct(
-        callable $nextHandler = null,
-        StatusMetadataExtractor $statusMetadataExtractor = null
+        ?callable $nextHandler = null,
+        ?StatusMetadataExtractor $statusMetadataExtractor = null
     ) {
         parent::__construct($nextHandler);
         $this->statusMetadataExtractor = $statusMetadataExtractor ?: new StatusMetadataExtractor();

--- a/src/Google/Ads/GoogleAds/Lib/V21/UnaryGoogleAdsResponseMetadataCallable.php
+++ b/src/Google/Ads/GoogleAds/Lib/V21/UnaryGoogleAdsResponseMetadataCallable.php
@@ -33,7 +33,7 @@ class UnaryGoogleAdsResponseMetadataCallable extends GoogleAdsMiddlewareAbstract
 
     private $adsClient;
 
-    public function __construct(callable $nextHandler = null, $adsClient = null)
+    public function __construct(?callable $nextHandler = null, $adsClient = null)
     {
         $this->adsClient = $adsClient;
         parent::__construct($nextHandler);


### PR DESCRIPTION
Follow-up #1056

Address the notice:
```
PHP Deprecated:  Google\Ads\GoogleAds\Lib\V20\UnaryGoogleAdsExceptionMiddleware::__construct(): Implicitly marking parameter $nextHandler as nullable is deprecated, the explicit nullable type must be used instead in /.../vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Lib/V20/UnaryGoogleAdsExceptionMiddleware.php on line 41

PHP Deprecated:  Google\Ads\GoogleAds\Lib\V20\UnaryGoogleAdsExceptionMiddleware::__construct(): Implicitly marking parameter $statusMetadataExtractor as nullable is deprecated, the explicit nullable type must be used instead in /.../vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Lib/V20/UnaryGoogleAdsExceptionMiddleware.php on line 41

PHP Deprecated:  Google\Ads\GoogleAds\Lib\GoogleAdsMiddlewareAbstract::__construct(): Implicitly marking parameter $nextHandler as nullable is deprecated, the explicit nullable type must be used instead in /.../vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Lib/GoogleAdsMiddlewareAbstract.php on line 38

PHP Deprecated:  Google\Ads\GoogleAds\Lib\V20\UnaryGoogleAdsResponseMetadataCallable::__construct(): Implicitly marking parameter $nextHandler as nullable is deprecated, the explicit nullable type must be used instead in /.../vendor/googleads/google-ads-php/src/Google/Ads/GoogleAds/Lib/V20/UnaryGoogleAdsResponseMetadataCallable.php on line 36
```