### PR TITLE
Swap build for image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,17 @@
-# Sets the PHP image to extend from.
-# See https://hub.docker.com/_/php.
-ARG PHP_IMAGE="apache"
+# Sets the PHP image to extend from dynamically for local testing.
+ARG PHP_IMAGE="8.1-apache"
 FROM php:${PHP_IMAGE}
-
-ARG USE_C_PROTOBUF=true
 
 RUN apt-get update && apt-get install -y libxml2 zlib1g-dev git unzip
 
-# Install PHP extension(s) required for development.
+# Install standard PHP extensions required for development.
 RUN docker-php-ext-install bcmath
 
 # Install and configure Composer.
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
-# Install and configure the gRPC extension.
-RUN pecl install grpc-1.80.0
-RUN echo 'extension=grpc.so' >> $PHP_INI_DIR/conf.d/grpc.ini
-
-# Install and configure the C implementation of Protobuf extension if needed.
-RUN if [ "$USE_C_PROTOBUF" = "false" ]; then echo 'Using PHP implementation of Protobuf'; else echo 'Using C implementation of Protobuf'; pecl install protobuf-4.33.6; echo 'extension=protobuf.so' >> $PHP_INI_DIR/conf.d/protobuf.ini; fi
+# NOTE: gRPC and Protobuf compilation steps are removed from this file 
+# because they are pulled pre-compiled via the Kokoro Bakery image layers.
 
 WORKDIR "/google-ads-php"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
 services:
   web:
-    image: us-central1-docker.pkg.dev/your-google-project/kokoro-bakery/google-ads-php-base:${PHP_VERSION:-8.1}
+    # Points to the official, secure KTCB-managed Artifact Registry paths
+    image: us-central1-docker.pkg.dev/kokoro-container-bakery/google-ads-php/php${PHP_VERSION:-81}-base:manual
     volumes:
       - ./:/google-ads-php
       - ~/:/root
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
 services:
   web:
-    build: .
+    image: us-central1-docker.pkg.dev/your-google-project/kokoro-bakery/google-ads-php-base:${PHP_VERSION:-8.1}
     volumes:
-    - ./:/google-ads-php
-    - ~/:/root
-      
+      - ./:/google-ads-php
+      - ~/:/root
+


### PR DESCRIPTION
Swapped 'build: .' for 'image' to pull the pre-baked extensions instantly