### PR TITLE
PHP 8.4 Compat: Throw UnexpectedValueException for calls to undefined methods.

### DIFF
--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AccountBudgetProposalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AccountBudgetProposalServiceClient.php
@@ -261,7 +261,7 @@ class AccountBudgetProposalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AccountLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AccountLinkServiceClient.php
@@ -221,7 +221,7 @@ class AccountLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAdLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAdLabelServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupAdLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAdServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAdServiceClient.php
@@ -296,7 +296,7 @@ class AdGroupAdServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAssetServiceClient.php
@@ -257,7 +257,7 @@ class AdGroupAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupAssetSetServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupBidModifierServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupBidModifierServiceClient.php
@@ -237,7 +237,7 @@ class AdGroupBidModifierServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCriterionCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCriterionCustomizerServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupCriterionCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCriterionLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCriterionLabelServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupCriterionLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCriterionServiceClient.php
@@ -309,7 +309,7 @@ class AdGroupCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupCustomizerServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupLabelServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdGroupServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdParameterServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdParameterServiceClient.php
@@ -241,7 +241,7 @@ class AdParameterServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AdServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AdServiceClient.php
@@ -216,7 +216,7 @@ class AdServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupAssetServiceClient.php
@@ -257,7 +257,7 @@ class AssetGroupAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupListingGroupFilterServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupListingGroupFilterServiceClient.php
@@ -237,7 +237,7 @@ class AssetGroupListingGroupFilterServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupServiceClient.php
@@ -235,7 +235,7 @@ class AssetGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupSignalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AssetGroupSignalServiceClient.php
@@ -237,7 +237,7 @@ class AssetGroupSignalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AssetServiceClient.php
@@ -237,7 +237,7 @@ class AssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AssetSetAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AssetSetAssetServiceClient.php
@@ -255,7 +255,7 @@ class AssetSetAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AssetSetServiceClient.php
@@ -217,7 +217,7 @@ class AssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AudienceInsightsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AudienceInsightsServiceClient.php
@@ -189,7 +189,7 @@ class AudienceInsightsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/AudienceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/AudienceServiceClient.php
@@ -271,7 +271,7 @@ class AudienceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/BatchJobServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/BatchJobServiceClient.php
@@ -1683,7 +1683,7 @@ class BatchJobServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/BiddingDataExclusionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/BiddingDataExclusionServiceClient.php
@@ -235,7 +235,7 @@ class BiddingDataExclusionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/BiddingSeasonalityAdjustmentServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/BiddingSeasonalityAdjustmentServiceClient.php
@@ -235,7 +235,7 @@ class BiddingSeasonalityAdjustmentServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/BiddingStrategyServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/BiddingStrategyServiceClient.php
@@ -217,7 +217,7 @@ class BiddingStrategyServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/BillingSetupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/BillingSetupServiceClient.php
@@ -243,7 +243,7 @@ class BillingSetupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/BrandSuggestionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/BrandSuggestionServiceClient.php
@@ -169,7 +169,7 @@ class BrandSuggestionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignAssetServiceClient.php
@@ -257,7 +257,7 @@ class CampaignAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignAssetSetServiceClient.php
@@ -255,7 +255,7 @@ class CampaignAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignBidModifierServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignBidModifierServiceClient.php
@@ -237,7 +237,7 @@ class CampaignBidModifierServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignBudgetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignBudgetServiceClient.php
@@ -217,7 +217,7 @@ class CampaignBudgetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignConversionGoalServiceClient.php
@@ -239,7 +239,7 @@ class CampaignConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignCriterionServiceClient.php
@@ -353,7 +353,7 @@ class CampaignCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignCustomizerServiceClient.php
@@ -255,7 +255,7 @@ class CampaignCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignDraftServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignDraftServiceClient.php
@@ -296,7 +296,7 @@ class CampaignDraftServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignGroupServiceClient.php
@@ -217,7 +217,7 @@ class CampaignGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignLabelServiceClient.php
@@ -255,7 +255,7 @@ class CampaignLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignLifecycleGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignLifecycleGoalServiceClient.php
@@ -235,7 +235,7 @@ class CampaignLifecycleGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignServiceClient.php
@@ -348,7 +348,7 @@ class CampaignServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignSharedSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CampaignSharedSetServiceClient.php
@@ -255,7 +255,7 @@ class CampaignSharedSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ContentCreatorInsightsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ContentCreatorInsightsServiceClient.php
@@ -174,7 +174,7 @@ class ContentCreatorInsightsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionActionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionActionServiceClient.php
@@ -233,7 +233,7 @@ class ConversionActionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionAdjustmentUploadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionAdjustmentUploadServiceClient.php
@@ -169,7 +169,7 @@ class ConversionAdjustmentUploadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionCustomVariableServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionCustomVariableServiceClient.php
@@ -233,7 +233,7 @@ class ConversionCustomVariableServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionGoalCampaignConfigServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionGoalCampaignConfigServiceClient.php
@@ -253,7 +253,7 @@ class ConversionGoalCampaignConfigServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionUploadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionUploadServiceClient.php
@@ -220,7 +220,7 @@ class ConversionUploadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionValueRuleServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionValueRuleServiceClient.php
@@ -285,7 +285,7 @@ class ConversionValueRuleServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionValueRuleSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ConversionValueRuleSetServiceClient.php
@@ -269,7 +269,7 @@ class ConversionValueRuleSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomAudienceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomAudienceServiceClient.php
@@ -217,7 +217,7 @@ class CustomAudienceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomConversionGoalServiceClient.php
@@ -235,7 +235,7 @@ class CustomConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomInterestServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomInterestServiceClient.php
@@ -217,7 +217,7 @@ class CustomInterestServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerAssetServiceClient.php
@@ -237,7 +237,7 @@ class CustomerAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerAssetSetServiceClient.php
@@ -251,7 +251,7 @@ class CustomerAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerClientLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerClientLinkServiceClient.php
@@ -235,7 +235,7 @@ class CustomerClientLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerConversionGoalServiceClient.php
@@ -219,7 +219,7 @@ class CustomerConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerCustomizerServiceClient.php
@@ -235,7 +235,7 @@ class CustomerCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerLabelServiceClient.php
@@ -251,7 +251,7 @@ class CustomerLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerLifecycleGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerLifecycleGoalServiceClient.php
@@ -231,7 +231,7 @@ class CustomerLifecycleGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerManagerLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerManagerLinkServiceClient.php
@@ -238,7 +238,7 @@ class CustomerManagerLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerNegativeCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerNegativeCriterionServiceClient.php
@@ -233,7 +233,7 @@ class CustomerNegativeCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerServiceClient.php
@@ -239,7 +239,7 @@ class CustomerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerSkAdNetworkConversionValueSchemaServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerSkAdNetworkConversionValueSchemaServiceClient.php
@@ -217,7 +217,7 @@ class CustomerSkAdNetworkConversionValueSchemaServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerUserAccessInvitationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerUserAccessInvitationServiceClient.php
@@ -218,7 +218,7 @@ class CustomerUserAccessInvitationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerUserAccessServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomerUserAccessServiceClient.php
@@ -217,7 +217,7 @@ class CustomerUserAccessServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/CustomizerAttributeServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/CustomizerAttributeServiceClient.php
@@ -217,7 +217,7 @@ class CustomizerAttributeServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/DataLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/DataLinkServiceClient.php
@@ -226,7 +226,7 @@ class DataLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ExperimentArmServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ExperimentArmServiceClient.php
@@ -255,7 +255,7 @@ class ExperimentArmServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ExperimentServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ExperimentServiceClient.php
@@ -318,7 +318,7 @@ class ExperimentServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/GeoTargetConstantServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/GeoTargetConstantServiceClient.php
@@ -169,7 +169,7 @@ class GeoTargetConstantServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/GoogleAdsFieldServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/GoogleAdsFieldServiceClient.php
@@ -218,7 +218,7 @@ class GoogleAdsFieldServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/GoogleAdsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/GoogleAdsServiceClient.php
@@ -1607,7 +1607,7 @@ class GoogleAdsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/IdentityVerificationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/IdentityVerificationServiceClient.php
@@ -171,7 +171,7 @@ class IdentityVerificationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/InvoiceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/InvoiceServiceClient.php
@@ -169,7 +169,7 @@ class InvoiceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanAdGroupKeywordServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanAdGroupKeywordServiceClient.php
@@ -239,7 +239,7 @@ class KeywordPlanAdGroupKeywordServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanAdGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanAdGroupServiceClient.php
@@ -235,7 +235,7 @@ class KeywordPlanAdGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanCampaignKeywordServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanCampaignKeywordServiceClient.php
@@ -238,7 +238,7 @@ class KeywordPlanCampaignKeywordServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanCampaignServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanCampaignServiceClient.php
@@ -267,7 +267,7 @@ class KeywordPlanCampaignServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanIdeaServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanIdeaServiceClient.php
@@ -178,7 +178,7 @@ class KeywordPlanIdeaServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordPlanServiceClient.php
@@ -217,7 +217,7 @@ class KeywordPlanServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordThemeConstantServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/KeywordThemeConstantServiceClient.php
@@ -169,7 +169,7 @@ class KeywordThemeConstantServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/LabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/LabelServiceClient.php
@@ -217,7 +217,7 @@ class LabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/LocalServicesLeadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/LocalServicesLeadServiceClient.php
@@ -221,7 +221,7 @@ class LocalServicesLeadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/OfflineUserDataJobServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/OfflineUserDataJobServiceClient.php
@@ -276,7 +276,7 @@ class OfflineUserDataJobServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/PaymentsAccountServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/PaymentsAccountServiceClient.php
@@ -170,7 +170,7 @@ class PaymentsAccountServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ProductLinkInvitationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ProductLinkInvitationServiceClient.php
@@ -240,7 +240,7 @@ class ProductLinkInvitationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ProductLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ProductLinkServiceClient.php
@@ -237,7 +237,7 @@ class ProductLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ReachPlanServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ReachPlanServiceClient.php
@@ -182,7 +182,7 @@ class ReachPlanServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/RecommendationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/RecommendationServiceClient.php
@@ -276,7 +276,7 @@ class RecommendationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/RecommendationSubscriptionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/RecommendationSubscriptionServiceClient.php
@@ -217,7 +217,7 @@ class RecommendationSubscriptionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/RemarketingActionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/RemarketingActionServiceClient.php
@@ -217,7 +217,7 @@ class RemarketingActionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ShareablePreviewServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ShareablePreviewServiceClient.php
@@ -169,7 +169,7 @@ class ShareablePreviewServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/SharedCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/SharedCriterionServiceClient.php
@@ -253,7 +253,7 @@ class SharedCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/SharedSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/SharedSetServiceClient.php
@@ -217,7 +217,7 @@ class SharedSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/SmartCampaignSettingServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/SmartCampaignSettingServiceClient.php
@@ -238,7 +238,7 @@ class SmartCampaignSettingServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/SmartCampaignSuggestServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/SmartCampaignSuggestServiceClient.php
@@ -241,7 +241,7 @@ class SmartCampaignSuggestServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/ThirdPartyAppAnalyticsLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/ThirdPartyAppAnalyticsLinkServiceClient.php
@@ -218,7 +218,7 @@ class ThirdPartyAppAnalyticsLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/TravelAssetSuggestionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/TravelAssetSuggestionServiceClient.php
@@ -169,7 +169,7 @@ class TravelAssetSuggestionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/UserDataServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/UserDataServiceClient.php
@@ -174,7 +174,7 @@ class UserDataServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/UserListCustomerTypeServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/UserListCustomerTypeServiceClient.php
@@ -237,7 +237,7 @@ class UserListCustomerTypeServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V19/Services/Client/UserListServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V19/Services/Client/UserListServiceClient.php
@@ -217,7 +217,7 @@ class UserListServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AccountBudgetProposalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AccountBudgetProposalServiceClient.php
@@ -261,7 +261,7 @@ class AccountBudgetProposalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AccountLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AccountLinkServiceClient.php
@@ -221,7 +221,7 @@ class AccountLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAdLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAdLabelServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupAdLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAdServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAdServiceClient.php
@@ -296,7 +296,7 @@ class AdGroupAdServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAssetServiceClient.php
@@ -257,7 +257,7 @@ class AdGroupAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupAssetSetServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupBidModifierServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupBidModifierServiceClient.php
@@ -237,7 +237,7 @@ class AdGroupBidModifierServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCriterionCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCriterionCustomizerServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupCriterionCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCriterionLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCriterionLabelServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupCriterionLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCriterionServiceClient.php
@@ -309,7 +309,7 @@ class AdGroupCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupCustomizerServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupLabelServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdGroupServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdParameterServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdParameterServiceClient.php
@@ -241,7 +241,7 @@ class AdParameterServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AdServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AdServiceClient.php
@@ -216,7 +216,7 @@ class AdServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupAssetServiceClient.php
@@ -257,7 +257,7 @@ class AssetGroupAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupListingGroupFilterServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupListingGroupFilterServiceClient.php
@@ -237,7 +237,7 @@ class AssetGroupListingGroupFilterServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupServiceClient.php
@@ -235,7 +235,7 @@ class AssetGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupSignalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AssetGroupSignalServiceClient.php
@@ -237,7 +237,7 @@ class AssetGroupSignalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AssetServiceClient.php
@@ -237,7 +237,7 @@ class AssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AssetSetAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AssetSetAssetServiceClient.php
@@ -255,7 +255,7 @@ class AssetSetAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AssetSetServiceClient.php
@@ -217,7 +217,7 @@ class AssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AudienceInsightsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AudienceInsightsServiceClient.php
@@ -189,7 +189,7 @@ class AudienceInsightsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/AudienceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/AudienceServiceClient.php
@@ -271,7 +271,7 @@ class AudienceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/BatchJobServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/BatchJobServiceClient.php
@@ -1683,7 +1683,7 @@ class BatchJobServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/BiddingDataExclusionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/BiddingDataExclusionServiceClient.php
@@ -235,7 +235,7 @@ class BiddingDataExclusionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/BiddingSeasonalityAdjustmentServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/BiddingSeasonalityAdjustmentServiceClient.php
@@ -235,7 +235,7 @@ class BiddingSeasonalityAdjustmentServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/BiddingStrategyServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/BiddingStrategyServiceClient.php
@@ -217,7 +217,7 @@ class BiddingStrategyServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/BillingSetupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/BillingSetupServiceClient.php
@@ -243,7 +243,7 @@ class BillingSetupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/BrandSuggestionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/BrandSuggestionServiceClient.php
@@ -169,7 +169,7 @@ class BrandSuggestionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignAssetServiceClient.php
@@ -257,7 +257,7 @@ class CampaignAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignAssetSetServiceClient.php
@@ -255,7 +255,7 @@ class CampaignAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignBidModifierServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignBidModifierServiceClient.php
@@ -237,7 +237,7 @@ class CampaignBidModifierServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignBudgetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignBudgetServiceClient.php
@@ -217,7 +217,7 @@ class CampaignBudgetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignConversionGoalServiceClient.php
@@ -239,7 +239,7 @@ class CampaignConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignCriterionServiceClient.php
@@ -353,7 +353,7 @@ class CampaignCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignCustomizerServiceClient.php
@@ -255,7 +255,7 @@ class CampaignCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignDraftServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignDraftServiceClient.php
@@ -296,7 +296,7 @@ class CampaignDraftServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignGroupServiceClient.php
@@ -217,7 +217,7 @@ class CampaignGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignLabelServiceClient.php
@@ -255,7 +255,7 @@ class CampaignLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignLifecycleGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignLifecycleGoalServiceClient.php
@@ -235,7 +235,7 @@ class CampaignLifecycleGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignServiceClient.php
@@ -348,7 +348,7 @@ class CampaignServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignSharedSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CampaignSharedSetServiceClient.php
@@ -255,7 +255,7 @@ class CampaignSharedSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ContentCreatorInsightsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ContentCreatorInsightsServiceClient.php
@@ -174,7 +174,7 @@ class ContentCreatorInsightsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionActionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionActionServiceClient.php
@@ -233,7 +233,7 @@ class ConversionActionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionAdjustmentUploadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionAdjustmentUploadServiceClient.php
@@ -169,7 +169,7 @@ class ConversionAdjustmentUploadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionCustomVariableServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionCustomVariableServiceClient.php
@@ -233,7 +233,7 @@ class ConversionCustomVariableServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionGoalCampaignConfigServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionGoalCampaignConfigServiceClient.php
@@ -253,7 +253,7 @@ class ConversionGoalCampaignConfigServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionUploadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionUploadServiceClient.php
@@ -220,7 +220,7 @@ class ConversionUploadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionValueRuleServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionValueRuleServiceClient.php
@@ -285,7 +285,7 @@ class ConversionValueRuleServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionValueRuleSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ConversionValueRuleSetServiceClient.php
@@ -269,7 +269,7 @@ class ConversionValueRuleSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomAudienceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomAudienceServiceClient.php
@@ -217,7 +217,7 @@ class CustomAudienceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomConversionGoalServiceClient.php
@@ -235,7 +235,7 @@ class CustomConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomInterestServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomInterestServiceClient.php
@@ -217,7 +217,7 @@ class CustomInterestServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerAssetServiceClient.php
@@ -237,7 +237,7 @@ class CustomerAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerAssetSetServiceClient.php
@@ -251,7 +251,7 @@ class CustomerAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerClientLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerClientLinkServiceClient.php
@@ -235,7 +235,7 @@ class CustomerClientLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerConversionGoalServiceClient.php
@@ -219,7 +219,7 @@ class CustomerConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerCustomizerServiceClient.php
@@ -235,7 +235,7 @@ class CustomerCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerLabelServiceClient.php
@@ -251,7 +251,7 @@ class CustomerLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerLifecycleGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerLifecycleGoalServiceClient.php
@@ -231,7 +231,7 @@ class CustomerLifecycleGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerManagerLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerManagerLinkServiceClient.php
@@ -238,7 +238,7 @@ class CustomerManagerLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerNegativeCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerNegativeCriterionServiceClient.php
@@ -233,7 +233,7 @@ class CustomerNegativeCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerServiceClient.php
@@ -239,7 +239,7 @@ class CustomerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerSkAdNetworkConversionValueSchemaServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerSkAdNetworkConversionValueSchemaServiceClient.php
@@ -217,7 +217,7 @@ class CustomerSkAdNetworkConversionValueSchemaServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerUserAccessInvitationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerUserAccessInvitationServiceClient.php
@@ -218,7 +218,7 @@ class CustomerUserAccessInvitationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerUserAccessServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomerUserAccessServiceClient.php
@@ -217,7 +217,7 @@ class CustomerUserAccessServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/CustomizerAttributeServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/CustomizerAttributeServiceClient.php
@@ -217,7 +217,7 @@ class CustomizerAttributeServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/DataLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/DataLinkServiceClient.php
@@ -226,7 +226,7 @@ class DataLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ExperimentArmServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ExperimentArmServiceClient.php
@@ -255,7 +255,7 @@ class ExperimentArmServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ExperimentServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ExperimentServiceClient.php
@@ -318,7 +318,7 @@ class ExperimentServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/GeoTargetConstantServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/GeoTargetConstantServiceClient.php
@@ -169,7 +169,7 @@ class GeoTargetConstantServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/GoogleAdsFieldServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/GoogleAdsFieldServiceClient.php
@@ -218,7 +218,7 @@ class GoogleAdsFieldServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/GoogleAdsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/GoogleAdsServiceClient.php
@@ -1607,7 +1607,7 @@ class GoogleAdsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/IdentityVerificationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/IdentityVerificationServiceClient.php
@@ -171,7 +171,7 @@ class IdentityVerificationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/InvoiceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/InvoiceServiceClient.php
@@ -169,7 +169,7 @@ class InvoiceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanAdGroupKeywordServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanAdGroupKeywordServiceClient.php
@@ -239,7 +239,7 @@ class KeywordPlanAdGroupKeywordServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanAdGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanAdGroupServiceClient.php
@@ -235,7 +235,7 @@ class KeywordPlanAdGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanCampaignKeywordServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanCampaignKeywordServiceClient.php
@@ -238,7 +238,7 @@ class KeywordPlanCampaignKeywordServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanCampaignServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanCampaignServiceClient.php
@@ -267,7 +267,7 @@ class KeywordPlanCampaignServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanIdeaServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanIdeaServiceClient.php
@@ -178,7 +178,7 @@ class KeywordPlanIdeaServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordPlanServiceClient.php
@@ -217,7 +217,7 @@ class KeywordPlanServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordThemeConstantServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/KeywordThemeConstantServiceClient.php
@@ -169,7 +169,7 @@ class KeywordThemeConstantServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/LabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/LabelServiceClient.php
@@ -217,7 +217,7 @@ class LabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/LocalServicesLeadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/LocalServicesLeadServiceClient.php
@@ -221,7 +221,7 @@ class LocalServicesLeadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/OfflineUserDataJobServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/OfflineUserDataJobServiceClient.php
@@ -276,7 +276,7 @@ class OfflineUserDataJobServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/PaymentsAccountServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/PaymentsAccountServiceClient.php
@@ -170,7 +170,7 @@ class PaymentsAccountServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ProductLinkInvitationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ProductLinkInvitationServiceClient.php
@@ -240,7 +240,7 @@ class ProductLinkInvitationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ProductLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ProductLinkServiceClient.php
@@ -237,7 +237,7 @@ class ProductLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ReachPlanServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ReachPlanServiceClient.php
@@ -185,7 +185,7 @@ class ReachPlanServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/RecommendationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/RecommendationServiceClient.php
@@ -276,7 +276,7 @@ class RecommendationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/RecommendationSubscriptionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/RecommendationSubscriptionServiceClient.php
@@ -217,7 +217,7 @@ class RecommendationSubscriptionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/RemarketingActionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/RemarketingActionServiceClient.php
@@ -217,7 +217,7 @@ class RemarketingActionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ShareablePreviewServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ShareablePreviewServiceClient.php
@@ -169,7 +169,7 @@ class ShareablePreviewServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/SharedCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/SharedCriterionServiceClient.php
@@ -253,7 +253,7 @@ class SharedCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/SharedSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/SharedSetServiceClient.php
@@ -217,7 +217,7 @@ class SharedSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/SmartCampaignSettingServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/SmartCampaignSettingServiceClient.php
@@ -238,7 +238,7 @@ class SmartCampaignSettingServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/SmartCampaignSuggestServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/SmartCampaignSuggestServiceClient.php
@@ -241,7 +241,7 @@ class SmartCampaignSuggestServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/ThirdPartyAppAnalyticsLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/ThirdPartyAppAnalyticsLinkServiceClient.php
@@ -218,7 +218,7 @@ class ThirdPartyAppAnalyticsLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/TravelAssetSuggestionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/TravelAssetSuggestionServiceClient.php
@@ -169,7 +169,7 @@ class TravelAssetSuggestionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/UserDataServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/UserDataServiceClient.php
@@ -174,7 +174,7 @@ class UserDataServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/UserListCustomerTypeServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/UserListCustomerTypeServiceClient.php
@@ -237,7 +237,7 @@ class UserListCustomerTypeServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V20/Services/Client/UserListServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V20/Services/Client/UserListServiceClient.php
@@ -217,7 +217,7 @@ class UserListServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AccountBudgetProposalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AccountBudgetProposalServiceClient.php
@@ -261,7 +261,7 @@ class AccountBudgetProposalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AccountLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AccountLinkServiceClient.php
@@ -221,7 +221,7 @@ class AccountLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAdLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAdLabelServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupAdLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAdServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAdServiceClient.php
@@ -296,7 +296,7 @@ class AdGroupAdServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAssetServiceClient.php
@@ -257,7 +257,7 @@ class AdGroupAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupAssetSetServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupBidModifierServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupBidModifierServiceClient.php
@@ -237,7 +237,7 @@ class AdGroupBidModifierServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCriterionCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCriterionCustomizerServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupCriterionCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCriterionLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCriterionLabelServiceClient.php
@@ -259,7 +259,7 @@ class AdGroupCriterionLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCriterionServiceClient.php
@@ -309,7 +309,7 @@ class AdGroupCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupCustomizerServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupLabelServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdGroupServiceClient.php
@@ -255,7 +255,7 @@ class AdGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdParameterServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdParameterServiceClient.php
@@ -241,7 +241,7 @@ class AdParameterServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AdServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AdServiceClient.php
@@ -216,7 +216,7 @@ class AdServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupAssetServiceClient.php
@@ -257,7 +257,7 @@ class AssetGroupAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupListingGroupFilterServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupListingGroupFilterServiceClient.php
@@ -237,7 +237,7 @@ class AssetGroupListingGroupFilterServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupServiceClient.php
@@ -235,7 +235,7 @@ class AssetGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupSignalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AssetGroupSignalServiceClient.php
@@ -237,7 +237,7 @@ class AssetGroupSignalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AssetServiceClient.php
@@ -237,7 +237,7 @@ class AssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AssetSetAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AssetSetAssetServiceClient.php
@@ -255,7 +255,7 @@ class AssetSetAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AssetSetServiceClient.php
@@ -217,7 +217,7 @@ class AssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AudienceInsightsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AudienceInsightsServiceClient.php
@@ -189,7 +189,7 @@ class AudienceInsightsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AudienceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AudienceServiceClient.php
@@ -271,7 +271,7 @@ class AudienceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/AutomaticallyCreatedAssetRemovalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/AutomaticallyCreatedAssetRemovalServiceClient.php
@@ -169,7 +169,7 @@ class AutomaticallyCreatedAssetRemovalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/BatchJobServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/BatchJobServiceClient.php
@@ -1683,7 +1683,7 @@ class BatchJobServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/BiddingDataExclusionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/BiddingDataExclusionServiceClient.php
@@ -235,7 +235,7 @@ class BiddingDataExclusionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/BiddingSeasonalityAdjustmentServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/BiddingSeasonalityAdjustmentServiceClient.php
@@ -235,7 +235,7 @@ class BiddingSeasonalityAdjustmentServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/BiddingStrategyServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/BiddingStrategyServiceClient.php
@@ -217,7 +217,7 @@ class BiddingStrategyServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/BillingSetupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/BillingSetupServiceClient.php
@@ -243,7 +243,7 @@ class BillingSetupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/BrandSuggestionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/BrandSuggestionServiceClient.php
@@ -169,7 +169,7 @@ class BrandSuggestionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignAssetServiceClient.php
@@ -257,7 +257,7 @@ class CampaignAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignAssetSetServiceClient.php
@@ -255,7 +255,7 @@ class CampaignAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignBidModifierServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignBidModifierServiceClient.php
@@ -237,7 +237,7 @@ class CampaignBidModifierServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignBudgetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignBudgetServiceClient.php
@@ -217,7 +217,7 @@ class CampaignBudgetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignConversionGoalServiceClient.php
@@ -239,7 +239,7 @@ class CampaignConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignCriterionServiceClient.php
@@ -353,7 +353,7 @@ class CampaignCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignCustomizerServiceClient.php
@@ -255,7 +255,7 @@ class CampaignCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignDraftServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignDraftServiceClient.php
@@ -296,7 +296,7 @@ class CampaignDraftServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignGroupServiceClient.php
@@ -217,7 +217,7 @@ class CampaignGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignLabelServiceClient.php
@@ -255,7 +255,7 @@ class CampaignLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignLifecycleGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignLifecycleGoalServiceClient.php
@@ -235,7 +235,7 @@ class CampaignLifecycleGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignServiceClient.php
@@ -348,7 +348,7 @@ class CampaignServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignSharedSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CampaignSharedSetServiceClient.php
@@ -255,7 +255,7 @@ class CampaignSharedSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ContentCreatorInsightsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ContentCreatorInsightsServiceClient.php
@@ -174,7 +174,7 @@ class ContentCreatorInsightsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionActionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionActionServiceClient.php
@@ -233,7 +233,7 @@ class ConversionActionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionAdjustmentUploadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionAdjustmentUploadServiceClient.php
@@ -169,7 +169,7 @@ class ConversionAdjustmentUploadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionCustomVariableServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionCustomVariableServiceClient.php
@@ -233,7 +233,7 @@ class ConversionCustomVariableServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionGoalCampaignConfigServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionGoalCampaignConfigServiceClient.php
@@ -253,7 +253,7 @@ class ConversionGoalCampaignConfigServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionUploadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionUploadServiceClient.php
@@ -220,7 +220,7 @@ class ConversionUploadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionValueRuleServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionValueRuleServiceClient.php
@@ -285,7 +285,7 @@ class ConversionValueRuleServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionValueRuleSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ConversionValueRuleSetServiceClient.php
@@ -269,7 +269,7 @@ class ConversionValueRuleSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomAudienceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomAudienceServiceClient.php
@@ -217,7 +217,7 @@ class CustomAudienceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomConversionGoalServiceClient.php
@@ -235,7 +235,7 @@ class CustomConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomInterestServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomInterestServiceClient.php
@@ -217,7 +217,7 @@ class CustomInterestServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerAssetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerAssetServiceClient.php
@@ -237,7 +237,7 @@ class CustomerAssetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerAssetSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerAssetSetServiceClient.php
@@ -251,7 +251,7 @@ class CustomerAssetSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerClientLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerClientLinkServiceClient.php
@@ -235,7 +235,7 @@ class CustomerClientLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerConversionGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerConversionGoalServiceClient.php
@@ -219,7 +219,7 @@ class CustomerConversionGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerCustomizerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerCustomizerServiceClient.php
@@ -235,7 +235,7 @@ class CustomerCustomizerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerLabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerLabelServiceClient.php
@@ -251,7 +251,7 @@ class CustomerLabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerLifecycleGoalServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerLifecycleGoalServiceClient.php
@@ -231,7 +231,7 @@ class CustomerLifecycleGoalServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerManagerLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerManagerLinkServiceClient.php
@@ -238,7 +238,7 @@ class CustomerManagerLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerNegativeCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerNegativeCriterionServiceClient.php
@@ -233,7 +233,7 @@ class CustomerNegativeCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerServiceClient.php
@@ -239,7 +239,7 @@ class CustomerServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerSkAdNetworkConversionValueSchemaServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerSkAdNetworkConversionValueSchemaServiceClient.php
@@ -217,7 +217,7 @@ class CustomerSkAdNetworkConversionValueSchemaServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerUserAccessInvitationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerUserAccessInvitationServiceClient.php
@@ -218,7 +218,7 @@ class CustomerUserAccessInvitationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerUserAccessServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomerUserAccessServiceClient.php
@@ -217,7 +217,7 @@ class CustomerUserAccessServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/CustomizerAttributeServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/CustomizerAttributeServiceClient.php
@@ -217,7 +217,7 @@ class CustomizerAttributeServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/DataLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/DataLinkServiceClient.php
@@ -226,7 +226,7 @@ class DataLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ExperimentArmServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ExperimentArmServiceClient.php
@@ -255,7 +255,7 @@ class ExperimentArmServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ExperimentServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ExperimentServiceClient.php
@@ -318,7 +318,7 @@ class ExperimentServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/GeoTargetConstantServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/GeoTargetConstantServiceClient.php
@@ -169,7 +169,7 @@ class GeoTargetConstantServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/GoogleAdsFieldServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/GoogleAdsFieldServiceClient.php
@@ -218,7 +218,7 @@ class GoogleAdsFieldServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/GoogleAdsServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/GoogleAdsServiceClient.php
@@ -1607,7 +1607,7 @@ class GoogleAdsServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/IdentityVerificationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/IdentityVerificationServiceClient.php
@@ -171,7 +171,7 @@ class IdentityVerificationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/InvoiceServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/InvoiceServiceClient.php
@@ -169,7 +169,7 @@ class InvoiceServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanAdGroupKeywordServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanAdGroupKeywordServiceClient.php
@@ -239,7 +239,7 @@ class KeywordPlanAdGroupKeywordServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanAdGroupServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanAdGroupServiceClient.php
@@ -235,7 +235,7 @@ class KeywordPlanAdGroupServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanCampaignKeywordServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanCampaignKeywordServiceClient.php
@@ -238,7 +238,7 @@ class KeywordPlanCampaignKeywordServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanCampaignServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanCampaignServiceClient.php
@@ -267,7 +267,7 @@ class KeywordPlanCampaignServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanIdeaServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanIdeaServiceClient.php
@@ -178,7 +178,7 @@ class KeywordPlanIdeaServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordPlanServiceClient.php
@@ -217,7 +217,7 @@ class KeywordPlanServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordThemeConstantServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/KeywordThemeConstantServiceClient.php
@@ -169,7 +169,7 @@ class KeywordThemeConstantServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/LabelServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/LabelServiceClient.php
@@ -217,7 +217,7 @@ class LabelServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/LocalServicesLeadServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/LocalServicesLeadServiceClient.php
@@ -221,7 +221,7 @@ class LocalServicesLeadServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/OfflineUserDataJobServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/OfflineUserDataJobServiceClient.php
@@ -276,7 +276,7 @@ class OfflineUserDataJobServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/PaymentsAccountServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/PaymentsAccountServiceClient.php
@@ -170,7 +170,7 @@ class PaymentsAccountServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ProductLinkInvitationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ProductLinkInvitationServiceClient.php
@@ -240,7 +240,7 @@ class ProductLinkInvitationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ProductLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ProductLinkServiceClient.php
@@ -237,7 +237,7 @@ class ProductLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ReachPlanServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ReachPlanServiceClient.php
@@ -188,7 +188,7 @@ class ReachPlanServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/RecommendationServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/RecommendationServiceClient.php
@@ -276,7 +276,7 @@ class RecommendationServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/RecommendationSubscriptionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/RecommendationSubscriptionServiceClient.php
@@ -217,7 +217,7 @@ class RecommendationSubscriptionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/RemarketingActionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/RemarketingActionServiceClient.php
@@ -217,7 +217,7 @@ class RemarketingActionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ShareablePreviewServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ShareablePreviewServiceClient.php
@@ -169,7 +169,7 @@ class ShareablePreviewServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/SharedCriterionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/SharedCriterionServiceClient.php
@@ -253,7 +253,7 @@ class SharedCriterionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/SharedSetServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/SharedSetServiceClient.php
@@ -217,7 +217,7 @@ class SharedSetServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/SmartCampaignSettingServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/SmartCampaignSettingServiceClient.php
@@ -238,7 +238,7 @@ class SmartCampaignSettingServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/SmartCampaignSuggestServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/SmartCampaignSuggestServiceClient.php
@@ -241,7 +241,7 @@ class SmartCampaignSuggestServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/ThirdPartyAppAnalyticsLinkServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/ThirdPartyAppAnalyticsLinkServiceClient.php
@@ -218,7 +218,7 @@ class ThirdPartyAppAnalyticsLinkServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/TravelAssetSuggestionServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/TravelAssetSuggestionServiceClient.php
@@ -169,7 +169,7 @@ class TravelAssetSuggestionServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/UserDataServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/UserDataServiceClient.php
@@ -174,7 +174,7 @@ class UserDataServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/UserListCustomerTypeServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/UserListCustomerTypeServiceClient.php
@@ -237,7 +237,7 @@ class UserListCustomerTypeServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));

