### PR TITLE
Add a new utility which will register an autoloader that will load either 'Current' (for a user specified version) or 'Latest' as a namespace path

### DIFF
--- a/src/Google/Ads/GoogleAds/Util/DynamicVersionAutoloader.php
+++ b/src/Google/Ads/GoogleAds/Util/DynamicVersionAutoloader.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @TODO: Confirm licence / copyright for new files
+ */
+
+namespace Google\Ads\GoogleAds\Util;
+
+/**
+ * Utilities to manage the support for Google Ads API versions in the library.
+ */
+class DynamicVersionAutoloader
+{
+    /** @var string The project's base namespace */
+    private const BASE_NAMESPACE = "Google\\Ads\\GoogleAds\\";
+
+    public static function getOldestSupportedApiVersion(): int
+    {
+        return min(static::getSupportedApiVersions());
+    }
+
+    public static function getLatestSupportedApiVersion(): int
+    {
+        return max(static::getSupportedApiVersions());
+    }
+
+    public static function getSupportedApiVersions(): array
+    {
+        $versionArray = [];
+
+        foreach (scandir(__DIR__) as $directory) {
+            if ($directory[0] === "V") {
+                $directoryVersion = \substr($directory, 1);
+                if ((int)$directoryVersion != 0) {
+                    $versionArray[] = $directoryVersion;
+                }
+            }
+        }
+
+        return $versionArray;
+    }
+
+    /**
+     * This function will register an autoloader that will convert
+     * \Google\Ads\GoogleAds\Current\... to \Google\Ads\GoogleAds\V{$version}
+     * for all namespaces where a version number exists.
+     *
+     * @param int $version A numeric version to use for all calls
+     */
+    public static function setGoogleAdsAutoloaderCurrentVersion(int $version): void
+    {
+        if (class_exists(__NAMESPACE__ . "\\V{$version}\\GoogleAdsErrors") === false) {
+            throw new \ValueError("{$version} specified for \$version is not provided by the SDK");
+        }
+
+        if (class_exists(__NAMESPACE__ . "\\Current\\GoogleAdsErrors", true)) {
+            throw new \ValueError("Autoloader already registered for " . __NAMESPACE__ . "\\Current");
+        }
+
+        static::setGoogleAdsAutoloader("Current", $version);
+    }
+
+    public static function setGoogleAdsAutoloaderLatestVersion(): void
+    {
+        if (class_exists(__NAMESPACE__ . "\\Latest\\GoogleAdsErrors", true)) {
+            throw new \ValueError("Autoloader already registered for " . __NAMESPACE__ . "\\Latest");
+        }
+
+        static::setGoogleAdsAutoloader("Latest", static::getLatestSupportedApiVersion());
+    }
+
+    protected static function setGoogleAdsAutoloader(string $namespaceString, int $apiVersion): void
+    {
+        \spl_autoload_register(
+            static function (string $class) use ($namespaceString, $apiVersion): void {
+                if (
+                    \strcasecmp(
+                        \substr($class, 0, strlen(static::BASE_NAMESPACE)),
+                        static::BASE_NAMESPACE,
+                    ) != 0
+                ) {
+                    return;
+                }
+
+                $baseNamespace = static::BASE_NAMESPACE;
+                $namespacePortions = explode("\\", \substr($class, strlen(static::BASE_NAMESPACE)));
+                if (\in_array(\strtolower($namespacePortions[0]), ["lib", "util"])) {
+                    $baseNamespace .= "{$namespacePortions[0]}\\";
+                    \array_shift($namespacePortions);
+                }
+
+                if (\strcasecmp($namespacePortions[0], $namespaceString) != 0) {
+                    return;
+                }
+                \array_shift($namespacePortions);
+
+                $fullyQualifiedClassName    = "{$baseNamespace}V{$apiVersion}\\" . implode("\\", $namespacePortions);
+
+                if (class_exists($fullyQualifiedClassName, true)) {
+                    \class_alias($fullyQualifiedClassName, $class);
+                }
+            }
+        );
+    }
+}


### PR DESCRIPTION
Will fix https://github.com/googleads/google-ads-php/issues/1065

Add a new utility which can register an autoloader that allows user code to specify `\Google\Ads\GoogleAds\Latest` to always use the latest API version, or `Google\Ads\GoogleAds\Current` to always use a specified version (allowing upgrades to newer versions by updating a single location in the code).

I would welcome any feedback or suggestions on improvements / changes. I am also aware that users using `setGoogleAdsAutoloaderLatestVersion` are running the risk of changing API version without reviewing the migration guide, however as each new release is a major version increase they should be manually updating their `composer.json`, and the original request seemed to want to be able to always use the latest version.

Finally, I have not added tests yet, as I would like to see if there is any feedback that requires changes first (although I have manually tested the code). I am happy to provide tests once the main code is in an acceptable state.