--- a/src/Google/Ads/GoogleAds/V21/Services/Client/UserListServiceClient.php
+++ b/src/Google/Ads/GoogleAds/V21/Services/Client/UserListServiceClient.php
@@ -217,7 +217,7 @@ class UserListServiceClient
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
-            trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);
+            throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");
         }
 
         array_unshift($args, substr($method, 0, -5));


### PR DESCRIPTION
This is to cover a deprecation in PHP 8.4 `Passing E_USER_ERROR to trigger_error() is deprecated since 8.4`, per [the PHP 8.4 migration guide](https://www.php.net/manual/en/migration84.deprecated.php#:~:text=Using%20trigger_error()%20with%20E_USER_ERROR).

All calls to `trigger_error('Call to undefined method ' . __CLASS__ . "::$method()", E_USER_ERROR);` are replaced by throwing an exception `throw new \UnexpectedValueException('Call to undefined method ' . __CLASS__ . "::$method()");`

This will continue triggering a fatal error for the library. I'm happy to bikeshed the correct type of exception to throw here, I went back and forth on a simple `Error` but decided against it in the end.

Note, this comes out of a ticket for https://github.com/woocommerce/google-listings-and-ads/pull/3117, a WooCommerce/WordPress plugin making use of the `dev-legacy-v31.0.1` release. This is due to the need to support PHP 7.4.

If this change is acceptable to you all, it would be great if you could backport it to a v31 branch. I'm happy to create a pull request for this if you wish.